### PR TITLE
Redesign plugin sidebar UX with inline toggles

### DIFF
--- a/.changeset/plugin-sidebar-ux.md
+++ b/.changeset/plugin-sidebar-ux.md
@@ -1,0 +1,5 @@
+---
+'@json-to-office/jto': patch
+---
+
+Redesign plugin sidebar UX: inline Switch toggles, active/inactive state, split-pane detail modal

--- a/packages/jto/src/client/components/playground/document-sidebar.tsx
+++ b/packages/jto/src/client/components/playground/document-sidebar.tsx
@@ -15,10 +15,12 @@ import {
   Search,
   PanelLeftClose,
   PanelLeftOpen,
+  Info,
 } from 'lucide-react';
 import { DocumentFormDialogContentMemoized } from './document-form-dialog-content';
 import { DocumentMenuItemMemoized } from './document-menu-item';
 import { PluginSelector } from './plugin-selector';
+import { Switch } from '../ui/switch';
 import { Button } from '../ui/button';
 import { Dialog, DialogContent, DialogTrigger } from '../ui/dialog';
 import {
@@ -56,6 +58,7 @@ import { SchemaDialog } from './schema-dialog';
 import { useTheme } from '../theme-provider';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { useToast } from '../ui/use-toast';
+import { usePluginsStore } from '../../store/plugins-store';
 
 interface DocumentSidebarProps {
   discoveryData: DiscoveryResult | null;
@@ -85,6 +88,12 @@ function DocumentSidebarComponent({
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
   const [themeDialogOpen, setThemeDialogOpen] = useState<boolean>(false);
   const [pluginSelectorOpen, setPluginSelectorOpen] = useState<boolean>(false);
+  const [pluginSelectorFocusedPlugin, setPluginSelectorFocusedPlugin] =
+    useState<string | null>(null);
+  const togglePlugin = usePluginsStore((state) => state.togglePlugin);
+  const isPluginSelected = usePluginsStore((state) => state.isPluginSelected);
+  const selectedPlugins = usePluginsStore((state) => state.selectedPlugins);
+  const isApplyingPlugins = usePluginsStore((state) => state.isApplyingPlugins);
   const [schemaDialogOpen, setSchemaDialogOpen] = useState(false);
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
     new Set(['current-docs', 'current-themes'])
@@ -732,33 +741,54 @@ function DocumentSidebarComponent({
                             )}
                           />
                           <Sparkles className="size-3 text-amber-600 dark:text-amber-400" />
-                          Plugins ({discoveryData.plugins.length})
+                          Plugins ({selectedPlugins.size}/
+                          {discoveryData.plugins.length})
                         </CollapsibleTrigger>
                         <CollapsibleContent>
                           <div className="pl-4 space-y-0.5">
-                            {discoveryData.plugins.map((p, idx) => (
-                              <div
-                                key={idx}
-                                className="py-1 px-2 text-sm text-muted-foreground border-l-2 border-amber-400/60 dark:border-amber-500/40"
-                              >
-                                <div className="font-medium">{p.name}</div>
-                                {p.description && (
-                                  <div className="text-xs opacity-70 truncate">
-                                    {p.description}
+                            {discoveryData.plugins.map((p, idx) => {
+                              const isActive = isPluginSelected(p.name);
+                              return (
+                                <div
+                                  key={idx}
+                                  className={cn(
+                                    'py-1 px-2 text-sm border-l-2 flex items-center gap-2 group transition-colors',
+                                    isActive
+                                      ? 'border-amber-500 dark:border-amber-400 text-foreground'
+                                      : 'border-amber-400/30 dark:border-amber-500/20 text-muted-foreground'
+                                  )}
+                                >
+                                  <div className="flex-1 min-w-0">
+                                    <div className="font-medium truncate">
+                                      {p.name}
+                                    </div>
+                                    {p.description && (
+                                      <div className="text-xs opacity-70 truncate">
+                                        {p.description}
+                                      </div>
+                                    )}
                                   </div>
-                                )}
-                              </div>
-                            ))}
-                            <div className="flex items-center justify-end pr-3 pt-1">
-                              <Button
-                                className="h-6 px-2 text-xs"
-                                variant="ghost"
-                                title="Open plugin manager"
-                                onClick={() => setPluginSelectorOpen(true)}
-                              >
-                                Manage plugins
-                              </Button>
-                            </div>
+                                  <button
+                                    className="flex-none size-5 flex items-center justify-center rounded-sm opacity-0 group-hover:opacity-100 hover:bg-accent transition-all cursor-pointer"
+                                    title={`View details for ${p.name}`}
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      setPluginSelectorFocusedPlugin(p.name);
+                                      setPluginSelectorOpen(true);
+                                    }}
+                                  >
+                                    <Info className="size-3 text-muted-foreground" />
+                                  </button>
+                                  <Switch
+                                    checked={isActive}
+                                    onCheckedChange={() => togglePlugin(p)}
+                                    disabled={isApplyingPlugins}
+                                    className="flex-none scale-[0.8]"
+                                    aria-label={`Toggle ${p.name} plugin`}
+                                  />
+                                </div>
+                              );
+                            })}
                           </div>
                         </CollapsibleContent>
                       </Collapsible>
@@ -781,9 +811,18 @@ function DocumentSidebarComponent({
         </SidebarFooter>
 
         {/* Plugin Selector Dialog */}
-        <Dialog open={pluginSelectorOpen} onOpenChange={setPluginSelectorOpen}>
+        <Dialog
+          open={pluginSelectorOpen}
+          onOpenChange={(open) => {
+            setPluginSelectorOpen(open);
+            if (!open) setPluginSelectorFocusedPlugin(null);
+          }}
+        >
           <DialogContent className="sm:max-w-5xl max-h-[85vh] overflow-hidden">
-            <PluginSelector plugins={discoveryData?.plugins || []} />
+            <PluginSelector
+              plugins={discoveryData?.plugins || []}
+              initialFocusedPlugin={pluginSelectorFocusedPlugin}
+            />
           </DialogContent>
         </Dialog>
       </Sidebar>

--- a/packages/jto/src/client/components/playground/plugin-selector.tsx
+++ b/packages/jto/src/client/components/playground/plugin-selector.tsx
@@ -1,25 +1,23 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { PluginMetadata } from '../../hooks/useDiscovery';
 import { copyPluginExample } from '../../utils/plugin-utils';
 import { DialogHeader, DialogTitle, DialogDescription } from '../ui/dialog';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { ScrollArea } from '../ui/scroll-area';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
+import { Switch } from '../ui/switch';
 import {
   Sparkles,
-  Code,
-  FileJson,
   Copy,
-  ChevronRight,
-  ChevronLeft,
   MapPin,
   Package,
   FileText,
-  Eye,
-  Info,
   CheckCircle,
-  Check,
+  FolderTree,
+  Braces,
+  BookOpen,
+  ChevronDown,
+  ChevronRight,
 } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import { SchemaViewer } from './schema-viewer';
@@ -27,53 +25,55 @@ import { usePluginsStore } from '../../store/plugins-store';
 
 interface PluginSelectorProps {
   plugins: PluginMetadata[];
+  initialFocusedPlugin?: string | null;
 }
 
-export function PluginSelector({ plugins }: PluginSelectorProps) {
+export function PluginSelector({
+  plugins,
+  initialFocusedPlugin,
+}: PluginSelectorProps) {
   const togglePlugin = usePluginsStore((state) => state.togglePlugin);
   const isPluginSelected = usePluginsStore((state) => state.isPluginSelected);
+  const selectedPlugins = usePluginsStore((state) => state.selectedPlugins);
+  const isApplyingPlugins = usePluginsStore((state) => state.isApplyingPlugins);
 
-  const [selectedPlugin, setSelectedPlugin] = useState<PluginMetadata | null>(
-    null
-  );
-  const [currentView, setCurrentView] = useState<'list' | 'detail'>('list');
-  const [activeTab, setActiveTab] = useState('overview');
+  const [activePlugin, setActivePlugin] = useState<PluginMetadata | null>(null);
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
-  const [selectedExample, setSelectedExample] = useState(0);
-  const [exampleView, setExampleView] = useState<'list' | 'detail'>('list');
+  const [detailSection, setDetailSection] = useState<
+    'properties' | 'schema' | 'examples'
+  >('properties');
 
-  const handlePluginSelect = (plugin: PluginMetadata) => {
-    setSelectedPlugin(plugin);
-    setCurrentView('detail');
-  };
+  // Auto-select first plugin or initialFocusedPlugin
+  useEffect(() => {
+    if (initialFocusedPlugin) {
+      const plugin = plugins.find((p) => p.name === initialFocusedPlugin);
+      if (plugin) {
+        setActivePlugin(plugin);
+        return;
+      }
+    }
+    if (plugins.length > 0 && !activePlugin) {
+      setActivePlugin(plugins[0]);
+    }
+  }, [initialFocusedPlugin, plugins]);
 
-  const handleBackToList = () => {
-    setCurrentView('list');
-    setActiveTab('overview');
-    setSelectedExample(0);
-    setExampleView('list');
-  };
-
-  // Group plugins by location
   const groupedPlugins = useMemo(() => {
     const groups: Record<string, PluginMetadata[]> = {
       current: [],
       downstream: [],
       upstream: [],
     };
-
     plugins.forEach((plugin) => {
       if (groups[plugin.location]) {
         groups[plugin.location].push(plugin);
       }
     });
-
     return groups;
   }, [plugins]);
 
   const copyExample = async (example: any, index: number) => {
-    if (!selectedPlugin) return;
-    await copyPluginExample(selectedPlugin.name, example.props);
+    if (!activePlugin) return;
+    await copyPluginExample(activePlugin.name, example.props);
     setCopiedIndex(index);
     setTimeout(() => setCopiedIndex(null), 2000);
   };
@@ -104,405 +104,359 @@ export function PluginSelector({ plugins }: PluginSelectorProps) {
     }
   };
 
+  const hasProperties =
+    activePlugin?.schema?.properties &&
+    Object.keys(activePlugin.schema.properties).length > 0;
+  const hasSchema = activePlugin?.schema?.jsonSchema;
+  const hasExamples =
+    activePlugin?.examples && activePlugin.examples.length > 0;
+
   return (
     <>
       <DialogHeader>
         <DialogTitle className="flex items-center gap-2">
           <Sparkles className="size-5 text-amber-600 dark:text-amber-400" />
-          Discovered Plugins
+          Plugins
+          <Badge variant="secondary" className="font-normal">
+            {selectedPlugins.size} active
+          </Badge>
         </DialogTitle>
         <DialogDescription>
           {plugins.length} plugin{plugins.length !== 1 ? 's' : ''} discovered in
-          your project.
+          your project
         </DialogDescription>
       </DialogHeader>
 
-      <div className="mt-4 flex-1 overflow-hidden">
-        {/* List View */}
-        {currentView === 'list' && (
-          <ScrollArea className="h-[600px] pr-4">
-            {Object.entries(groupedPlugins).map(
-              ([location, locationPlugins]) => {
-                if (locationPlugins.length === 0) return null;
+      <div className="mt-3 flex gap-0 h-[600px] border rounded-lg overflow-hidden">
+        {/* Left panel — plugin list */}
+        <div className="w-[240px] flex-none border-r bg-muted/30">
+          <ScrollArea className="h-full">
+            <div className="p-2 space-y-3">
+              {Object.entries(groupedPlugins).map(
+                ([location, locationPlugins]) => {
+                  if (locationPlugins.length === 0) return null;
 
-                return (
-                  <div key={location} className="mb-6">
-                    <div className="flex items-center gap-2 mb-2 text-sm font-semibold text-muted-foreground">
-                      {getLocationIcon(location)}
-                      {getLocationLabel(location)}
-                      <Badge variant="secondary" className="ml-auto">
-                        {locationPlugins.length}
-                      </Badge>
-                    </div>
-
-                    <div className="space-y-1">
-                      {locationPlugins.map((plugin) => {
-                        const isSelected = isPluginSelected(plugin.name);
-                        return (
-                          <div
-                            key={plugin.name}
-                            role="checkbox"
-                            aria-checked={isSelected}
-                            tabIndex={0}
-                            onKeyDown={(e) => {
-                              if (e.key === ' ' || e.key === 'Enter') {
-                                e.preventDefault();
-                                togglePlugin(plugin);
-                              }
-                            }}
-                            onClick={() => togglePlugin(plugin)}
-                            className={cn(
-                              'flex items-center gap-3 p-2.5 rounded-lg border cursor-pointer transition-colors group',
-                              isSelected
-                                ? 'bg-primary/10 border-primary'
-                                : 'hover:bg-accent/50'
-                            )}
-                          >
-                            <div
+                  return (
+                    <div key={location}>
+                      <div className="flex items-center gap-1.5 px-2 py-1 text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                        {getLocationIcon(location)}
+                        {getLocationLabel(location)}
+                      </div>
+                      <div className="space-y-0.5">
+                        {locationPlugins.map((plugin) => {
+                          const isEnabled = isPluginSelected(plugin.name);
+                          const isActive = activePlugin?.name === plugin.name;
+                          return (
+                            <button
+                              key={plugin.name}
+                              onClick={() => setActivePlugin(plugin)}
                               className={cn(
-                                'flex-none size-4 rounded border transition-colors flex items-center justify-center',
-                                isSelected
-                                  ? 'bg-primary border-primary'
-                                  : 'border-muted-foreground/40'
+                                'w-full text-left px-2 py-1.5 rounded-md transition-colors cursor-pointer',
+                                'flex items-center gap-2',
+                                isActive
+                                  ? 'bg-accent text-accent-foreground'
+                                  : 'hover:bg-accent/50 text-foreground'
                               )}
                             >
-                              {isSelected && (
-                                <Check className="size-3 text-primary-foreground" />
-                              )}
-                            </div>
-                            <div className="flex-1 min-w-0">
-                              <div className="flex items-center gap-2">
-                                <span className="font-medium truncate">
-                                  {plugin.name}
-                                </span>
-                                {plugin.version && (
-                                  <span className="text-xs text-muted-foreground font-mono">
-                                    v{plugin.version}
-                                  </span>
+                              <div
+                                className={cn(
+                                  'size-1.5 rounded-full flex-none transition-colors',
+                                  isEnabled
+                                    ? 'bg-amber-500 dark:bg-amber-400'
+                                    : 'bg-muted-foreground/30'
                                 )}
-                              </div>
-                              {plugin.description && (
-                                <p className="text-xs text-muted-foreground mt-0.5 truncate">
-                                  {plugin.description}
-                                </p>
-                              )}
-                            </div>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="flex-none size-7 opacity-0 group-hover:opacity-100 transition-opacity"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handlePluginSelect(plugin);
-                              }}
-                            >
-                              <ChevronRight className="size-4 text-muted-foreground" />
-                            </Button>
-                          </div>
-                        );
-                      })}
+                              />
+                              <span className="text-sm font-medium truncate flex-1">
+                                {plugin.name}
+                              </span>
+                            </button>
+                          );
+                        })}
+                      </div>
                     </div>
-                  </div>
-                );
-              }
-            )}
+                  );
+                }
+              )}
+            </div>
           </ScrollArea>
-        )}
+        </div>
 
-        {/* Detail View with Tabs */}
-        {currentView === 'detail' && selectedPlugin && (
-          <div className="flex flex-col h-full">
-            {/* Back button */}
-            <div className="flex items-center gap-2 mb-4 pb-2 border-b">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleBackToList}
-                className="gap-1 -ml-2"
-              >
-                <ChevronLeft className="size-4" />
-                Back to Plugins
-              </Button>
-              <div className="flex-1" />
-              <Badge variant="outline">
-                {selectedPlugin.name}
-                {selectedPlugin.version && ` v${selectedPlugin.version}`}
-              </Badge>
+        {/* Right panel — detail */}
+        {activePlugin ? (
+          <div className="flex-1 flex flex-col min-w-0">
+            {/* Plugin header */}
+            <div className="flex-none px-5 py-4 border-b bg-background">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2.5">
+                    <h3 className="text-base font-semibold truncate">
+                      {activePlugin.name}
+                    </h3>
+                    {activePlugin.version && (
+                      <Badge
+                        variant="outline"
+                        className="font-mono text-[11px] flex-none"
+                      >
+                        v{activePlugin.version}
+                      </Badge>
+                    )}
+                  </div>
+                  {activePlugin.description && (
+                    <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+                      {activePlugin.description}
+                    </p>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 flex-none pt-0.5">
+                  <span className="text-xs text-muted-foreground">
+                    {isPluginSelected(activePlugin.name) ? 'On' : 'Off'}
+                  </span>
+                  <Switch
+                    checked={isPluginSelected(activePlugin.name)}
+                    onCheckedChange={() => togglePlugin(activePlugin)}
+                    disabled={isApplyingPlugins}
+                    aria-label={`Toggle ${activePlugin.name}`}
+                  />
+                </div>
+              </div>
+              <div className="flex items-center gap-1.5 mt-2 text-xs text-muted-foreground">
+                {getLocationIcon(activePlugin.location)}
+                <span>{getLocationLabel(activePlugin.location)}</span>
+                <span className="text-muted-foreground/60 mx-1">/</span>
+                <span className="font-mono truncate">
+                  {activePlugin.relativePath}
+                </span>
+              </div>
             </div>
 
-            <Tabs
-              value={activeTab}
-              onValueChange={setActiveTab}
-              className="flex-1 flex flex-col overflow-hidden5"
-            >
-              <TabsList className="grid w-full grid-cols-3 mb-4">
-                <TabsTrigger value="overview" className="gap-2">
-                  <Info className="size-4" />
-                  Overview
-                </TabsTrigger>
-                <TabsTrigger
-                  value="schema"
-                  className="gap-2"
-                  disabled={
-                    !selectedPlugin.schema ||
-                    Object.keys(selectedPlugin.schema).length === 0
-                  }
+            {/* Section nav */}
+            <div className="flex-none px-5 pt-3 pb-0 flex gap-1 border-b bg-background">
+              {hasProperties && (
+                <button
+                  onClick={() => setDetailSection('properties')}
+                  className={cn(
+                    'px-3 py-1.5 text-sm font-medium rounded-t-md border-b-2 transition-colors cursor-pointer',
+                    detailSection === 'properties'
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground'
+                  )}
                 >
-                  <FileJson className="size-4" />
-                  Schema
-                </TabsTrigger>
-                <TabsTrigger
-                  value="examples"
-                  className="gap-2"
-                  disabled={
-                    !selectedPlugin.examples ||
-                    selectedPlugin.examples.length === 0
-                  }
+                  <span className="flex items-center gap-1.5">
+                    <Braces className="size-3.5" />
+                    Properties
+                  </span>
+                </button>
+              )}
+              {hasSchema && (
+                <button
+                  onClick={() => setDetailSection('schema')}
+                  className={cn(
+                    'px-3 py-1.5 text-sm font-medium rounded-t-md border-b-2 transition-colors cursor-pointer',
+                    detailSection === 'schema'
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground'
+                  )}
                 >
-                  <Eye className="size-4" />
-                  Examples{' '}
-                  {selectedPlugin.examples &&
-                    `(${selectedPlugin.examples.length})`}
-                </TabsTrigger>
-              </TabsList>
+                  <span className="flex items-center gap-1.5">
+                    <FolderTree className="size-3.5" />
+                    Schema
+                  </span>
+                </button>
+              )}
+              {hasExamples && (
+                <button
+                  onClick={() => setDetailSection('examples')}
+                  className={cn(
+                    'px-3 py-1.5 text-sm font-medium rounded-t-md border-b-2 transition-colors cursor-pointer',
+                    detailSection === 'examples'
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground'
+                  )}
+                >
+                  <span className="flex items-center gap-1.5">
+                    <BookOpen className="size-3.5" />
+                    Examples
+                    <Badge
+                      variant="secondary"
+                      className="text-[10px] px-1.5 py-0 h-4"
+                    >
+                      {activePlugin.examples!.length}
+                    </Badge>
+                  </span>
+                </button>
+              )}
+            </div>
 
-              {/* Overview Tab */}
-              <TabsContent value="overview" className="flex-1 overflow-hidden">
-                <ScrollArea className="h-[500px] pr-4">
-                  <div className="space-y-4">
-                    <div>
-                      <h3 className="text-lg font-semibold flex items-center gap-2">
-                        <Code className="size-5 text-blue-600 dark:text-blue-400" />
-                        {selectedPlugin.name}
-                      </h3>
-                      {selectedPlugin.version && (
-                        <Badge variant="outline" className="mt-2 mb-1">
-                          Version {selectedPlugin.version}
-                        </Badge>
-                      )}
-                    </div>
-
-                    {selectedPlugin.description && (
-                      <div>
-                        <h4 className="text-sm font-medium mb-1">
-                          Description
-                        </h4>
-                        <p className="text-sm text-muted-foreground">
-                          {selectedPlugin.description}
-                        </p>
-                      </div>
+            {/* Section content */}
+            <ScrollArea className="flex-1">
+              <div className="p-5">
+                {/* Properties section */}
+                {detailSection === 'properties' && hasProperties && (
+                  <div className="space-y-1">
+                    {Object.entries(activePlugin.schema.properties!).map(
+                      ([key, prop]: [string, any]) => (
+                        <PropertyRow key={key} name={key} prop={prop} />
+                      )
                     )}
-
-                    <div>
-                      <h4 className="text-sm font-medium mb-1">Location</h4>
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                        {getLocationIcon(selectedPlugin.location)}
-                        <span>{getLocationLabel(selectedPlugin.location)}</span>
-                        <span className="text-xs">
-                          ({selectedPlugin.relativePath})
-                        </span>
-                      </div>
-                    </div>
-
-                    {selectedPlugin.schema?.properties && (
-                      <div>
-                        <h4 className="text-sm font-medium mb-2">
-                          Configuration Properties (Quick Preview)
-                        </h4>
-                        <div className="space-y-1">
-                          {Object.entries(selectedPlugin.schema.properties)
-                            .slice(0, 5)
-                            .map(([key, prop]: [string, any]) => (
-                              <div key={key} className="text-xs">
-                                <span className="font-mono font-medium">
-                                  {key}
-                                </span>
-                                {prop.type && (
-                                  <span className="text-muted-foreground ml-2">
-                                    ({prop.type})
-                                    {prop.optional ? ' - optional' : ''}
-                                  </span>
-                                )}
-                              </div>
-                            ))}
-                          {Object.keys(selectedPlugin.schema.properties)
-                            .length > 5 && (
-                            <div className="text-xs text-muted-foreground">
-                              ...and{' '}
-                              {Object.keys(selectedPlugin.schema.properties)
-                                .length - 5}{' '}
-                              more properties. View the Schema tab for complete
-                              details.
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </ScrollArea>
-              </TabsContent>
-
-              {/* Schema Tab */}
-              <TabsContent value="schema" className="flex-1 overflow-hidden">
-                <SchemaViewer
-                  schema={selectedPlugin.schema?.jsonSchema || null}
-                  loading={false}
-                  className="h-[500px]"
-                />
-              </TabsContent>
-
-              {/* Examples Tab */}
-              <TabsContent value="examples" className="flex-1 overflow-hidden">
-                {selectedPlugin.examples &&
-                selectedPlugin.examples.length > 0 ? (
-                  <>
-                    {/* Examples List View */}
-                    {exampleView === 'list' &&
-                      selectedPlugin.examples.length > 1 && (
-                        <ScrollArea className="h-[500px]">
-                          <div className="space-y-3">
-                            {selectedPlugin.examples.map((example, index) => (
-                              <div
-                                key={index}
-                                className="p-4 border rounded-lg hover:bg-muted cursor-pointer transition-colors group"
-                                onClick={() => {
-                                  setSelectedExample(index);
-                                  setExampleView('detail');
-                                }}
-                              >
-                                <div className="flex items-start justify-between">
-                                  <div className="flex-1">
-                                    <div className="flex items-center gap-2 mb-1">
-                                      <Badge
-                                        variant="secondary"
-                                        className="text-xs"
-                                      >
-                                        Example {index + 1}
-                                      </Badge>
-                                      <h3 className="font-semibold text-sm">
-                                        {example.title ||
-                                          `Example ${index + 1}`}
-                                      </h3>
-                                    </div>
-                                    {example.description && (
-                                      <p className="text-sm text-muted-foreground mt-2 line-clamp-2">
-                                        {example.description}
-                                      </p>
-                                    )}
-                                  </div>
-                                  <ChevronRight className="size-5 text-muted-foreground mt-1 group-hover:translate-x-1 transition-transform" />
-                                </div>
-                              </div>
-                            ))}
-                          </div>
-                        </ScrollArea>
-                      )}
-
-                    {/* Example Detail View */}
-                    {(exampleView === 'detail' ||
-                      selectedPlugin.examples.length === 1) &&
-                      selectedPlugin.examples[selectedExample] && (
-                        <>
-                          {/* Back button for multiple examples */}
-                          {selectedPlugin.examples.length > 1 && (
-                            <div className="flex items-center gap-2 mb-4 pb-2 border-b">
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => setExampleView('list')}
-                                className="gap-1 -ml-2"
-                              >
-                                <ChevronLeft className="size-4" />
-                                Back to Examples
-                              </Button>
-                              <div className="flex-1" />
-                              <Badge variant="secondary" className="text-xs">
-                                Example {selectedExample + 1} of{' '}
-                                {selectedPlugin.examples.length}
-                              </Badge>
-                            </div>
-                          )}
-
-                          <ScrollArea className="max-h-[50vh]">
-                            <div className="space-y-4">
-                              {selectedPlugin.examples[selectedExample]
-                                .title && (
-                                <h3 className="text-lg font-semibold">
-                                  {
-                                    selectedPlugin.examples[selectedExample]
-                                      .title
-                                  }
-                                </h3>
-                              )}
-
-                              {selectedPlugin.examples[selectedExample]
-                                .description && (
-                                <p className="text-sm text-muted-foreground">
-                                  {
-                                    selectedPlugin.examples[selectedExample]
-                                      .description
-                                  }
-                                </p>
-                              )}
-
-                              <div>
-                                <div className="flex items-center justify-between mb-2">
-                                  <h4 className="text-sm font-medium">
-                                    Full Component Configuration
-                                  </h4>
-                                  <Button
-                                    size="sm"
-                                    variant="outline"
-                                    onClick={() =>
-                                      copyExample(
-                                        selectedPlugin.examples![
-                                          selectedExample
-                                        ],
-                                        selectedExample
-                                      )
-                                    }
-                                  >
-                                    {copiedIndex === selectedExample ? (
-                                      <>
-                                        <CheckCircle className="size-4 mr-2 text-green-600" />
-                                        Copied!
-                                      </>
-                                    ) : (
-                                      <>
-                                        <Copy className="size-4 mr-2" />
-                                        Copy
-                                      </>
-                                    )}
-                                  </Button>
-                                </div>
-
-                                <pre className="p-4 bg-muted rounded-lg overflow-x-auto">
-                                  <code className="text-sm">
-                                    {JSON.stringify(
-                                      selectedPlugin.examples[selectedExample]
-                                        .props,
-                                      null,
-                                      2
-                                    )}
-                                  </code>
-                                </pre>
-                              </div>
-                            </div>
-                          </ScrollArea>
-                        </>
-                      )}
-                  </>
-                ) : (
-                  <div className="text-center text-muted-foreground py-12">
-                    <Eye className="size-12 mx-auto mb-3 opacity-20" />
-                    <p>No examples available for this plugin</p>
                   </div>
                 )}
-              </TabsContent>
-            </Tabs>
+
+                {/* Schema section */}
+                {detailSection === 'schema' && hasSchema && (
+                  <SchemaViewer
+                    schema={activePlugin.schema.jsonSchema}
+                    loading={false}
+                    className="h-[420px]"
+                  />
+                )}
+
+                {/* Examples section */}
+                {detailSection === 'examples' &&
+                  hasExamples &&
+                  activePlugin.examples!.map((example, index) => (
+                    <div
+                      key={index}
+                      className={cn(index > 0 && 'mt-4 pt-4 border-t')}
+                    >
+                      <div className="flex items-center justify-between mb-2">
+                        <div className="flex items-center gap-2 min-w-0">
+                          {example.title && (
+                            <span className="font-medium text-sm truncate">
+                              {example.title}
+                            </span>
+                          )}
+                          {!example.title && (
+                            <span className="text-sm text-muted-foreground">
+                              Example {index + 1}
+                            </span>
+                          )}
+                        </div>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-7 px-2 text-xs flex-none"
+                          onClick={() => copyExample(example, index)}
+                        >
+                          {copiedIndex === index ? (
+                            <>
+                              <CheckCircle className="size-3 mr-1 text-green-600" />
+                              Copied
+                            </>
+                          ) : (
+                            <>
+                              <Copy className="size-3 mr-1" />
+                              Copy
+                            </>
+                          )}
+                        </Button>
+                      </div>
+                      {example.description && (
+                        <p className="text-xs text-muted-foreground mb-2">
+                          {example.description}
+                        </p>
+                      )}
+                      <pre className="p-3 bg-muted rounded-md overflow-x-auto text-xs font-mono leading-relaxed">
+                        {JSON.stringify(example.props, null, 2)}
+                      </pre>
+                    </div>
+                  ))}
+
+                {/* Empty state when no sections available */}
+                {!hasProperties && !hasSchema && !hasExamples && (
+                  <div className="text-center py-12 text-muted-foreground">
+                    <Braces className="size-10 mx-auto mb-3 opacity-20" />
+                    <p className="text-sm">
+                      No schema or examples available for this plugin
+                    </p>
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </div>
+        ) : (
+          <div className="flex-1 flex items-center justify-center text-muted-foreground">
+            <p className="text-sm">Select a plugin to view details</p>
           </div>
         )}
       </div>
     </>
+  );
+}
+
+/** Compact property row for the properties section */
+function PropertyRow({ name, prop }: { name: string; prop: any }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasDetails =
+    prop.description ||
+    prop.enum ||
+    prop.default !== undefined ||
+    prop.items ||
+    prop.properties;
+
+  const typeLabel =
+    prop.type || (prop.enum ? 'enum' : prop.oneOf ? 'oneOf' : '—');
+
+  return (
+    <div className="rounded-md border">
+      <button
+        onClick={() => hasDetails && setExpanded(!expanded)}
+        className={cn(
+          'w-full text-left flex items-center gap-2 px-3 py-2 text-sm',
+          hasDetails && 'cursor-pointer hover:bg-muted/50'
+        )}
+      >
+        {hasDetails ? (
+          expanded ? (
+            <ChevronDown className="size-3 text-muted-foreground flex-none" />
+          ) : (
+            <ChevronRight className="size-3 text-muted-foreground flex-none" />
+          )
+        ) : (
+          <span className="size-3 flex-none" />
+        )}
+        <span className="font-mono font-medium text-xs">{name}</span>
+        <Badge
+          variant="outline"
+          className="text-[10px] px-1.5 py-0 h-4 flex-none"
+        >
+          {typeLabel}
+        </Badge>
+        {prop.optional === false && (
+          <span className="text-[10px] text-red-500 font-medium flex-none">
+            required
+          </span>
+        )}
+        <span className="flex-1" />
+        {prop.default !== undefined && (
+          <span className="text-[10px] font-mono text-muted-foreground flex-none">
+            = {JSON.stringify(prop.default)}
+          </span>
+        )}
+      </button>
+      {expanded && hasDetails && (
+        <div className="px-3 pb-2 pt-0 ml-5 text-xs space-y-1 text-muted-foreground">
+          {prop.description && <p>{prop.description}</p>}
+          {prop.enum && (
+            <p>
+              <span className="font-medium text-foreground">Values: </span>
+              {prop.enum.map((v: any, i: number) => (
+                <span key={i}>
+                  {i > 0 && ', '}
+                  <code className="bg-muted px-1 rounded">
+                    {JSON.stringify(v)}
+                  </code>
+                </span>
+              ))}
+            </p>
+          )}
+          {prop.items?.type && (
+            <p>
+              <span className="font-medium text-foreground">Items: </span>
+              {prop.items.type}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add inline Switch toggles to sidebar plugin list — enable/disable without opening modal
- Clear active/inactive visual state (solid vs faded amber border, text color shift)
- Header shows active count (`Plugins (2/5)`)
- Per-plugin info button opens modal pre-focused on that plugin
- Redesign plugin modal as split-pane master/detail (list always visible on left, details on right)
- Collapsible property rows with type badges, required markers, enum values
- All examples shown inline with copy buttons (no nested navigation)

## Test plan
- [ ] Open sidebar, verify plugins show switches reflecting persisted state
- [ ] Toggle a plugin via switch — schema reapplies, Monaco validation updates
- [ ] Click info icon — modal opens in detail view for that plugin
- [ ] Verify split-pane layout: plugin list on left, details on right
- [ ] Toggle plugin from within modal header switch
- [ ] Check Properties, Schema, Examples sections render correctly
- [ ] Rapid-toggle — switches disabled while applying

🤖 Generated with [Claude Code](https://claude.com/claude-code)