### PR TITLE
fix(shared-docx): align docx dep to 9.5.1

### DIFF
--- a/.changeset/fix-docx-version.md
+++ b/.changeset/fix-docx-version.md
@@ -1,0 +1,5 @@
+---
+'@json-to-office/shared-docx': patch
+---
+
+Fix docx dependency version: 9.0.4 doesn't exist on npm, aligned to 9.5.1

--- a/packages/shared-docx/package.json
+++ b/packages/shared-docx/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@json-to-office/shared": "workspace:^",
     "@sinclair/typebox": "0.34.38",
-    "docx": "9.0.4"
+    "docx": "9.5.1"
   },
   "devDependencies": {
     "@types/node": "20.11.0",


### PR DESCRIPTION
## Summary
- `docx@9.0.4` doesn't exist on npm (goes 9.0.3 → 9.1.0), causing install failures
- Aligns shared-docx to `9.5.1` matching core-docx and json-to-docx

🤖 Generated with [Claude Code](https://claude.com/claude-code)