### PR TITLE
chore: bump patch versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-to-office",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Generate professional .docx and .pptx files from JSON definitions",
   "private": true,
   "scripts": {

--- a/packages/core-docx/package.json
+++ b/packages/core-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-to-office/core-docx",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Core DOCX document generation engine",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core-pptx/package.json
+++ b/packages/core-pptx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-to-office/core-pptx",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Core PPTX presentation generation engine",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/json-to-docx/package.json
+++ b/packages/json-to-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-to-office/json-to-docx",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Professional .docx document generation from JSON - Public API package",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/json-to-pptx/package.json
+++ b/packages/json-to-pptx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-to-office/json-to-pptx",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Professional .pptx presentation generation from JSON - Public API package",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/jto/package.json
+++ b/packages/jto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-to-office/jto",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "JSON to Office CLI - Unified document and presentation generation",
   "type": "module",
   "bin": {

--- a/packages/shared-docx/package.json
+++ b/packages/shared-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-to-office/shared-docx",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "DOCX-specific schemas, component registry and validation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared-pptx/package.json
+++ b/packages/shared-pptx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-to-office/shared-pptx",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "PPTX-specific schemas, component registry and validation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-to-office/shared",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Format-agnostic shared types, schemas and validation utilities",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump all package patch versions (0.1.0→0.1.1, shared-docx 0.1.2→0.1.3) to trigger release

🤖 Generated with [Claude Code](https://claude.com/claude-code)