### PR TITLE
feat(schema): per-container narrowed children validation

### DIFF
--- a/.changeset/narrowed-children-validation.md
+++ b/.changeset/narrowed-children-validation.md
@@ -1,0 +1,14 @@
+---
+'@json-to-office/shared-docx': minor
+'@json-to-office/shared-pptx': minor
+'@json-to-office/jto': patch
+---
+
+feat(schema): per-container narrowed children validation for DOCX and PPTX
+
+Each container component now declares its `allowedChildren`, and the schema
+generator builds per-container children unions instead of one flat recursive
+union. Monaco immediately flags invalid nesting (e.g. heading inside docx).
+
+Also skips auto-builds when JSON is syntactically invalid or has schema
+validation errors, preventing wasted server roundtrips during typing.

--- a/packages/jto/src/client/components/json-editor/editor-monaco-json.tsx
+++ b/packages/jto/src/client/components/json-editor/editor-monaco-json.tsx
@@ -35,6 +35,7 @@ function EditorMonacoJson({
   const { resolvedTheme } = useTheme();
   const saveDocument = useDocumentsStore((state) => state.saveDocument);
   const bumpEditSequence = useOutputStore((state) => state.bumpEditSequence);
+  const setOutput = useOutputStore((state) => state.setOutput);
   const closeDocument = useDocumentsStore((state) => state.closeDocument);
   const pendingDiff = useDocumentsStore((state) => state.pendingDiffs[name]);
   const clearPendingDiff = useDocumentsStore((state) => state.clearPendingDiff);
@@ -171,6 +172,9 @@ function EditorMonacoJson({
     }));
 
     setValidationErrors(errors);
+    setOutput({
+      hasValidationErrors: errors.some((e) => e.severity === 'error'),
+    });
 
     // Decorations are now handled by Monaco's native validation
     decorationIdsRef.current = [];

--- a/packages/jto/src/client/components/playground/document-sidebar.tsx
+++ b/packages/jto/src/client/components/playground/document-sidebar.tsx
@@ -15,10 +15,12 @@ import {
   Search,
   PanelLeftClose,
   PanelLeftOpen,
+  Info,
 } from 'lucide-react';
 import { DocumentFormDialogContentMemoized } from './document-form-dialog-content';
 import { DocumentMenuItemMemoized } from './document-menu-item';
 import { PluginSelector } from './plugin-selector';
+import { Switch } from '../ui/switch';
 import { Button } from '../ui/button';
 import { Dialog, DialogContent, DialogTrigger } from '../ui/dialog';
 import {
@@ -56,6 +58,7 @@ import { SchemaDialog } from './schema-dialog';
 import { useTheme } from '../theme-provider';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { useToast } from '../ui/use-toast';
+import { usePluginsStore } from '../../store/plugins-store';
 
 interface DocumentSidebarProps {
   discoveryData: DiscoveryResult | null;
@@ -85,6 +88,12 @@ function DocumentSidebarComponent({
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
   const [themeDialogOpen, setThemeDialogOpen] = useState<boolean>(false);
   const [pluginSelectorOpen, setPluginSelectorOpen] = useState<boolean>(false);
+  const [pluginSelectorFocusedPlugin, setPluginSelectorFocusedPlugin] =
+    useState<string | null>(null);
+  const togglePlugin = usePluginsStore((state) => state.togglePlugin);
+  const isPluginSelected = usePluginsStore((state) => state.isPluginSelected);
+  const selectedPlugins = usePluginsStore((state) => state.selectedPlugins);
+  const isApplyingPlugins = usePluginsStore((state) => state.isApplyingPlugins);
   const [schemaDialogOpen, setSchemaDialogOpen] = useState(false);
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
     new Set(['current-docs', 'current-themes'])
@@ -732,33 +741,54 @@ function DocumentSidebarComponent({
                             )}
                           />
                           <Sparkles className="size-3 text-amber-600 dark:text-amber-400" />
-                          Plugins ({discoveryData.plugins.length})
+                          Plugins ({selectedPlugins.size}/
+                          {discoveryData.plugins.length})
                         </CollapsibleTrigger>
                         <CollapsibleContent>
                           <div className="pl-4 space-y-0.5">
-                            {discoveryData.plugins.map((p, idx) => (
-                              <div
-                                key={idx}
-                                className="py-1 px-2 text-sm text-muted-foreground border-l-2 border-amber-400/60 dark:border-amber-500/40"
-                              >
-                                <div className="font-medium">{p.name}</div>
-                                {p.description && (
-                                  <div className="text-xs opacity-70 truncate">
-                                    {p.description}
+                            {discoveryData.plugins.map((p, idx) => {
+                              const isActive = isPluginSelected(p.name);
+                              return (
+                                <div
+                                  key={idx}
+                                  className={cn(
+                                    'py-1 px-2 text-sm border-l-2 flex items-center gap-2 group transition-colors',
+                                    isActive
+                                      ? 'border-amber-500 dark:border-amber-400 text-foreground'
+                                      : 'border-amber-400/30 dark:border-amber-500/20 text-muted-foreground'
+                                  )}
+                                >
+                                  <div className="flex-1 min-w-0">
+                                    <div className="font-medium truncate">
+                                      {p.name}
+                                    </div>
+                                    {p.description && (
+                                      <div className="text-xs opacity-70 truncate">
+                                        {p.description}
+                                      </div>
+                                    )}
                                   </div>
-                                )}
-                              </div>
-                            ))}
-                            <div className="flex items-center justify-end pr-3 pt-1">
-                              <Button
-                                className="h-6 px-2 text-xs"
-                                variant="ghost"
-                                title="Open plugin manager"
-                                onClick={() => setPluginSelectorOpen(true)}
-                              >
-                                Manage plugins
-                              </Button>
-                            </div>
+                                  <button
+                                    className="flex-none size-5 flex items-center justify-center rounded-sm opacity-0 group-hover:opacity-100 hover:bg-accent transition-all cursor-pointer"
+                                    title={`View details for ${p.name}`}
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      setPluginSelectorFocusedPlugin(p.name);
+                                      setPluginSelectorOpen(true);
+                                    }}
+                                  >
+                                    <Info className="size-3 text-muted-foreground" />
+                                  </button>
+                                  <Switch
+                                    checked={isActive}
+                                    onCheckedChange={() => togglePlugin(p)}
+                                    disabled={isApplyingPlugins}
+                                    className="flex-none scale-[0.8]"
+                                    aria-label={`Toggle ${p.name} plugin`}
+                                  />
+                                </div>
+                              );
+                            })}
                           </div>
                         </CollapsibleContent>
                       </Collapsible>
@@ -781,9 +811,18 @@ function DocumentSidebarComponent({
         </SidebarFooter>
 
         {/* Plugin Selector Dialog */}
-        <Dialog open={pluginSelectorOpen} onOpenChange={setPluginSelectorOpen}>
+        <Dialog
+          open={pluginSelectorOpen}
+          onOpenChange={(open) => {
+            setPluginSelectorOpen(open);
+            if (!open) setPluginSelectorFocusedPlugin(null);
+          }}
+        >
           <DialogContent className="sm:max-w-5xl max-h-[85vh] overflow-hidden">
-            <PluginSelector plugins={discoveryData?.plugins || []} />
+            <PluginSelector
+              plugins={discoveryData?.plugins || []}
+              initialFocusedPlugin={pluginSelectorFocusedPlugin}
+            />
           </DialogContent>
         </Dialog>
       </Sidebar>

--- a/packages/jto/src/client/components/playground/editor.tsx
+++ b/packages/jto/src/client/components/playground/editor.tsx
@@ -1,11 +1,27 @@
-import { useEffect, useCallback, useRef, useMemo, memo, useContext } from 'react';
+import {
+  useEffect,
+  useCallback,
+  useRef,
+  useMemo,
+  memo,
+  useContext,
+} from 'react';
 import { EditorTabsContentMemoized } from './editor-tabs-content';
 import { Tabs } from '../ui/tabs';
-import { useDocumentsStore, DocumentsStoreContext } from '../../store/documents-store-provider';
-import { useOutputStore, OutputStoreContext } from '../../store/output-store-provider';
+import {
+  useDocumentsStore,
+  DocumentsStoreContext,
+} from '../../store/documents-store-provider';
+import {
+  useOutputStore,
+  OutputStoreContext,
+} from '../../store/output-store-provider';
 import { useSettingsStore } from '../../store/settings-store-provider';
 import { useEditorRefsStore } from '../../store/editor-refs-store';
-import { useThemesStore, ThemesStoreContext } from '../../store/themes-store-provider';
+import {
+  useThemesStore,
+  ThemesStoreContext,
+} from '../../store/themes-store-provider';
 import { usePresentationGenerator } from '../../hooks/usePresentationGenerator';
 import { retry, RetryStrategies } from '../../utils/retry';
 import { themeChangeEmitter } from '../../utils/theme-change-emitter';
@@ -112,7 +128,11 @@ function EditorComponent() {
       };
 
       // Process immediately (bypass queue for theme changes)
-      await processBuildRequestWithThemesRef.current(buildRequest, version, themesData);
+      await processBuildRequestWithThemesRef.current(
+        buildRequest,
+        version,
+        themesData
+      );
     },
     [generatePresentation, setOutput, getDocumentVersion]
   );
@@ -224,8 +244,12 @@ function EditorComponent() {
     },
     [generatePresentation, setOutput, setBuildError, outputStore]
   );
-  const processBuildRequestWithThemesRef = useRef(processBuildRequestWithThemes);
-  useEffect(() => { processBuildRequestWithThemesRef.current = processBuildRequestWithThemes; });
+  const processBuildRequestWithThemesRef = useRef(
+    processBuildRequestWithThemes
+  );
+  useEffect(() => {
+    processBuildRequestWithThemesRef.current = processBuildRequestWithThemes;
+  });
 
   // Prepare valid custom themes with deep comparison
   const customThemesContentHash = useMemo(() => {
@@ -276,7 +300,11 @@ function EditorComponent() {
 
   // Helper function to build a document with proper cancellation and retry
   const buildDocument = useCallback(
-    async (doc: any, signal?: AbortSignal, options?: { bypassCache?: boolean }) => {
+    async (
+      doc: any,
+      signal?: AbortSignal,
+      options?: { bypassCache?: boolean }
+    ) => {
       if (!doc || !generatePresentation) {
         return;
       }
@@ -315,7 +343,11 @@ function EditorComponent() {
 
   // Process a build request from the queue
   const processBuildRequest = useCallback(
-    async (request: BuildRequest, version: number, options?: { bypassCache?: boolean }) => {
+    async (
+      request: BuildRequest,
+      version: number,
+      options?: { bypassCache?: boolean }
+    ) => {
       const { doc, signal, id } = request;
 
       // Check if this is still the latest request
@@ -476,14 +508,21 @@ function EditorComponent() {
         buildAbortControllersRef.current.delete(doc.name);
       }
     },
-    [generatePresentation, getFreshThemeData, setOutput, setBuildError, outputStore]
+    [
+      generatePresentation,
+      getFreshThemeData,
+      setOutput,
+      setBuildError,
+      outputStore,
+    ]
   );
   const processBuildRequestRef = useRef(processBuildRequest);
-  useEffect(() => { processBuildRequestRef.current = processBuildRequest; });
+  useEffect(() => {
+    processBuildRequestRef.current = processBuildRequest;
+  });
 
   // Track the last viewed document for theme updates
   const lastViewedDocumentRef = useRef<string | null>(null);
-
 
   // re-build on active tab change or any document change
   useEffect(() => {
@@ -527,16 +566,39 @@ function EditorComponent() {
         });
 
         // Debounce the build to avoid rapid rebuilds
+        // Only fire when the JSON is syntactically valid to avoid
+        // sending incomplete/invalid payloads during mid-edit typing.
         const timeout = setTimeout(() => {
-          console.log('Editor: Triggering document build after debounce', {
-            docName: activeFile.name,
-            debounceTime,
-          });
           buildTimeoutsRef.current.delete(activeTab);
 
+          // Re-read from store to avoid stale-closure issues
+          const latestFile = documentsStore
+            .getState()
+            .documents.find((d) => d.name === activeTab);
+          if (!latestFile) return;
+
+          try {
+            JSON.parse(latestFile.text);
+          } catch {
+            // JSON not valid yet — mark stale, don't fire build
+            setOutput({ isPreviewStale: true });
+            return;
+          }
+
+          // Skip if Monaco reports schema validation errors (e.g. unknown component names)
+          if (outputStore.getState().hasValidationErrors) {
+            setOutput({ isPreviewStale: true });
+            return;
+          }
+
+          console.log('Editor: Triggering document build after debounce', {
+            docName: latestFile.name,
+            debounceTime,
+          });
+
           // Force new version when themes change to ensure rebuild
-          getDocumentVersion(activeFile.name);
-          buildDocument(activeFile);
+          getDocumentVersion(latestFile.name);
+          buildDocument(latestFile);
         }, debounceTime);
 
         buildTimeoutsRef.current.set(activeTab, timeout);
@@ -570,7 +632,10 @@ function EditorComponent() {
   const documentThemeDependencies = useMemo(() => {
     const deps = new Map<string, string>();
     const activeDoc = documents.find((d) => d.name === activeTab);
-    if (activeDoc && documentTypes[activeDoc.name] === 'application/json+report') {
+    if (
+      activeDoc &&
+      documentTypes[activeDoc.name] === 'application/json+report'
+    ) {
       try {
         const parsed = JSON.parse(activeDoc.text);
         const themeName = parsed.props?.theme;
@@ -746,9 +811,13 @@ function EditorComponent() {
   // Stable refs so the event handler never goes stale and doesn't need
   // reactive deps that would cause cleanup to cancel the pending timeout
   const buildDocumentRef = useRef(buildDocument);
-  useEffect(() => { buildDocumentRef.current = buildDocument; });
+  useEffect(() => {
+    buildDocumentRef.current = buildDocument;
+  });
   const getDocumentVersionRef = useRef(getDocumentVersion);
-  useEffect(() => { getDocumentVersionRef.current = getDocumentVersion; });
+  useEffect(() => {
+    getDocumentVersionRef.current = getDocumentVersion;
+  });
 
   useEffect(() => {
     const handler = () => {
@@ -761,16 +830,20 @@ function EditorComponent() {
       const editorRef = useEditorRefsStore.getState().getActiveEditor();
       if (editorRef) {
         // Don't flush if a pending diff is active — editor may be disposed
-        const hasPendingDiff = documentsStore.getState().pendingDiffs[editorRef.documentName];
+        const hasPendingDiff =
+          documentsStore.getState().pendingDiffs[editorRef.documentName];
         if (!hasPendingDiff) {
           const liveText = editorRef.editor.getValue();
-          documentsStore.getState().saveDocument(editorRef.documentName, liveText);
+          documentsStore
+            .getState()
+            .saveDocument(editorRef.documentName, liveText);
         }
       }
 
       // Flush all open theme editors whose live text differs from the
       // themes store so the build always uses up-to-date theme data.
-      const { documents: allDocs, documentTypes: allDtypes } = documentsStore.getState();
+      const { documents: allDocs, documentTypes: allDtypes } =
+        documentsStore.getState();
       for (const doc of allDocs) {
         if (allDtypes[doc.name] === 'application/json+theme') {
           const ref = useEditorRefsStore.getState().getEditor(doc.name);
@@ -799,7 +872,11 @@ function EditorComponent() {
       }
       flushBuildTimerRef.current = setTimeout(() => {
         flushBuildTimerRef.current = null;
-        const { documents: docs, activeTab: tab, documentTypes: dtypes } = documentsStore.getState();
+        const {
+          documents: docs,
+          activeTab: tab,
+          documentTypes: dtypes,
+        } = documentsStore.getState();
 
         // Determine target: if active tab is a theme, build the last-viewed document instead
         let targetName = tab;
@@ -826,7 +903,11 @@ function EditorComponent() {
               : freshDoc;
           getDocumentVersionRef.current(doc.name);
           // Bypass cache only when a theme was updated during this flush
-          buildDocumentRef.current(doc, undefined, themeDirty ? { bypassCache: true } : undefined);
+          buildDocumentRef.current(
+            doc,
+            undefined,
+            themeDirty ? { bypassCache: true } : undefined
+          );
         } else {
           setOutput({ isGenerating: false });
         }

--- a/packages/jto/src/client/components/playground/plugin-selector.tsx
+++ b/packages/jto/src/client/components/playground/plugin-selector.tsx
@@ -1,25 +1,23 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { PluginMetadata } from '../../hooks/useDiscovery';
 import { copyPluginExample } from '../../utils/plugin-utils';
 import { DialogHeader, DialogTitle, DialogDescription } from '../ui/dialog';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { ScrollArea } from '../ui/scroll-area';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
+import { Switch } from '../ui/switch';
 import {
   Sparkles,
-  Code,
-  FileJson,
   Copy,
-  ChevronRight,
-  ChevronLeft,
   MapPin,
   Package,
   FileText,
-  Eye,
-  Info,
   CheckCircle,
-  Check,
+  FolderTree,
+  Braces,
+  BookOpen,
+  ChevronDown,
+  ChevronRight,
 } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import { SchemaViewer } from './schema-viewer';
@@ -27,53 +25,55 @@ import { usePluginsStore } from '../../store/plugins-store';
 
 interface PluginSelectorProps {
   plugins: PluginMetadata[];
+  initialFocusedPlugin?: string | null;
 }
 
-export function PluginSelector({ plugins }: PluginSelectorProps) {
+export function PluginSelector({
+  plugins,
+  initialFocusedPlugin,
+}: PluginSelectorProps) {
   const togglePlugin = usePluginsStore((state) => state.togglePlugin);
   const isPluginSelected = usePluginsStore((state) => state.isPluginSelected);
+  const selectedPlugins = usePluginsStore((state) => state.selectedPlugins);
+  const isApplyingPlugins = usePluginsStore((state) => state.isApplyingPlugins);
 
-  const [selectedPlugin, setSelectedPlugin] = useState<PluginMetadata | null>(
-    null
-  );
-  const [currentView, setCurrentView] = useState<'list' | 'detail'>('list');
-  const [activeTab, setActiveTab] = useState('overview');
+  const [activePlugin, setActivePlugin] = useState<PluginMetadata | null>(null);
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
-  const [selectedExample, setSelectedExample] = useState(0);
-  const [exampleView, setExampleView] = useState<'list' | 'detail'>('list');
+  const [detailSection, setDetailSection] = useState<
+    'properties' | 'schema' | 'examples'
+  >('properties');
 
-  const handlePluginSelect = (plugin: PluginMetadata) => {
-    setSelectedPlugin(plugin);
-    setCurrentView('detail');
-  };
+  // Auto-select first plugin or initialFocusedPlugin
+  useEffect(() => {
+    if (initialFocusedPlugin) {
+      const plugin = plugins.find((p) => p.name === initialFocusedPlugin);
+      if (plugin) {
+        setActivePlugin(plugin);
+        return;
+      }
+    }
+    if (plugins.length > 0 && !activePlugin) {
+      setActivePlugin(plugins[0]);
+    }
+  }, [initialFocusedPlugin, plugins]);
 
-  const handleBackToList = () => {
-    setCurrentView('list');
-    setActiveTab('overview');
-    setSelectedExample(0);
-    setExampleView('list');
-  };
-
-  // Group plugins by location
   const groupedPlugins = useMemo(() => {
     const groups: Record<string, PluginMetadata[]> = {
       current: [],
       downstream: [],
       upstream: [],
     };
-
     plugins.forEach((plugin) => {
       if (groups[plugin.location]) {
         groups[plugin.location].push(plugin);
       }
     });
-
     return groups;
   }, [plugins]);
 
   const copyExample = async (example: any, index: number) => {
-    if (!selectedPlugin) return;
-    await copyPluginExample(selectedPlugin.name, example.props);
+    if (!activePlugin) return;
+    await copyPluginExample(activePlugin.name, example.props);
     setCopiedIndex(index);
     setTimeout(() => setCopiedIndex(null), 2000);
   };
@@ -104,405 +104,359 @@ export function PluginSelector({ plugins }: PluginSelectorProps) {
     }
   };
 
+  const hasProperties =
+    activePlugin?.schema?.properties &&
+    Object.keys(activePlugin.schema.properties).length > 0;
+  const hasSchema = activePlugin?.schema?.jsonSchema;
+  const hasExamples =
+    activePlugin?.examples && activePlugin.examples.length > 0;
+
   return (
     <>
       <DialogHeader>
         <DialogTitle className="flex items-center gap-2">
           <Sparkles className="size-5 text-amber-600 dark:text-amber-400" />
-          Discovered Plugins
+          Plugins
+          <Badge variant="secondary" className="font-normal">
+            {selectedPlugins.size} active
+          </Badge>
         </DialogTitle>
         <DialogDescription>
           {plugins.length} plugin{plugins.length !== 1 ? 's' : ''} discovered in
-          your project.
+          your project
         </DialogDescription>
       </DialogHeader>
 
-      <div className="mt-4 flex-1 overflow-hidden">
-        {/* List View */}
-        {currentView === 'list' && (
-          <ScrollArea className="h-[600px] pr-4">
-            {Object.entries(groupedPlugins).map(
-              ([location, locationPlugins]) => {
-                if (locationPlugins.length === 0) return null;
+      <div className="mt-3 flex gap-0 h-[600px] border rounded-lg overflow-hidden">
+        {/* Left panel — plugin list */}
+        <div className="w-[240px] flex-none border-r bg-muted/30">
+          <ScrollArea className="h-full">
+            <div className="p-2 space-y-3">
+              {Object.entries(groupedPlugins).map(
+                ([location, locationPlugins]) => {
+                  if (locationPlugins.length === 0) return null;
 
-                return (
-                  <div key={location} className="mb-6">
-                    <div className="flex items-center gap-2 mb-2 text-sm font-semibold text-muted-foreground">
-                      {getLocationIcon(location)}
-                      {getLocationLabel(location)}
-                      <Badge variant="secondary" className="ml-auto">
-                        {locationPlugins.length}
-                      </Badge>
-                    </div>
-
-                    <div className="space-y-1">
-                      {locationPlugins.map((plugin) => {
-                        const isSelected = isPluginSelected(plugin.name);
-                        return (
-                          <div
-                            key={plugin.name}
-                            role="checkbox"
-                            aria-checked={isSelected}
-                            tabIndex={0}
-                            onKeyDown={(e) => {
-                              if (e.key === ' ' || e.key === 'Enter') {
-                                e.preventDefault();
-                                togglePlugin(plugin);
-                              }
-                            }}
-                            onClick={() => togglePlugin(plugin)}
-                            className={cn(
-                              'flex items-center gap-3 p-2.5 rounded-lg border cursor-pointer transition-colors group',
-                              isSelected
-                                ? 'bg-primary/10 border-primary'
-                                : 'hover:bg-accent/50'
-                            )}
-                          >
-                            <div
+                  return (
+                    <div key={location}>
+                      <div className="flex items-center gap-1.5 px-2 py-1 text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                        {getLocationIcon(location)}
+                        {getLocationLabel(location)}
+                      </div>
+                      <div className="space-y-0.5">
+                        {locationPlugins.map((plugin) => {
+                          const isEnabled = isPluginSelected(plugin.name);
+                          const isActive = activePlugin?.name === plugin.name;
+                          return (
+                            <button
+                              key={plugin.name}
+                              onClick={() => setActivePlugin(plugin)}
                               className={cn(
-                                'flex-none size-4 rounded border transition-colors flex items-center justify-center',
-                                isSelected
-                                  ? 'bg-primary border-primary'
-                                  : 'border-muted-foreground/40'
+                                'w-full text-left px-2 py-1.5 rounded-md transition-colors cursor-pointer',
+                                'flex items-center gap-2',
+                                isActive
+                                  ? 'bg-accent text-accent-foreground'
+                                  : 'hover:bg-accent/50 text-foreground'
                               )}
                             >
-                              {isSelected && (
-                                <Check className="size-3 text-primary-foreground" />
-                              )}
-                            </div>
-                            <div className="flex-1 min-w-0">
-                              <div className="flex items-center gap-2">
-                                <span className="font-medium truncate">
-                                  {plugin.name}
-                                </span>
-                                {plugin.version && (
-                                  <span className="text-xs text-muted-foreground font-mono">
-                                    v{plugin.version}
-                                  </span>
+                              <div
+                                className={cn(
+                                  'size-1.5 rounded-full flex-none transition-colors',
+                                  isEnabled
+                                    ? 'bg-amber-500 dark:bg-amber-400'
+                                    : 'bg-muted-foreground/30'
                                 )}
-                              </div>
-                              {plugin.description && (
-                                <p className="text-xs text-muted-foreground mt-0.5 truncate">
-                                  {plugin.description}
-                                </p>
-                              )}
-                            </div>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="flex-none size-7 opacity-0 group-hover:opacity-100 transition-opacity"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handlePluginSelect(plugin);
-                              }}
-                            >
-                              <ChevronRight className="size-4 text-muted-foreground" />
-                            </Button>
-                          </div>
-                        );
-                      })}
+                              />
+                              <span className="text-sm font-medium truncate flex-1">
+                                {plugin.name}
+                              </span>
+                            </button>
+                          );
+                        })}
+                      </div>
                     </div>
-                  </div>
-                );
-              }
-            )}
+                  );
+                }
+              )}
+            </div>
           </ScrollArea>
-        )}
+        </div>
 
-        {/* Detail View with Tabs */}
-        {currentView === 'detail' && selectedPlugin && (
-          <div className="flex flex-col h-full">
-            {/* Back button */}
-            <div className="flex items-center gap-2 mb-4 pb-2 border-b">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleBackToList}
-                className="gap-1 -ml-2"
-              >
-                <ChevronLeft className="size-4" />
-                Back to Plugins
-              </Button>
-              <div className="flex-1" />
-              <Badge variant="outline">
-                {selectedPlugin.name}
-                {selectedPlugin.version && ` v${selectedPlugin.version}`}
-              </Badge>
+        {/* Right panel — detail */}
+        {activePlugin ? (
+          <div className="flex-1 flex flex-col min-w-0">
+            {/* Plugin header */}
+            <div className="flex-none px-5 py-4 border-b bg-background">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2.5">
+                    <h3 className="text-base font-semibold truncate">
+                      {activePlugin.name}
+                    </h3>
+                    {activePlugin.version && (
+                      <Badge
+                        variant="outline"
+                        className="font-mono text-[11px] flex-none"
+                      >
+                        v{activePlugin.version}
+                      </Badge>
+                    )}
+                  </div>
+                  {activePlugin.description && (
+                    <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+                      {activePlugin.description}
+                    </p>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 flex-none pt-0.5">
+                  <span className="text-xs text-muted-foreground">
+                    {isPluginSelected(activePlugin.name) ? 'On' : 'Off'}
+                  </span>
+                  <Switch
+                    checked={isPluginSelected(activePlugin.name)}
+                    onCheckedChange={() => togglePlugin(activePlugin)}
+                    disabled={isApplyingPlugins}
+                    aria-label={`Toggle ${activePlugin.name}`}
+                  />
+                </div>
+              </div>
+              <div className="flex items-center gap-1.5 mt-2 text-xs text-muted-foreground">
+                {getLocationIcon(activePlugin.location)}
+                <span>{getLocationLabel(activePlugin.location)}</span>
+                <span className="text-muted-foreground/60 mx-1">/</span>
+                <span className="font-mono truncate">
+                  {activePlugin.relativePath}
+                </span>
+              </div>
             </div>
 
-            <Tabs
-              value={activeTab}
-              onValueChange={setActiveTab}
-              className="flex-1 flex flex-col overflow-hidden5"
-            >
-              <TabsList className="grid w-full grid-cols-3 mb-4">
-                <TabsTrigger value="overview" className="gap-2">
-                  <Info className="size-4" />
-                  Overview
-                </TabsTrigger>
-                <TabsTrigger
-                  value="schema"
-                  className="gap-2"
-                  disabled={
-                    !selectedPlugin.schema ||
-                    Object.keys(selectedPlugin.schema).length === 0
-                  }
+            {/* Section nav */}
+            <div className="flex-none px-5 pt-3 pb-0 flex gap-1 border-b bg-background">
+              {hasProperties && (
+                <button
+                  onClick={() => setDetailSection('properties')}
+                  className={cn(
+                    'px-3 py-1.5 text-sm font-medium rounded-t-md border-b-2 transition-colors cursor-pointer',
+                    detailSection === 'properties'
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground'
+                  )}
                 >
-                  <FileJson className="size-4" />
-                  Schema
-                </TabsTrigger>
-                <TabsTrigger
-                  value="examples"
-                  className="gap-2"
-                  disabled={
-                    !selectedPlugin.examples ||
-                    selectedPlugin.examples.length === 0
-                  }
+                  <span className="flex items-center gap-1.5">
+                    <Braces className="size-3.5" />
+                    Properties
+                  </span>
+                </button>
+              )}
+              {hasSchema && (
+                <button
+                  onClick={() => setDetailSection('schema')}
+                  className={cn(
+                    'px-3 py-1.5 text-sm font-medium rounded-t-md border-b-2 transition-colors cursor-pointer',
+                    detailSection === 'schema'
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground'
+                  )}
                 >
-                  <Eye className="size-4" />
-                  Examples{' '}
-                  {selectedPlugin.examples &&
-                    `(${selectedPlugin.examples.length})`}
-                </TabsTrigger>
-              </TabsList>
+                  <span className="flex items-center gap-1.5">
+                    <FolderTree className="size-3.5" />
+                    Schema
+                  </span>
+                </button>
+              )}
+              {hasExamples && (
+                <button
+                  onClick={() => setDetailSection('examples')}
+                  className={cn(
+                    'px-3 py-1.5 text-sm font-medium rounded-t-md border-b-2 transition-colors cursor-pointer',
+                    detailSection === 'examples'
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground'
+                  )}
+                >
+                  <span className="flex items-center gap-1.5">
+                    <BookOpen className="size-3.5" />
+                    Examples
+                    <Badge
+                      variant="secondary"
+                      className="text-[10px] px-1.5 py-0 h-4"
+                    >
+                      {activePlugin.examples!.length}
+                    </Badge>
+                  </span>
+                </button>
+              )}
+            </div>
 
-              {/* Overview Tab */}
-              <TabsContent value="overview" className="flex-1 overflow-hidden">
-                <ScrollArea className="h-[500px] pr-4">
-                  <div className="space-y-4">
-                    <div>
-                      <h3 className="text-lg font-semibold flex items-center gap-2">
-                        <Code className="size-5 text-blue-600 dark:text-blue-400" />
-                        {selectedPlugin.name}
-                      </h3>
-                      {selectedPlugin.version && (
-                        <Badge variant="outline" className="mt-2 mb-1">
-                          Version {selectedPlugin.version}
-                        </Badge>
-                      )}
-                    </div>
-
-                    {selectedPlugin.description && (
-                      <div>
-                        <h4 className="text-sm font-medium mb-1">
-                          Description
-                        </h4>
-                        <p className="text-sm text-muted-foreground">
-                          {selectedPlugin.description}
-                        </p>
-                      </div>
+            {/* Section content */}
+            <ScrollArea className="flex-1">
+              <div className="p-5">
+                {/* Properties section */}
+                {detailSection === 'properties' && hasProperties && (
+                  <div className="space-y-1">
+                    {Object.entries(activePlugin.schema.properties!).map(
+                      ([key, prop]: [string, any]) => (
+                        <PropertyRow key={key} name={key} prop={prop} />
+                      )
                     )}
-
-                    <div>
-                      <h4 className="text-sm font-medium mb-1">Location</h4>
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                        {getLocationIcon(selectedPlugin.location)}
-                        <span>{getLocationLabel(selectedPlugin.location)}</span>
-                        <span className="text-xs">
-                          ({selectedPlugin.relativePath})
-                        </span>
-                      </div>
-                    </div>
-
-                    {selectedPlugin.schema?.properties && (
-                      <div>
-                        <h4 className="text-sm font-medium mb-2">
-                          Configuration Properties (Quick Preview)
-                        </h4>
-                        <div className="space-y-1">
-                          {Object.entries(selectedPlugin.schema.properties)
-                            .slice(0, 5)
-                            .map(([key, prop]: [string, any]) => (
-                              <div key={key} className="text-xs">
-                                <span className="font-mono font-medium">
-                                  {key}
-                                </span>
-                                {prop.type && (
-                                  <span className="text-muted-foreground ml-2">
-                                    ({prop.type})
-                                    {prop.optional ? ' - optional' : ''}
-                                  </span>
-                                )}
-                              </div>
-                            ))}
-                          {Object.keys(selectedPlugin.schema.properties)
-                            .length > 5 && (
-                            <div className="text-xs text-muted-foreground">
-                              ...and{' '}
-                              {Object.keys(selectedPlugin.schema.properties)
-                                .length - 5}{' '}
-                              more properties. View the Schema tab for complete
-                              details.
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </ScrollArea>
-              </TabsContent>
-
-              {/* Schema Tab */}
-              <TabsContent value="schema" className="flex-1 overflow-hidden">
-                <SchemaViewer
-                  schema={selectedPlugin.schema?.jsonSchema || null}
-                  loading={false}
-                  className="h-[500px]"
-                />
-              </TabsContent>
-
-              {/* Examples Tab */}
-              <TabsContent value="examples" className="flex-1 overflow-hidden">
-                {selectedPlugin.examples &&
-                selectedPlugin.examples.length > 0 ? (
-                  <>
-                    {/* Examples List View */}
-                    {exampleView === 'list' &&
-                      selectedPlugin.examples.length > 1 && (
-                        <ScrollArea className="h-[500px]">
-                          <div className="space-y-3">
-                            {selectedPlugin.examples.map((example, index) => (
-                              <div
-                                key={index}
-                                className="p-4 border rounded-lg hover:bg-muted cursor-pointer transition-colors group"
-                                onClick={() => {
-                                  setSelectedExample(index);
-                                  setExampleView('detail');
-                                }}
-                              >
-                                <div className="flex items-start justify-between">
-                                  <div className="flex-1">
-                                    <div className="flex items-center gap-2 mb-1">
-                                      <Badge
-                                        variant="secondary"
-                                        className="text-xs"
-                                      >
-                                        Example {index + 1}
-                                      </Badge>
-                                      <h3 className="font-semibold text-sm">
-                                        {example.title ||
-                                          `Example ${index + 1}`}
-                                      </h3>
-                                    </div>
-                                    {example.description && (
-                                      <p className="text-sm text-muted-foreground mt-2 line-clamp-2">
-                                        {example.description}
-                                      </p>
-                                    )}
-                                  </div>
-                                  <ChevronRight className="size-5 text-muted-foreground mt-1 group-hover:translate-x-1 transition-transform" />
-                                </div>
-                              </div>
-                            ))}
-                          </div>
-                        </ScrollArea>
-                      )}
-
-                    {/* Example Detail View */}
-                    {(exampleView === 'detail' ||
-                      selectedPlugin.examples.length === 1) &&
-                      selectedPlugin.examples[selectedExample] && (
-                        <>
-                          {/* Back button for multiple examples */}
-                          {selectedPlugin.examples.length > 1 && (
-                            <div className="flex items-center gap-2 mb-4 pb-2 border-b">
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => setExampleView('list')}
-                                className="gap-1 -ml-2"
-                              >
-                                <ChevronLeft className="size-4" />
-                                Back to Examples
-                              </Button>
-                              <div className="flex-1" />
-                              <Badge variant="secondary" className="text-xs">
-                                Example {selectedExample + 1} of{' '}
-                                {selectedPlugin.examples.length}
-                              </Badge>
-                            </div>
-                          )}
-
-                          <ScrollArea className="max-h-[50vh]">
-                            <div className="space-y-4">
-                              {selectedPlugin.examples[selectedExample]
-                                .title && (
-                                <h3 className="text-lg font-semibold">
-                                  {
-                                    selectedPlugin.examples[selectedExample]
-                                      .title
-                                  }
-                                </h3>
-                              )}
-
-                              {selectedPlugin.examples[selectedExample]
-                                .description && (
-                                <p className="text-sm text-muted-foreground">
-                                  {
-                                    selectedPlugin.examples[selectedExample]
-                                      .description
-                                  }
-                                </p>
-                              )}
-
-                              <div>
-                                <div className="flex items-center justify-between mb-2">
-                                  <h4 className="text-sm font-medium">
-                                    Full Component Configuration
-                                  </h4>
-                                  <Button
-                                    size="sm"
-                                    variant="outline"
-                                    onClick={() =>
-                                      copyExample(
-                                        selectedPlugin.examples![
-                                          selectedExample
-                                        ],
-                                        selectedExample
-                                      )
-                                    }
-                                  >
-                                    {copiedIndex === selectedExample ? (
-                                      <>
-                                        <CheckCircle className="size-4 mr-2 text-green-600" />
-                                        Copied!
-                                      </>
-                                    ) : (
-                                      <>
-                                        <Copy className="size-4 mr-2" />
-                                        Copy
-                                      </>
-                                    )}
-                                  </Button>
-                                </div>
-
-                                <pre className="p-4 bg-muted rounded-lg overflow-x-auto">
-                                  <code className="text-sm">
-                                    {JSON.stringify(
-                                      selectedPlugin.examples[selectedExample]
-                                        .props,
-                                      null,
-                                      2
-                                    )}
-                                  </code>
-                                </pre>
-                              </div>
-                            </div>
-                          </ScrollArea>
-                        </>
-                      )}
-                  </>
-                ) : (
-                  <div className="text-center text-muted-foreground py-12">
-                    <Eye className="size-12 mx-auto mb-3 opacity-20" />
-                    <p>No examples available for this plugin</p>
                   </div>
                 )}
-              </TabsContent>
-            </Tabs>
+
+                {/* Schema section */}
+                {detailSection === 'schema' && hasSchema && (
+                  <SchemaViewer
+                    schema={activePlugin.schema.jsonSchema}
+                    loading={false}
+                    className="h-[420px]"
+                  />
+                )}
+
+                {/* Examples section */}
+                {detailSection === 'examples' &&
+                  hasExamples &&
+                  activePlugin.examples!.map((example, index) => (
+                    <div
+                      key={index}
+                      className={cn(index > 0 && 'mt-4 pt-4 border-t')}
+                    >
+                      <div className="flex items-center justify-between mb-2">
+                        <div className="flex items-center gap-2 min-w-0">
+                          {example.title && (
+                            <span className="font-medium text-sm truncate">
+                              {example.title}
+                            </span>
+                          )}
+                          {!example.title && (
+                            <span className="text-sm text-muted-foreground">
+                              Example {index + 1}
+                            </span>
+                          )}
+                        </div>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-7 px-2 text-xs flex-none"
+                          onClick={() => copyExample(example, index)}
+                        >
+                          {copiedIndex === index ? (
+                            <>
+                              <CheckCircle className="size-3 mr-1 text-green-600" />
+                              Copied
+                            </>
+                          ) : (
+                            <>
+                              <Copy className="size-3 mr-1" />
+                              Copy
+                            </>
+                          )}
+                        </Button>
+                      </div>
+                      {example.description && (
+                        <p className="text-xs text-muted-foreground mb-2">
+                          {example.description}
+                        </p>
+                      )}
+                      <pre className="p-3 bg-muted rounded-md overflow-x-auto text-xs font-mono leading-relaxed">
+                        {JSON.stringify(example.props, null, 2)}
+                      </pre>
+                    </div>
+                  ))}
+
+                {/* Empty state when no sections available */}
+                {!hasProperties && !hasSchema && !hasExamples && (
+                  <div className="text-center py-12 text-muted-foreground">
+                    <Braces className="size-10 mx-auto mb-3 opacity-20" />
+                    <p className="text-sm">
+                      No schema or examples available for this plugin
+                    </p>
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </div>
+        ) : (
+          <div className="flex-1 flex items-center justify-center text-muted-foreground">
+            <p className="text-sm">Select a plugin to view details</p>
           </div>
         )}
       </div>
     </>
+  );
+}
+
+/** Compact property row for the properties section */
+function PropertyRow({ name, prop }: { name: string; prop: any }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasDetails =
+    prop.description ||
+    prop.enum ||
+    prop.default !== undefined ||
+    prop.items ||
+    prop.properties;
+
+  const typeLabel =
+    prop.type || (prop.enum ? 'enum' : prop.oneOf ? 'oneOf' : '—');
+
+  return (
+    <div className="rounded-md border">
+      <button
+        onClick={() => hasDetails && setExpanded(!expanded)}
+        className={cn(
+          'w-full text-left flex items-center gap-2 px-3 py-2 text-sm',
+          hasDetails && 'cursor-pointer hover:bg-muted/50'
+        )}
+      >
+        {hasDetails ? (
+          expanded ? (
+            <ChevronDown className="size-3 text-muted-foreground flex-none" />
+          ) : (
+            <ChevronRight className="size-3 text-muted-foreground flex-none" />
+          )
+        ) : (
+          <span className="size-3 flex-none" />
+        )}
+        <span className="font-mono font-medium text-xs">{name}</span>
+        <Badge
+          variant="outline"
+          className="text-[10px] px-1.5 py-0 h-4 flex-none"
+        >
+          {typeLabel}
+        </Badge>
+        {prop.optional === false && (
+          <span className="text-[10px] text-red-500 font-medium flex-none">
+            required
+          </span>
+        )}
+        <span className="flex-1" />
+        {prop.default !== undefined && (
+          <span className="text-[10px] font-mono text-muted-foreground flex-none">
+            = {JSON.stringify(prop.default)}
+          </span>
+        )}
+      </button>
+      {expanded && hasDetails && (
+        <div className="px-3 pb-2 pt-0 ml-5 text-xs space-y-1 text-muted-foreground">
+          {prop.description && <p>{prop.description}</p>}
+          {prop.enum && (
+            <p>
+              <span className="font-medium text-foreground">Values: </span>
+              {prop.enum.map((v: any, i: number) => (
+                <span key={i}>
+                  {i > 0 && ', '}
+                  <code className="bg-muted px-1 rounded">
+                    {JSON.stringify(v)}
+                  </code>
+                </span>
+              ))}
+            </p>
+          )}
+          {prop.items?.type && (
+            <p>
+              <span className="font-medium text-foreground">Items: </span>
+              {prop.items.type}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
   );
 }

--- a/packages/jto/src/client/components/playground/preview.tsx
+++ b/packages/jto/src/client/components/playground/preview.tsx
@@ -1,19 +1,8 @@
-import React, {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  memo,
-} from 'react';
+import React, { useCallback, useEffect, useRef, useState, memo } from 'react';
 import { PreviewFrameMemoized } from './preview-frame';
 import { PreviewHeaderMemoized } from './preview-header';
 import { WarningsPanel } from './warnings-panel';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '../ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
 import { Separator } from '../ui/separator';
 import { useOutputStore } from '../../store/output-store-provider';
 import { useSettingsStore } from '../../store/settings-store-provider';
@@ -21,7 +10,6 @@ import { renderDocument } from '../../lib/render';
 import { useDocumentsStore } from '../../store/documents-store-provider';
 import { CacheMetrics } from '../cache-metrics';
 import { FORMAT_LABEL } from '../../lib/env';
-
 
 /**
  * Tiny live countdown that ticks every 100ms and shows the
@@ -40,14 +28,17 @@ const DebounceCountdown = memo(function DebounceCountdown({
   );
 
   useEffect(() => {
+    let id: ReturnType<typeof setInterval> | undefined;
     const tick = () => {
       const r = Math.max(0, editTimestamp + debounceMs - Date.now());
       setRemaining(r);
-      if (r <= 0) clearInterval(id);
+      if (r <= 0 && id != null) clearInterval(id);
     };
     tick();
-    const id = setInterval(tick, 100);
-    return () => clearInterval(id);
+    id = setInterval(tick, 100);
+    return () => {
+      if (id != null) clearInterval(id);
+    };
   }, [editTimestamp, debounceMs]);
 
   if (remaining <= 0) return null;
@@ -67,7 +58,12 @@ const DebounceCountdown = memo(function DebounceCountdown({
 });
 
 export function Preview() {
-  const { autoReload, renderingLibrary, saveDocumentDebounceWait, setSettings } = useSettingsStore((state) => state);
+  const {
+    autoReload,
+    renderingLibrary,
+    saveDocumentDebounceWait,
+    setSettings,
+  } = useSettingsStore((state) => state);
   const {
     name,
     text,
@@ -83,6 +79,7 @@ export function Preview() {
     editSequence,
     lastBuiltSequence,
     editTimestamp,
+    hasValidationErrors,
     setOutput,
   } = useOutputStore((state) => state);
   const activeTab = useDocumentsStore((state) => state.activeTab);
@@ -105,17 +102,20 @@ export function Preview() {
     }
   }, []);
 
-
   // Core render function
   const doRender = useCallback(
     async (docName: string, docBlob: Blob) => {
-      setOutput({ isRendering: true, isPreviewStale: false, globalError: undefined });
+      setOutput({
+        isRendering: true,
+        isPreviewStale: false,
+        globalError: undefined,
+      });
 
       try {
         const { status, payload } = await renderDocument(
           docName,
           docBlob,
-          renderingLibrary,
+          renderingLibrary
         );
 
         if (status !== 'success') {
@@ -200,66 +200,89 @@ export function Preview() {
         {(useSettingsStore as any) &&
           (useSettingsStore as any).getState?.().useGlobalPreviewHeader ===
             false && (
-          <PreviewHeaderMemoized
-            iframeRef={iframeRef}
-            displayReloadButton={
-              Boolean(iframeSrc) && !(iframeSrc?.startsWith('blob:') ?? false)
-            }
-            name={name?.trim() || 'Preview'}
-            blob={blob}
-            autoReload={autoReload}
-            onToggleAutoReload={() => setSettings({ autoReload: !autoReload })}
-            onManualRender={handleManualRender}
-            isGenerating={isGenerating}
-            isRendering={isRendering}
-            onShowCacheMetrics={() => setShowCacheMetrics(true)}
-            documentText={text}
-            warnings={warnings}
-            renderingLibrary={renderingLibrary}
-            setRenderingLibrary={(lib) => setSettings({ renderingLibrary: lib } as any)}
-          />
-        )}
+            <PreviewHeaderMemoized
+              iframeRef={iframeRef}
+              displayReloadButton={
+                Boolean(iframeSrc) && !(iframeSrc?.startsWith('blob:') ?? false)
+              }
+              name={name?.trim() || 'Preview'}
+              blob={blob}
+              autoReload={autoReload}
+              onToggleAutoReload={() =>
+                setSettings({ autoReload: !autoReload })
+              }
+              onManualRender={handleManualRender}
+              isGenerating={isGenerating}
+              isRendering={isRendering}
+              onShowCacheMetrics={() => setShowCacheMetrics(true)}
+              documentText={text}
+              warnings={warnings}
+              renderingLibrary={renderingLibrary}
+              setRenderingLibrary={(lib) =>
+                setSettings({ renderingLibrary: lib } as any)
+              }
+            />
+          )}
         <Separator />
         {/* Status Bar: cache + stale combined */}
         {(() => {
-          const hasUnsyncedEdits = (editSequence ?? 0) > (lastBuiltSequence ?? 0);
-          const isStale = (isPreviewStale || hasUnsyncedEdits) && !isGenerating && !isRendering;
-          return ((cacheStatus && cacheStatus !== 'UNKNOWN') || isStale) && (
-            <div className={
-              `px-3 py-1.5 flex items-center justify-between border-b overflow-hidden ${
-                isStale
-                  ? 'bg-amber-500/10 border-amber-500/30'
-                  : 'bg-muted/30'
-              }`
-            }>
-              <div className="flex items-center gap-2 min-w-0 truncate">
-                {cacheStatus === 'HIT' && !isStale ? (
-                  <>
-                    <div className="h-1.5 w-1.5 rounded-full bg-green-500 flex-shrink-0" />
-                    <span className="text-xs text-muted-foreground truncate">Cached</span>
-                  </>
-                ) : cacheStatus === 'MISS' && !isStale ? (
-                  <>
-                    <div className="h-1.5 w-1.5 rounded-full bg-orange-500 flex-shrink-0" />
-                    <span className="text-xs text-muted-foreground truncate">Fresh {FORMAT_LABEL.toLowerCase()}</span>
-                  </>
-                ) : isStale ? (
-                  <>
-                    <div className="h-1.5 w-1.5 rounded-full bg-amber-500 flex-shrink-0" />
-                    <span className="text-xs text-amber-600 dark:text-amber-400 truncate">Outdated — click Run</span>
-                    {editTimestamp && hasUnsyncedEdits && !isGenerating && autoReload && renderingLibrary === 'docxjs' && (
-                      <DebounceCountdown
-                        editTimestamp={editTimestamp}
-                        debounceMs={saveDocumentDebounceWait + 200}
-                      />
-                    )}
-                  </>
-                ) : null}
+          const hasUnsyncedEdits =
+            (editSequence ?? 0) > (lastBuiltSequence ?? 0);
+          const isStale =
+            (isPreviewStale || hasUnsyncedEdits) &&
+            !isGenerating &&
+            !isRendering;
+          return (
+            ((cacheStatus && cacheStatus !== 'UNKNOWN') || isStale) && (
+              <div
+                className={`px-3 py-1.5 flex items-center justify-between border-b overflow-hidden ${
+                  isStale
+                    ? 'bg-amber-500/10 border-amber-500/30'
+                    : 'bg-muted/30'
+                }`}
+              >
+                <div className="flex items-center gap-2 min-w-0 truncate">
+                  {cacheStatus === 'HIT' && !isStale ? (
+                    <>
+                      <div className="h-1.5 w-1.5 rounded-full bg-green-500 flex-shrink-0" />
+                      <span className="text-xs text-muted-foreground truncate">
+                        Cached
+                      </span>
+                    </>
+                  ) : cacheStatus === 'MISS' && !isStale ? (
+                    <>
+                      <div className="h-1.5 w-1.5 rounded-full bg-orange-500 flex-shrink-0" />
+                      <span className="text-xs text-muted-foreground truncate">
+                        Fresh {FORMAT_LABEL.toLowerCase()}
+                      </span>
+                    </>
+                  ) : isStale ? (
+                    <>
+                      <div className="h-1.5 w-1.5 rounded-full bg-amber-500 flex-shrink-0" />
+                      <span className="text-xs text-amber-600 dark:text-amber-400 truncate">
+                        Outdated — click Run
+                      </span>
+                      {editTimestamp &&
+                        hasUnsyncedEdits &&
+                        !isGenerating &&
+                        !hasValidationErrors &&
+                        autoReload &&
+                        renderingLibrary === 'docxjs' && (
+                          <DebounceCountdown
+                            editTimestamp={editTimestamp}
+                            debounceMs={saveDocumentDebounceWait + 200}
+                          />
+                        )}
+                    </>
+                  ) : null}
+                </div>
+                {!isStale && cacheHitRate && cacheHitRate !== '0.0%' && (
+                  <span className="text-xs text-muted-foreground flex-shrink-0 ml-2">
+                    {cacheHitRate} hit rate
+                  </span>
+                )}
               </div>
-              {!isStale && cacheHitRate && cacheHitRate !== '0.0%' && (
-                <span className="text-xs text-muted-foreground flex-shrink-0 ml-2">{cacheHitRate} hit rate</span>
-              )}
-            </div>
+            )
           );
         })()}
         {/* Warnings Panel */}
@@ -269,7 +292,9 @@ export function Preview() {
           <div className="flex-1 flex items-center justify-center p-6">
             <div className="max-w-md rounded-lg border border-red-400/50 bg-red-400/10 px-4 py-3 text-sm text-red-400">
               <p className="font-medium mb-1">Generation failed</p>
-              <p className="text-xs text-red-400/80 break-words">{globalError}</p>
+              <p className="text-xs text-red-400/80 break-words">
+                {globalError}
+              </p>
             </div>
           </div>
         ) : (
@@ -280,16 +305,28 @@ export function Preview() {
             iframeSrcDoc={iframeSrcDoc}
             isGenerating={(() => {
               const willAutoBuild = autoReload && renderingLibrary === 'docxjs';
-              const isSwitchingDoc = activeTab && name && activeTab !== name &&
+              const isSwitchingDoc =
+                activeTab &&
+                name &&
+                activeTab !== name &&
                 documentTypes[activeTab] !== 'application/json+theme';
-              return Boolean(isGenerating) || Boolean(willAutoBuild && isSwitchingDoc);
+              return (
+                Boolean(isGenerating) ||
+                Boolean(willAutoBuild && isSwitchingDoc)
+              );
             })()}
             generationProgress={(() => {
               const willAutoBuild = autoReload && renderingLibrary === 'docxjs';
-              const isSwitchingDoc = activeTab && name && activeTab !== name &&
+              const isSwitchingDoc =
+                activeTab &&
+                name &&
+                activeTab !== name &&
                 documentTypes[activeTab] !== 'application/json+theme';
               return willAutoBuild && isSwitchingDoc && !isGenerating
-                ? { stage: 'parsing' as const, message: `Building preview for ${activeTab}...` }
+                ? {
+                    stage: 'parsing' as const,
+                    message: `Building preview for ${activeTab}...`,
+                  }
                 : generationProgress;
             })()}
           />

--- a/packages/jto/src/client/store/output-store.ts
+++ b/packages/jto/src/client/store/output-store.ts
@@ -26,6 +26,7 @@ export type OutputState = {
   editSequence?: number; // incremented on every Monaco keystroke (init 0)
   lastBuiltSequence?: number; // stamped when generation completes (init 0)
   editTimestamp?: number; // Date.now() of the last edit (for debounce countdown)
+  hasValidationErrors?: boolean; // true when Monaco reports schema validation errors
   // ⚠️ name doesn't necessarily correspond to the global error message
 };
 
@@ -48,6 +49,7 @@ export const initOutputStore = (): OutputState => {
     isPreviewStale: false,
     editSequence: 0,
     lastBuiltSequence: 0,
+    hasValidationErrors: false,
   };
 };
 

--- a/packages/jto/src/server/routes/format.ts
+++ b/packages/jto/src/server/routes/format.ts
@@ -1,7 +1,10 @@
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { getContainer } from '../container/index.js';
-import { LooseDocumentGenerationRequestSchema, LooseDocumentValidationRequestSchema } from '../schemas/loose.js';
+import {
+  LooseDocumentGenerationRequestSchema,
+  LooseDocumentValidationRequestSchema,
+} from '../schemas/loose.js';
 import { tbValidator, getValidated } from '../lib/typebox-validator.js';
 import { logger } from '../utils/logger.js';
 import { rateLimiter } from '../middleware/hono/rate-limit.js';
@@ -21,7 +24,9 @@ export function createFormatRouter(adapter: FormatAdapter) {
   const contentTypeMw = async (c: any, next: () => Promise<void>) => {
     const contentType = c.req.header('content-type');
     if (!contentType || !contentType.includes('application/json')) {
-      throw new HTTPException(400, { message: 'Content-Type must be application/json' });
+      throw new HTTPException(400, {
+        message: 'Content-Type must be application/json',
+      });
     }
     await next();
   };
@@ -32,7 +37,10 @@ export function createFormatRouter(adapter: FormatAdapter) {
     rateLimiter({
       limit: process.env.NODE_ENV === 'production' ? 10 : 1000,
       window: 15 * 60 * 1000,
-      keyGenerator: (c) => c.req.header('X-Real-IP') || c.req.header('X-Forwarded-For')?.split(',').pop()?.trim() || 'anonymous',
+      keyGenerator: (c) =>
+        c.req.header('X-Real-IP') ||
+        c.req.header('X-Forwarded-For')?.split(',').pop()?.trim() ||
+        'anonymous',
     }),
     contentTypeMw,
     tbValidator(LooseDocumentGenerationRequestSchema),
@@ -60,9 +68,10 @@ export function createFormatRouter(adapter: FormatAdapter) {
         const cacheService = getContainer().get('cacheService');
         const cacheStats = cacheService.getStats();
 
-        const contentType = adapter.name === 'pptx'
-          ? 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
-          : 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+        const contentType =
+          adapter.name === 'pptx'
+            ? 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+            : 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
 
         return c.json({
           success: true,
@@ -80,11 +89,19 @@ export function createFormatRouter(adapter: FormatAdapter) {
           meta: { timestamp: new Date().toISOString(), requestId },
         });
       } catch (error) {
-        logger.error(`${adapter.label} generation failed`, { error, requestId });
+        logger.error(`${adapter.label} generation failed`, {
+          error,
+          requestId,
+        });
 
         if (error instanceof Error) {
           const msg = error.message.toLowerCase();
-          if (msg.includes('invalid') || msg.includes('validation') || msg.includes('missing required')) {
+          if (
+            msg.includes('invalid') ||
+            msg.includes('validation') ||
+            msg.includes('missing required') ||
+            msg.includes('unknown component')
+          ) {
             throw new HTTPException(400, { message: error.message });
           }
         }
@@ -103,7 +120,10 @@ export function createFormatRouter(adapter: FormatAdapter) {
     tbValidator(LooseDocumentValidationRequestSchema),
     async (c) => {
       const generatorService = getContainer().get('generatorService');
-      const { jsonDefinition } = getValidated<{ jsonDefinition: any }>(c, 'json');
+      const { jsonDefinition } = getValidated<{ jsonDefinition: any }>(
+        c,
+        'json'
+      );
       const requestId = c.get('requestId');
 
       try {
@@ -126,45 +146,70 @@ export function createFormatRouter(adapter: FormatAdapter) {
     rateLimiter({
       limit: process.env.NODE_ENV === 'production' ? 20 : 1000,
       window: 15 * 60 * 1000,
-      keyGenerator: (c) => c.req.header('X-Real-IP') || c.req.header('X-Forwarded-For')?.split(',').pop()?.trim() || 'anonymous',
+      keyGenerator: (c) =>
+        c.req.header('X-Real-IP') ||
+        c.req.header('X-Forwarded-For')?.split(',').pop()?.trim() ||
+        'anonymous',
     }),
     async (c) => {
       const requestId = c.get('requestId');
-      const libreOfficeService = getContainer().get('libreOfficeConverterService');
+      const libreOfficeService = getContainer().get(
+        'libreOfficeConverterService'
+      );
 
       try {
         const body = await c.req.parseBody();
         const file = body.file;
 
         if (!file || typeof file === 'string') {
-          throw new HTTPException(400, { message: `No ${adapter.name.toUpperCase()} file provided` });
+          throw new HTTPException(400, {
+            message: `No ${adapter.name.toUpperCase()} file provided`,
+          });
         }
         if ((file as File).size === 0) {
-          throw new HTTPException(400, { message: `${adapter.name.toUpperCase()} file is empty` });
+          throw new HTTPException(400, {
+            message: `${adapter.name.toUpperCase()} file is empty`,
+          });
         }
 
         const arrayBuffer = await (file as File).arrayBuffer();
         const inputBuffer = Buffer.from(arrayBuffer);
-        const pdfBuffer = await libreOfficeService.convertToPdf(inputBuffer, (file as File).name);
+        const pdfBuffer = await libreOfficeService.convertToPdf(
+          inputBuffer,
+          (file as File).name
+        );
 
-        const pdfName = ((file as File).name || 'preview').replace(/\.[^.]+$/i, '') + '.pdf';
+        const pdfName =
+          ((file as File).name || 'preview').replace(/\.[^.]+$/i, '') + '.pdf';
         c.header('Content-Type', 'application/pdf');
         c.header('Content-Disposition', `inline; filename="${pdfName}"`);
         c.header('Content-Length', String(pdfBuffer.length));
 
         return c.body(pdfBuffer);
       } catch (error) {
-        logger.error('LibreOffice preview conversion failed', { error, requestId });
+        logger.error('LibreOffice preview conversion failed', {
+          error,
+          requestId,
+        });
         if (error instanceof HTTPException) throw error;
         if (error instanceof LibreOfficeBinaryNotFoundError) {
           throw new HTTPException(503, {
-            message: 'LibreOffice is not available. Install LibreOffice or set LIBREOFFICE_PATH.',
+            message:
+              'LibreOffice is not available. Install LibreOffice or set LIBREOFFICE_PATH.',
           });
         }
-        if (error instanceof LibreOfficeTimeoutError || error instanceof LibreOfficeConversionError || error instanceof LibreOfficeOutputNotFoundError) {
-          throw new HTTPException(500, { message: 'LibreOffice preview conversion failed.' });
+        if (
+          error instanceof LibreOfficeTimeoutError ||
+          error instanceof LibreOfficeConversionError ||
+          error instanceof LibreOfficeOutputNotFoundError
+        ) {
+          throw new HTTPException(500, {
+            message: 'LibreOffice preview conversion failed.',
+          });
         }
-        throw new HTTPException(500, { message: 'Internal server error during preview conversion' });
+        throw new HTTPException(500, {
+          message: 'Internal server error during preview conversion',
+        });
       }
     }
   );
@@ -213,9 +258,14 @@ export function createFormatRouter(adapter: FormatAdapter) {
           meta: { timestamp: new Date().toISOString(), requestId },
         });
       } catch (error) {
-        logger.error('Failed to get standard components definition', { error, requestId });
+        logger.error('Failed to get standard components definition', {
+          error,
+          requestId,
+        });
         if (error instanceof HTTPException) throw error;
-        throw new HTTPException(500, { message: 'Failed to get standard components definition' });
+        throw new HTTPException(500, {
+          message: 'Failed to get standard components definition',
+        });
       }
     }
   );
@@ -243,7 +293,9 @@ export function createFormatRouter(adapter: FormatAdapter) {
       });
     } catch (error) {
       logger.error('Failed to get cache statistics', { error });
-      throw new HTTPException(500, { message: 'Failed to get cache statistics' });
+      throw new HTTPException(500, {
+        message: 'Failed to get cache statistics',
+      });
     }
   });
 
@@ -252,7 +304,11 @@ export function createFormatRouter(adapter: FormatAdapter) {
     try {
       const analytics = await adapter.getComponentCacheAnalytics?.();
       if (!analytics) {
-        return c.json({ success: true, data: null, meta: { timestamp: new Date().toISOString() } });
+        return c.json({
+          success: true,
+          data: null,
+          meta: { timestamp: new Date().toISOString() },
+        });
       }
       return c.json({
         success: true,
@@ -261,7 +317,9 @@ export function createFormatRouter(adapter: FormatAdapter) {
       });
     } catch (error) {
       logger.error('Failed to get cache analytics', { error });
-      throw new HTTPException(500, { message: 'Failed to get cache analytics' });
+      throw new HTTPException(500, {
+        message: 'Failed to get cache analytics',
+      });
     }
   });
 
@@ -270,7 +328,9 @@ export function createFormatRouter(adapter: FormatAdapter) {
     try {
       const cacheService = getContainer().get('cacheService');
       cacheService.clear();
-      const { invalidateAllCaches } = await import('../../services/cache-events.js');
+      const { invalidateAllCaches } = await import(
+        '../../services/cache-events.js'
+      );
       invalidateAllCaches();
       return c.json({
         success: true,

--- a/packages/shared-docx/src/__tests__/allowed-children.test.ts
+++ b/packages/shared-docx/src/__tests__/allowed-children.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+import {
+  STANDARD_COMPONENTS_REGISTRY,
+  getContainerComponents,
+} from '../schemas/component-registry';
+import { ComponentDefinitionSchema } from '../schemas/components';
+
+describe('allowedChildren coverage', () => {
+  const containers = getContainerComponents();
+  const allAllowed = containers.flatMap((c) => c.allowedChildren ?? []);
+  // header/footer are special — they go in section props, not children
+  const excludeFromCoverage = new Set(['docx', 'header', 'footer']);
+  const nonRootComponents = STANDARD_COMPONENTS_REGISTRY.filter(
+    (c) => !excludeFromCoverage.has(c.name)
+  );
+
+  it('every non-root standard component appears in at least one allowedChildren', () => {
+    for (const comp of nonRootComponents) {
+      expect(
+        allAllowed,
+        `${comp.name} not in any container's allowedChildren`
+      ).toContain(comp.name);
+    }
+  });
+
+  it('every allowedChildren entry references an existing component', () => {
+    const allNames = STANDARD_COMPONENTS_REGISTRY.map((c) => c.name);
+    for (const container of containers) {
+      for (const child of container.allowedChildren ?? []) {
+        expect(
+          allNames,
+          `${container.name}.allowedChildren references unknown "${child}"`
+        ).toContain(child);
+      }
+    }
+  });
+
+  it('every container with hasChildren has allowedChildren defined', () => {
+    for (const c of containers) {
+      expect(
+        c.allowedChildren,
+        `${c.name} has hasChildren=true but no allowedChildren`
+      ).toBeDefined();
+    }
+  });
+});
+
+describe('narrowed children validation', () => {
+  it('rejects a slide-like component as child of docx (only section allowed)', () => {
+    const doc = {
+      name: 'docx',
+      props: {},
+      children: [{ name: 'heading', props: { text: 'Bad', level: 1 } }],
+    };
+    const valid = Value.Check(ComponentDefinitionSchema, doc);
+    expect(valid).toBe(false);
+  });
+
+  it('accepts section as child of docx', () => {
+    const doc = {
+      name: 'docx',
+      props: {},
+      children: [{ name: 'section', props: {} }],
+    };
+    const valid = Value.Check(ComponentDefinitionSchema, doc);
+    expect(valid).toBe(true);
+  });
+
+  it('accepts content components as children of section', () => {
+    const section = {
+      name: 'section',
+      props: {},
+      children: [
+        { name: 'heading', props: { text: 'Hello', level: 1 } },
+        { name: 'paragraph', props: { text: 'World' } },
+      ],
+    };
+    const valid = Value.Check(ComponentDefinitionSchema, section);
+    expect(valid).toBe(true);
+  });
+
+  it('rejects docx nested inside section', () => {
+    const section = {
+      name: 'section',
+      props: {},
+      children: [{ name: 'docx', props: {} }],
+    };
+    const valid = Value.Check(ComponentDefinitionSchema, section);
+    expect(valid).toBe(false);
+  });
+
+  it('rejects toc inside text-box (only heading/paragraph/image allowed)', () => {
+    const textBox = {
+      name: 'text-box',
+      props: {},
+      children: [{ name: 'toc', props: {} }],
+    };
+    const valid = Value.Check(ComponentDefinitionSchema, textBox);
+    expect(valid).toBe(false);
+  });
+
+  it('accepts paragraph inside text-box', () => {
+    const textBox = {
+      name: 'text-box',
+      props: {},
+      children: [{ name: 'paragraph', props: { text: 'Hello' } }],
+    };
+    const valid = Value.Check(ComponentDefinitionSchema, textBox);
+    expect(valid).toBe(true);
+  });
+});

--- a/packages/shared-docx/src/schemas/component-registry.ts
+++ b/packages/shared-docx/src/schemas/component-registry.ts
@@ -17,14 +17,17 @@ import { Type, TSchema } from '@sinclair/typebox';
 // Import directly from individual component files to avoid circular dependency
 // (components.ts imports from this file, so we can't import from components.ts)
 import { ReportPropsSchema } from './components/report';
-import { SectionPropsSchema } from './components/section';
+import {
+  SectionPropsSchema,
+  createSectionPropsSchema,
+} from './components/section';
 import { ColumnsPropsSchema } from './components/columns';
 import { HeadingPropsSchema } from './components/heading';
 import { ParagraphPropsSchema } from './components/paragraph';
 import { TextBoxPropsSchema } from './components/text-box';
 import { ImagePropsSchema } from './components/image';
 import { StatisticPropsSchema } from './components/statistic';
-import { TablePropsSchema } from './components/table';
+import { TablePropsSchema, createTablePropsSchema } from './components/table';
 import { HeaderPropsSchema } from './components/header';
 import { FooterPropsSchema } from './components/footer';
 import { ListPropsSchema } from './components/list';
@@ -41,6 +44,19 @@ export interface StandardComponentDefinition {
   propsSchema: TSchema;
   /** Whether this component can contain children */
   hasChildren: boolean;
+  /**
+   * Names of standard components allowed as direct children.
+   * Only meaningful when hasChildren is true.
+   * Plugin components are always allowed in addition to these.
+   * Omit to allow the full recursive union (backward-compat).
+   */
+  allowedChildren?: readonly string[];
+  /**
+   * Factory that builds props with a live recursive ref (e.g., for section
+   * header/footer, table cell content). When present and a recursive ref is
+   * available, used instead of the static `propsSchema`.
+   */
+  createPropsSchema?: (recursiveRef: TSchema) => TSchema;
   /** Component category for organization */
   category: 'container' | 'content' | 'layout';
   /** Human-readable description */
@@ -63,130 +79,158 @@ export interface StandardComponentDefinition {
  * 2. Import its props schema at the top of this file
  * 3. That's it! The component will automatically appear everywhere.
  */
-export const STANDARD_COMPONENTS_REGISTRY: readonly StandardComponentDefinition[] = [
-  // ========================================================================
-  // Container Components (can contain children)
-  // ========================================================================
-  {
-    name: 'docx',
-    propsSchema: ReportPropsSchema,
-    hasChildren: true,
-    category: 'container',
-    description:
-      'Main document container - defines the overall document structure. Required as the root component.',
-    special: {
-      hasSchemaField: true, // Only docx root has $schema field
+export const STANDARD_COMPONENTS_REGISTRY: readonly StandardComponentDefinition[] =
+  [
+    // ========================================================================
+    // Container Components (can contain children)
+    // ========================================================================
+    {
+      name: 'docx',
+      propsSchema: ReportPropsSchema,
+      hasChildren: true,
+      allowedChildren: ['section'],
+      category: 'container',
+      description:
+        'Main document container - defines the overall document structure. Required as the root component.',
+      special: {
+        hasSchemaField: true, // Only docx root has $schema field
+      },
     },
-  },
-  {
-    name: 'section',
-    propsSchema: SectionPropsSchema,
-    hasChildren: true,
-    category: 'container',
-    description:
-      'Section container - groups related content with optional title. Use for organizing document structure.',
-  },
-  {
-    name: 'columns',
-    propsSchema: ColumnsPropsSchema,
-    hasChildren: true,
-    category: 'layout',
-    description:
-      'Multi-column layout - arranges content in 2-4 columns. Great for side-by-side content.',
-  },
-  {
-    name: 'text-box',
-    propsSchema: TextBoxPropsSchema,
-    hasChildren: true,
-    category: 'layout',
-    description:
-      'Floating text container - allows positioning text anywhere on the page with absolute or relative positioning.',
-  },
+    {
+      name: 'section',
+      propsSchema: SectionPropsSchema,
+      createPropsSchema: createSectionPropsSchema,
+      hasChildren: true,
+      allowedChildren: [
+        'heading',
+        'paragraph',
+        'image',
+        'statistic',
+        'table',
+        'list',
+        'toc',
+        'highcharts',
+        'columns',
+        'text-box',
+      ],
+      category: 'container',
+      description:
+        'Section container - groups related content with optional title. Use for organizing document structure.',
+    },
+    {
+      name: 'columns',
+      propsSchema: ColumnsPropsSchema,
+      hasChildren: true,
+      allowedChildren: [
+        'heading',
+        'paragraph',
+        'image',
+        'statistic',
+        'table',
+        'list',
+        'toc',
+        'highcharts',
+        'text-box',
+      ],
+      category: 'layout',
+      description:
+        'Multi-column layout - arranges content in 2-4 columns. Great for side-by-side content.',
+    },
+    {
+      name: 'text-box',
+      propsSchema: TextBoxPropsSchema,
+      hasChildren: true,
+      allowedChildren: ['heading', 'paragraph', 'image'],
+      category: 'layout',
+      description:
+        'Floating text container - allows positioning text anywhere on the page with absolute or relative positioning.',
+    },
 
-  // ========================================================================
-  // Content Components (leaf nodes, no children)
-  // ========================================================================
-  {
-    name: 'heading',
-    propsSchema: HeadingPropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Heading text - supports levels 1-6 for document hierarchy. Level 1 is largest.',
-  },
-  {
-    name: 'paragraph',
-    propsSchema: ParagraphPropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Paragraph text - supports formatting like bold, italic, and color. Main content element.',
-  },
-  {
-    name: 'image',
-    propsSchema: ImagePropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Image element - displays images with optional caption. Supports various formats.',
-  },
-  {
-    name: 'statistic',
-    propsSchema: StatisticPropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Statistic display - shows a number with description. Perfect for KPIs and metrics.',
-  },
-  {
-    name: 'table',
-    propsSchema: TablePropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Data table - displays tabular data with headers. Supports formatting and alignment.',
-  },
-  {
-    name: 'header',
-    propsSchema: HeaderPropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Page header - appears at the top of pages. Can include text and page numbers.',
-  },
-  {
-    name: 'footer',
-    propsSchema: FooterPropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Page footer - appears at the bottom of pages. Can include text and page numbers.',
-  },
-  {
-    name: 'list',
-    propsSchema: ListPropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'List element - bulleted or numbered list items. Supports nested lists.',
-  },
-  {
-    name: 'toc',
-    propsSchema: TocPropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Table of contents - automatically generates TOC from document headings. Supports depth ranges and custom styles.',
-  },
-  {
-    name: 'highcharts',
-    propsSchema: HighchartsPropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Chart component powered by Highcharts - render line, bar, pie, heatmap, and more with rich options.',
-  },
-] as const;
+    // ========================================================================
+    // Content Components (leaf nodes, no children)
+    // ========================================================================
+    {
+      name: 'heading',
+      propsSchema: HeadingPropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Heading text - supports levels 1-6 for document hierarchy. Level 1 is largest.',
+    },
+    {
+      name: 'paragraph',
+      propsSchema: ParagraphPropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Paragraph text - supports formatting like bold, italic, and color. Main content element.',
+    },
+    {
+      name: 'image',
+      propsSchema: ImagePropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Image element - displays images with optional caption. Supports various formats.',
+    },
+    {
+      name: 'statistic',
+      propsSchema: StatisticPropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Statistic display - shows a number with description. Perfect for KPIs and metrics.',
+    },
+    {
+      name: 'table',
+      propsSchema: TablePropsSchema,
+      createPropsSchema: createTablePropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Data table - displays tabular data with headers. Supports formatting and alignment.',
+    },
+    {
+      name: 'header',
+      propsSchema: HeaderPropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Page header - appears at the top of pages. Can include text and page numbers.',
+    },
+    {
+      name: 'footer',
+      propsSchema: FooterPropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Page footer - appears at the bottom of pages. Can include text and page numbers.',
+    },
+    {
+      name: 'list',
+      propsSchema: ListPropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'List element - bulleted or numbered list items. Supports nested lists.',
+    },
+    {
+      name: 'toc',
+      propsSchema: TocPropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Table of contents - automatically generates TOC from document headings. Supports depth ranges and custom styles.',
+    },
+    {
+      name: 'highcharts',
+      propsSchema: HighchartsPropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Chart component powered by Highcharts - render line, bar, pie, heatmap, and more with rich options.',
+    },
+  ] as const;
 
 // ============================================================================
 // Helper Functions
@@ -243,15 +287,17 @@ export function isStandardComponent(name: string): boolean {
 // ============================================================================
 
 /**
- * Generate TypeBox schema object for a component
+ * Generate TypeBox schema object for a component.
  *
  * @param component - Component definition from the registry
- * @param recursiveRef - Optional recursive reference for children (use Type.Recursive's 'This')
+ * @param childrenType - Schema for children items. For containers this should be
+ *   a narrowed union of allowed children; for leaves omit it.
  * @returns TypeBox schema object for the component
  */
 export function createComponentSchemaObject(
   component: StandardComponentDefinition,
-  recursiveRef?: TSchema
+  childrenType?: TSchema,
+  selfRef?: TSchema
 ): TSchema {
   const schema: Record<string, TSchema> = {
     name: Type.Literal(component.name),
@@ -270,19 +316,24 @@ export function createComponentSchemaObject(
     schema.$schema = Type.Optional(Type.String({ format: 'uri' }));
   }
 
-  // Add props schema
-  schema.props = component.propsSchema;
+  // selfRef (full union) is intentionally passed to createPropsSchema so that
+  // header/footer sub-schemas and table cell content can reference any component.
+  schema.props =
+    component.createPropsSchema && selfRef
+      ? component.createPropsSchema(selfRef)
+      : component.propsSchema;
 
   // Add children support if applicable
-  if (component.hasChildren && recursiveRef) {
-    schema.children = Type.Optional(Type.Array(recursiveRef));
+  if (component.hasChildren && childrenType) {
+    schema.children = Type.Optional(Type.Array(childrenType));
   }
 
   return Type.Object(schema, { additionalProperties: false });
 }
 
 /**
- * Generate an array of TypeBox schemas for all standard components
+ * Generate an array of TypeBox schemas for all standard components.
+ * Uses a flat recursive ref for all containers (legacy behavior).
  *
  * @param recursiveRef - Optional recursive reference for children
  * @returns Array of TypeBox schemas for all components in the registry
@@ -293,4 +344,87 @@ export function createAllComponentSchemas(
   return STANDARD_COMPONENTS_REGISTRY.map((component) =>
     createComponentSchemaObject(component, recursiveRef)
   );
+}
+
+/**
+ * Build all standard component schemas with per-container narrowed children.
+ *
+ * Resolves containers in dependency order so each container's children union
+ * only references its allowedChildren. Plugin schemas are always included in
+ * every container's children.
+ *
+ * @param selfRef - The Type.Recursive self-reference (used as fallback and for plugin children)
+ * @param pluginSchemas - Plugin component schemas (always allowed in all containers)
+ * @returns schemas array and a byName map for direct lookups
+ */
+export function createAllComponentSchemasNarrowed(
+  selfRef: TSchema,
+  pluginSchemas: TSchema[] = []
+): { schemas: TSchema[]; byName: Map<string, TSchema> } {
+  // Phase 1: Build leaf (non-container) component schemas — no children
+  // selfRef is passed so factories (e.g. table) can wire up recursive refs.
+  const leafSchemas = new Map<string, TSchema>();
+  for (const comp of STANDARD_COMPONENTS_REGISTRY) {
+    if (!comp.hasChildren) {
+      leafSchemas.set(
+        comp.name,
+        createComponentSchemaObject(comp, undefined, selfRef)
+      );
+    }
+  }
+
+  // Phase 2: Resolve containers in dependency order
+  const containers = STANDARD_COMPONENTS_REGISTRY.filter((c) => c.hasChildren);
+  const resolved = new Map<string, TSchema>();
+  const pending = [...containers];
+
+  while (pending.length > 0) {
+    const before = pending.length;
+    for (let i = pending.length - 1; i >= 0; i--) {
+      const comp = pending[i];
+
+      if (!comp.allowedChildren) {
+        // No allowedChildren declared — fallback to full recursive ref
+        resolved.set(
+          comp.name,
+          createComponentSchemaObject(comp, selfRef, selfRef)
+        );
+        pending.splice(i, 1);
+        continue;
+      }
+
+      // Check if all container dependencies are resolved
+      const containerDeps = comp.allowedChildren.filter((name) =>
+        containers.some((c) => c.name === name)
+      );
+      if (!containerDeps.every((d) => resolved.has(d))) continue;
+
+      // Build narrowed children union
+      const childSchemas = comp.allowedChildren
+        .map((name) => resolved.get(name) ?? leafSchemas.get(name))
+        .filter((s): s is TSchema => s !== undefined);
+
+      const allChildSchemas = [...childSchemas, ...pluginSchemas];
+      const childrenType =
+        allChildSchemas.length === 1
+          ? allChildSchemas[0]
+          : Type.Union(allChildSchemas);
+
+      resolved.set(
+        comp.name,
+        createComponentSchemaObject(comp, childrenType, selfRef)
+      );
+      pending.splice(i, 1);
+    }
+
+    if (pending.length === before) {
+      throw new Error(
+        `Circular allowedChildren among: ${pending.map((c) => c.name).join(', ')}`
+      );
+    }
+  }
+
+  // Combine: containers (resolved) + leaves
+  const byName = new Map([...resolved, ...leafSchemas]);
+  return { schemas: [...byName.values()], byName };
 }

--- a/packages/shared-docx/src/schemas/components.ts
+++ b/packages/shared-docx/src/schemas/components.ts
@@ -9,7 +9,10 @@
  */
 
 import { Type, Static } from '@sinclair/typebox';
-import { createAllComponentSchemas } from './component-registry';
+import {
+  createAllComponentSchemas,
+  createAllComponentSchemasNarrowed,
+} from './component-registry';
 
 // Re-export all schemas from individual component files
 export * from './components/common';
@@ -40,18 +43,15 @@ export const StandardComponentDefinitionSchema = Type.Union(
   [...createAllComponentSchemas(Type.Any())],
   {
     discriminator: { propertyName: 'name' },
-    description:
-      'Standard component definition with discriminated union',
+    description: 'Standard component definition with discriminated union',
   }
 );
 
 export const ComponentDefinitionSchema = Type.Recursive((This) =>
   Type.Union(
     [
-      // Standard components from registry - SINGLE SOURCE OF TRUTH
-      // Note: Report and section use special factory functions with recursive refs
-      // Convert readonly array to mutable array for Type.Union
-      ...createAllComponentSchemas(This),
+      // Standard components from registry with per-container narrowed children
+      ...createAllComponentSchemasNarrowed(This).schemas,
     ],
     {
       discriminator: { propertyName: 'name' },

--- a/packages/shared-docx/src/schemas/components/table.ts
+++ b/packages/shared-docx/src/schemas/components/table.ts
@@ -2,7 +2,7 @@
  * Table Component Schema
  */
 
-import { Type, Static } from '@sinclair/typebox';
+import { Type, Static, TSchema } from '@sinclair/typebox';
 import { HexColorSchema } from '../font';
 
 // Define Cell type - can be plain text or a component definition
@@ -147,100 +147,103 @@ const CellDefaultsSchema = Type.Object({
   ),
 });
 
-// Header schema - includes all CellDefaults properties plus content
-const HeaderSchema = Type.Object({
-  color: Type.Optional(HexColorSchema),
-  backgroundColor: Type.Optional(HexColorSchema),
-  horizontalAlignment: Type.Optional(HorizontalAlignmentSchema),
-  verticalAlignment: Type.Optional(VerticalAlignmentSchema),
-  font: Type.Optional(FontConfigSchema),
-  borderColor: Type.Optional(BorderColorSchema),
-  borderSize: Type.Optional(BorderSizeSchema),
-  padding: Type.Optional(PaddingSchema),
-  height: Type.Optional(
-    Type.Number({ minimum: 0, description: 'Cell height in points' })
-  ),
-  content: Type.Optional(CellContentSchema),
-});
+/**
+ * Build TablePropsSchema with a given cell-content type.
+ * Called with `CellContentSchema` for the static export below, and with a
+ * live recursive ref at schema-generation time.
+ */
+export function createTablePropsSchema(componentRef: TSchema): TSchema {
+  const cellContent = Type.Union([Type.String(), componentRef]);
 
-// Cell schema - includes all CellDefaults properties plus content
-const CellSchema = Type.Object({
-  color: Type.Optional(HexColorSchema),
-  backgroundColor: Type.Optional(HexColorSchema),
-  horizontalAlignment: Type.Optional(HorizontalAlignmentSchema),
-  verticalAlignment: Type.Optional(VerticalAlignmentSchema),
-  font: Type.Optional(FontConfigSchema),
-  borderColor: Type.Optional(BorderColorSchema),
-  borderSize: Type.Optional(BorderSizeSchema),
-  padding: Type.Optional(PaddingSchema),
-  height: Type.Optional(
-    Type.Number({ minimum: 0, description: 'Cell height in points' })
-  ),
-  content: Type.Optional(CellContentSchema),
-});
-
-// Column schema with new structure
-const ColumnSchema = Type.Object({
-  width: Type.Optional(
-    Type.Union([
-      Type.Number({
-        minimum: 0,
-        description:
-          'Column width in points. When set on some columns, remaining columns will automatically share the leftover table space equally. Leave undefined to distribute space evenly among unspecified columns.',
-      }),
-      Type.String({
-        pattern: '^\\d+(\\.\\d+)?%$',
-        description:
-          'Column width as percentage of available width (e.g., "40%")',
-      }),
-    ])
-  ),
-  cellDefaults: Type.Optional(CellDefaultsSchema),
-  header: Type.Optional(HeaderSchema),
-  cells: Type.Optional(Type.Array(CellSchema)),
-});
-
-export const TablePropsSchema = Type.Object(
-  {
+  const cellFields = {
+    color: Type.Optional(HexColorSchema),
+    backgroundColor: Type.Optional(HexColorSchema),
+    horizontalAlignment: Type.Optional(HorizontalAlignmentSchema),
+    verticalAlignment: Type.Optional(VerticalAlignmentSchema),
+    font: Type.Optional(FontConfigSchema),
     borderColor: Type.Optional(BorderColorSchema),
     borderSize: Type.Optional(BorderSizeSchema),
-    hideBorders: Type.Optional(HideBordersSchema),
-    cellDefaults: Type.Optional(CellDefaultsSchema),
-    headerCellDefaults: Type.Optional(CellDefaultsSchema),
+    padding: Type.Optional(PaddingSchema),
+    height: Type.Optional(
+      Type.Number({ minimum: 0, description: 'Cell height in points' })
+    ),
+  };
+
+  const headerSchema = Type.Object({
+    ...cellFields,
+    content: Type.Optional(cellContent),
+  });
+
+  const cellSchema = Type.Object({
+    ...cellFields,
+    content: Type.Optional(cellContent),
+  });
+
+  const columnSchema = Type.Object({
     width: Type.Optional(
-      Type.Number({
-        minimum: 0,
-        maximum: 100,
-        description: 'Table width in percentage (0-100)',
-      })
+      Type.Union([
+        Type.Number({
+          minimum: 0,
+          description:
+            'Column width in points. When set on some columns, remaining columns will automatically share the leftover table space equally. Leave undefined to distribute space evenly among unspecified columns.',
+        }),
+        Type.String({
+          pattern: '^\\d+(\\.\\d+)?%$',
+          description:
+            'Column width as percentage of available width (e.g., "40%")',
+        }),
+      ])
     ),
-    columns: Type.Array(ColumnSchema, {
-      description: 'Table columns with headers and cells',
-      minItems: 1,
-    }),
-    keepInOnePage: Type.Optional(
-      Type.Boolean({
-        description:
-          'Keep table rows together on the same page by setting keepNext on all paragraphs',
-      })
-    ),
-    keepNext: Type.Optional(
-      Type.Boolean({
-        description:
-          'Set keepNext on the last row to keep it connected to the next element. Works independently of keepInOnePage. Defaults to false.',
-      })
-    ),
-    repeatHeaderOnPageBreak: Type.Optional(
-      Type.Boolean({
-        description:
-          'Repeat the header row on each page when the table spans multiple pages. Defaults to false.',
-        default: true,
-      })
-    ),
-  },
-  {
-    description: 'Table component props with column-based structure',
-  }
-);
+    cellDefaults: Type.Optional(CellDefaultsSchema),
+    header: Type.Optional(headerSchema),
+    cells: Type.Optional(Type.Array(cellSchema)),
+  });
+
+  return Type.Object(
+    {
+      borderColor: Type.Optional(BorderColorSchema),
+      borderSize: Type.Optional(BorderSizeSchema),
+      hideBorders: Type.Optional(HideBordersSchema),
+      cellDefaults: Type.Optional(CellDefaultsSchema),
+      headerCellDefaults: Type.Optional(CellDefaultsSchema),
+      width: Type.Optional(
+        Type.Number({
+          minimum: 0,
+          maximum: 100,
+          description: 'Table width in percentage (0-100)',
+        })
+      ),
+      columns: Type.Array(columnSchema, {
+        description: 'Table columns with headers and cells',
+        minItems: 1,
+      }),
+      keepInOnePage: Type.Optional(
+        Type.Boolean({
+          description:
+            'Keep table rows together on the same page by setting keepNext on all paragraphs',
+        })
+      ),
+      keepNext: Type.Optional(
+        Type.Boolean({
+          description:
+            'Set keepNext on the last row to keep it connected to the next element. Works independently of keepInOnePage. Defaults to false.',
+        })
+      ),
+      repeatHeaderOnPageBreak: Type.Optional(
+        Type.Boolean({
+          description:
+            'Repeat the header row on each page when the table spans multiple pages. Defaults to false.',
+          default: true,
+        })
+      ),
+    },
+    {
+      description: 'Table component props with column-based structure',
+    }
+  );
+}
+
+// Static version for validators, type inference, and theme defaults.
+export const TablePropsSchema = createTablePropsSchema(CellContentSchema);
 
 export type TableProps = Static<typeof TablePropsSchema>;

--- a/packages/shared-docx/src/schemas/export.ts
+++ b/packages/shared-docx/src/schemas/export.ts
@@ -6,6 +6,7 @@
  */
 
 import { TSchema } from '@sinclair/typebox';
+import { getContainerComponents } from './component-registry';
 
 /**
  * Configuration for a component schema
@@ -213,7 +214,8 @@ export function createComponentSchema(
   };
 
   // Add children array for container types
-  if (['docx', 'section', 'columns', 'text-box'].includes(name)) {
+  const containerNames = getContainerComponents().map((c) => c.name);
+  if (containerNames.includes(name)) {
     (componentStructure.properties as Record<string, unknown>).children = {
       type: 'array',
       description: 'Children within this container',

--- a/packages/shared-docx/src/schemas/generator.ts
+++ b/packages/shared-docx/src/schemas/generator.ts
@@ -27,8 +27,7 @@
 
 import { Type, TSchema } from '@sinclair/typebox';
 import {
-  STANDARD_COMPONENTS_REGISTRY,
-  createComponentSchemaObject,
+  createAllComponentSchemasNarrowed,
   getStandardComponent,
 } from './component-registry';
 import { latestVersion } from '@json-to-office/shared';
@@ -94,19 +93,16 @@ export function generateUnifiedDocumentSchema(
     description = 'JSON report definition with TypeBox schemas',
   } = options;
 
+  // Captured from inside the recursive callback for the root's children.
+  let capturedSectionSchema: TSchema | undefined;
+  let capturedPluginSchemas: TSchema[] = [];
+
   // Create a recursive component definition schema
   const ComponentDefinition = Type.Recursive(
     (This) => {
-      const componentSchemas: TSchema[] = [];
+      // ── Phase 1: Build plugin schemas (plugins get Self for arbitrary nesting) ──
+      const pluginSchemas: TSchema[] = [];
 
-      // Add standard components from registry - SINGLE SOURCE OF TRUTH
-      if (includeStandardComponents) {
-        for (const component of STANDARD_COMPONENTS_REGISTRY) {
-          componentSchemas.push(createComponentSchemaObject(component, This));
-        }
-      }
-
-      // Add custom components
       for (const customComponent of customComponents) {
         if (
           customComponent.versionedProps &&
@@ -118,8 +114,6 @@ export function generateUnifiedDocumentSchema(
 
           // Per-version variants: version is required, props are version-specific
           for (const entry of versionEntries) {
-            // Attach description directly to the version literal so Monaco
-            // shows it in the autocomplete dropdown for version values
             const versionLiteralDesc =
               entry.description || customComponent.description;
             const schema: Record<string, TSchema> = {
@@ -127,21 +121,20 @@ export function generateUnifiedDocumentSchema(
               id: Type.Optional(Type.String()),
               version: versionLiteralDesc
                 ? Type.Literal(entry.version, {
-                  description: versionLiteralDesc,
-                })
+                    description: versionLiteralDesc,
+                  })
                 : Type.Literal(entry.version),
               props: entry.propsSchema,
             };
             if (entry.hasChildren) {
               schema.children = Type.Optional(Type.Array(This));
             }
-            // Build description: combine component-level + version-level descriptions
             const versionDesc = entry.description
               ? `${customComponent.name} v${entry.version} — ${entry.description}`
               : customComponent.description
                 ? `${customComponent.name} v${entry.version} — ${customComponent.description}`
                 : `${customComponent.name} v${entry.version}`;
-            componentSchemas.push(
+            pluginSchemas.push(
               Type.Object(schema, {
                 additionalProperties: false,
                 description: versionDesc,
@@ -164,7 +157,7 @@ export function generateUnifiedDocumentSchema(
             : customComponent.description
               ? `${customComponent.name} (latest: v${latest}) — ${customComponent.description}`
               : `${customComponent.name} (latest: v${latest})`;
-          componentSchemas.push(
+          pluginSchemas.push(
             Type.Object(fallbackSchema, {
               additionalProperties: false,
               description: fallbackDesc,
@@ -181,7 +174,7 @@ export function generateUnifiedDocumentSchema(
           if (hasChildren) {
             schema.children = Type.Optional(Type.Array(This));
           }
-          componentSchemas.push(
+          pluginSchemas.push(
             Type.Object(schema, {
               additionalProperties: false,
               ...(customComponent.description
@@ -192,13 +185,24 @@ export function generateUnifiedDocumentSchema(
         }
       }
 
+      // ── Phase 2: Build standard components with narrowed children ──
+      const { schemas: standardSchemas, byName } = includeStandardComponents
+        ? createAllComponentSchemasNarrowed(This, pluginSchemas)
+        : { schemas: [] as TSchema[], byName: new Map<string, TSchema>() };
+
+      // Capture the narrowed section schema + plugins for the root's children.
+      // Must happen inside the callback while standardSchemas is available.
+      capturedSectionSchema = byName.get('section');
+      capturedPluginSchemas = pluginSchemas;
+
+      const componentSchemas = [...standardSchemas, ...pluginSchemas];
+
       // Create the union based on the number of schemas
       if (componentSchemas.length === 0) {
         return Type.Any();
       } else if (componentSchemas.length === 1) {
         return componentSchemas[0];
       } else {
-        // Create union with discriminator for proper JSON Schema generation
         const componentDescription =
           customComponents.length > 0
             ? 'Component definition with discriminated union including custom components'
@@ -213,13 +217,16 @@ export function generateUnifiedDocumentSchema(
     { $id: 'ComponentDefinition' }
   );
 
-  // In the unified structure, a document IS a report component with an optional $schema field
-  // Only support the new unified structure - no legacy support
-
-  // Get report component props from registry
+  // Build root docx schema with narrowed children (section only).
+  // ComponentDefinition is embedded in `definitions` so that $refs inside
+  // section header/footer and table cell content resolve correctly.
   const reportComponent = getStandardComponent('docx');
   if (!reportComponent) {
     throw new Error('Docx root component not found in registry');
+  }
+
+  if (!capturedSectionSchema) {
+    throw new Error('Section schema not found in narrowed standard schemas');
   }
 
   return Type.Object(
@@ -228,12 +235,21 @@ export function generateUnifiedDocumentSchema(
       id: Type.Optional(Type.String()),
       $schema: Type.Optional(Type.String({ format: 'uri' })),
       props: reportComponent.propsSchema,
-      children: Type.Optional(Type.Array(ComponentDefinition)),
+      children: Type.Optional(
+        Type.Array(
+          capturedPluginSchemas.length > 0
+            ? Type.Union([capturedSectionSchema, ...capturedPluginSchemas])
+            : capturedSectionSchema
+        )
+      ),
     },
     {
       additionalProperties: false,
       title,
       description,
-    }
+      // Embed ComponentDefinition so convertToJsonSchema extracts it to
+      // definitions and bare $ref: "ComponentDefinition" values resolve.
+      definitions: { ComponentDefinition },
+    } as Record<string, unknown>
   );
 }

--- a/packages/shared-pptx/src/__tests__/allowed-children.test.ts
+++ b/packages/shared-pptx/src/__tests__/allowed-children.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+import {
+  PPTX_STANDARD_COMPONENTS_REGISTRY,
+  getPptxContainerComponents,
+} from '../schemas/component-registry';
+import { PptxComponentDefinitionSchema } from '../schemas/component-union';
+
+describe('allowedChildren coverage', () => {
+  const containers = getPptxContainerComponents();
+  const allAllowed = containers.flatMap((c) => c.allowedChildren ?? []);
+  const nonRootComponents = PPTX_STANDARD_COMPONENTS_REGISTRY.filter(
+    (c) => c.name !== 'pptx'
+  );
+
+  it('every non-root standard component appears in at least one allowedChildren', () => {
+    for (const comp of nonRootComponents) {
+      expect(
+        allAllowed,
+        `${comp.name} not in any container's allowedChildren`
+      ).toContain(comp.name);
+    }
+  });
+
+  it('every allowedChildren entry references an existing component', () => {
+    const allNames = PPTX_STANDARD_COMPONENTS_REGISTRY.map((c) => c.name);
+    for (const container of containers) {
+      for (const child of container.allowedChildren ?? []) {
+        expect(
+          allNames,
+          `${container.name}.allowedChildren references unknown "${child}"`
+        ).toContain(child);
+      }
+    }
+  });
+
+  it('every container with hasChildren has allowedChildren defined', () => {
+    for (const c of containers) {
+      expect(
+        c.allowedChildren,
+        `${c.name} has hasChildren=true but no allowedChildren`
+      ).toBeDefined();
+    }
+  });
+});
+
+describe('narrowed children validation', () => {
+  it('rejects content component as direct child of pptx (only slide allowed)', () => {
+    const pres = {
+      name: 'pptx',
+      props: {},
+      children: [
+        { name: 'text', props: { text: 'Bad', x: 0, y: 0, w: 1, h: 1 } },
+      ],
+    };
+    const valid = Value.Check(PptxComponentDefinitionSchema, pres);
+    expect(valid).toBe(false);
+  });
+
+  it('accepts slide as child of pptx', () => {
+    const pres = {
+      name: 'pptx',
+      props: {},
+      children: [{ name: 'slide', props: {} }],
+    };
+    const valid = Value.Check(PptxComponentDefinitionSchema, pres);
+    expect(valid).toBe(true);
+  });
+
+  it('accepts content components as children of slide', () => {
+    const slide = {
+      name: 'slide',
+      props: {},
+      children: [
+        { name: 'text', props: { text: 'Hello', x: 0, y: 0, w: 5, h: 1 } },
+        { name: 'image', props: { path: 'test.png', x: 0, y: 0, w: 5, h: 5 } },
+      ],
+    };
+    const valid = Value.Check(PptxComponentDefinitionSchema, slide);
+    expect(valid).toBe(true);
+  });
+
+  it('rejects pptx nested inside slide', () => {
+    const slide = {
+      name: 'slide',
+      props: {},
+      children: [{ name: 'pptx', props: {} }],
+    };
+    const valid = Value.Check(PptxComponentDefinitionSchema, slide);
+    expect(valid).toBe(false);
+  });
+
+  it('rejects slide nested inside slide', () => {
+    const slide = {
+      name: 'slide',
+      props: {},
+      children: [{ name: 'slide', props: {} }],
+    };
+    const valid = Value.Check(PptxComponentDefinitionSchema, slide);
+    expect(valid).toBe(false);
+  });
+});

--- a/packages/shared-pptx/src/schemas/component-registry.ts
+++ b/packages/shared-pptx/src/schemas/component-registry.ts
@@ -14,6 +14,13 @@ export interface PptxStandardComponentDefinition {
   name: string;
   propsSchema: TSchema;
   hasChildren: boolean;
+  /**
+   * Names of standard components allowed as direct children.
+   * Only meaningful when hasChildren is true.
+   * Plugin components are always allowed in addition to these.
+   * Omit to allow the full recursive union (backward-compat).
+   */
+  allowedChildren?: readonly string[];
   hasPlaceholders?: boolean;
   category: 'container' | 'content' | 'layout';
   description: string;
@@ -33,83 +40,93 @@ import { PptxChartPropsSchema } from './components/chart';
 /**
  * SINGLE SOURCE OF TRUTH for all standard PPTX components
  */
-export const PPTX_STANDARD_COMPONENTS_REGISTRY: readonly PptxStandardComponentDefinition[] = [
-  // ========================================================================
-  // Container Components (can contain children)
-  // ========================================================================
-  {
-    name: 'pptx',
-    propsSchema: PresentationPropsSchema,
-    hasChildren: true,
-    category: 'container',
-    description:
-      'Main presentation container - defines the overall presentation structure. Required as the root component.',
-    special: {
-      hasSchemaField: true,
+export const PPTX_STANDARD_COMPONENTS_REGISTRY: readonly PptxStandardComponentDefinition[] =
+  [
+    // ========================================================================
+    // Container Components (can contain children)
+    // ========================================================================
+    {
+      name: 'pptx',
+      propsSchema: PresentationPropsSchema,
+      hasChildren: true,
+      allowedChildren: ['slide'],
+      category: 'container',
+      description:
+        'Main presentation container - defines the overall presentation structure. Required as the root component.',
+      special: {
+        hasSchemaField: true,
+      },
     },
-  },
-  {
-    name: 'slide',
-    propsSchema: SlidePropsSchema,
-    hasChildren: true,
-    hasPlaceholders: true,
-    category: 'container',
-    description:
-      'Slide container - groups content elements on a single slide.',
-  },
+    {
+      name: 'slide',
+      propsSchema: SlidePropsSchema,
+      hasChildren: true,
+      allowedChildren: [
+        'text',
+        'image',
+        'shape',
+        'table',
+        'highcharts',
+        'chart',
+      ],
+      hasPlaceholders: true,
+      category: 'container',
+      description:
+        'Slide container - groups content elements on a single slide.',
+    },
 
-  // ========================================================================
-  // Content Components (leaf nodes, no children)
-  // ========================================================================
-  {
-    name: 'text',
-    propsSchema: TextPropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Text element - displays text with formatting, positioning and styling options.',
-  },
-  {
-    name: 'image',
-    propsSchema: PptxImagePropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Image element - displays images from file path, URL, or base64 data.',
-  },
-  {
-    name: 'shape',
-    propsSchema: ShapePropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Shape element - draws geometric shapes with optional text, fill, and line styling.',
-  },
-  {
-    name: 'table',
-    propsSchema: PptxTablePropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Table element - displays tabular data with rows and columns.',
-  },
-  {
-    name: 'highcharts',
-    propsSchema: PptxHighchartsPropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Highcharts element - renders charts via Highcharts Export Server.',
-  },
-  {
-    name: 'chart',
-    propsSchema: PptxChartPropsSchema,
-    hasChildren: false,
-    category: 'content',
-    description:
-      'Native PowerPoint chart - editable, scalable, no external server needed.',
-  },
-] as const;
+    // ========================================================================
+    // Content Components (leaf nodes, no children)
+    // ========================================================================
+    {
+      name: 'text',
+      propsSchema: TextPropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Text element - displays text with formatting, positioning and styling options.',
+    },
+    {
+      name: 'image',
+      propsSchema: PptxImagePropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Image element - displays images from file path, URL, or base64 data.',
+    },
+    {
+      name: 'shape',
+      propsSchema: ShapePropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Shape element - draws geometric shapes with optional text, fill, and line styling.',
+    },
+    {
+      name: 'table',
+      propsSchema: PptxTablePropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Table element - displays tabular data with rows and columns.',
+    },
+    {
+      name: 'highcharts',
+      propsSchema: PptxHighchartsPropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Highcharts element - renders charts via Highcharts Export Server.',
+    },
+    {
+      name: 'chart',
+      propsSchema: PptxChartPropsSchema,
+      hasChildren: false,
+      category: 'content',
+      description:
+        'Native PowerPoint chart - editable, scalable, no external server needed.',
+    },
+  ] as const;
 
 // ============================================================================
 // Helper Functions
@@ -128,7 +145,9 @@ export function getAllPptxComponentNames(): readonly string[] {
 export function getPptxComponentsByCategory(
   category: PptxStandardComponentDefinition['category']
 ): readonly PptxStandardComponentDefinition[] {
-  return PPTX_STANDARD_COMPONENTS_REGISTRY.filter((c) => c.category === category);
+  return PPTX_STANDARD_COMPONENTS_REGISTRY.filter(
+    (c) => c.category === category
+  );
 }
 
 export function getPptxContainerComponents(): readonly PptxStandardComponentDefinition[] {
@@ -149,7 +168,8 @@ export function isPptxStandardComponent(name: string): boolean {
 
 export function createPptxComponentSchemaObject(
   component: PptxStandardComponentDefinition,
-  recursiveRef?: TSchema
+  recursiveRef?: TSchema,
+  placeholderRef?: TSchema
 ): TSchema {
   const schema: Record<string, TSchema> = {
     name: Type.Literal(component.name),
@@ -173,20 +193,23 @@ export function createPptxComponentSchemaObject(
     schema.children = Type.Optional(Type.Array(recursiveRef));
   }
 
-  if (component.hasPlaceholders && recursiveRef) {
+  if (component.hasPlaceholders && (placeholderRef ?? recursiveRef)) {
     const baseProperties = (component.propsSchema as any).properties ?? {};
+    const phRef = placeholderRef ?? recursiveRef!;
     schema.props = Type.Object(
       {
         ...baseProperties,
         placeholders: Type.Optional(
-          Type.Record(
-            Type.String(),
-            recursiveRef,
-            { description: 'Content for named placeholders: { "title": { "name": "text", ... } }' }
-          )
+          Type.Record(Type.String(), phRef, {
+            description:
+              'Content for named placeholders: { "title": { "name": "text", ... } }',
+          })
         ),
       },
-      { additionalProperties: false, description: (component.propsSchema as any).description }
+      {
+        additionalProperties: false,
+        description: (component.propsSchema as any).description,
+      }
     );
   }
 
@@ -199,4 +222,87 @@ export function createAllPptxComponentSchemas(
   return PPTX_STANDARD_COMPONENTS_REGISTRY.map((component) =>
     createPptxComponentSchemaObject(component, recursiveRef)
   );
+}
+
+/**
+ * Build all standard PPTX component schemas with per-container narrowed children.
+ *
+ * Resolves containers in dependency order so each container's children union
+ * only references its allowedChildren. Plugin schemas are always included in
+ * every container's children.
+ *
+ * @param selfRef - The Type.Recursive self-reference (fallback and for plugin children)
+ * @param pluginSchemas - Plugin component schemas (always allowed in all containers)
+ * @returns Array of TypeBox schemas with narrowed children per container
+ */
+export function createAllPptxComponentSchemasNarrowed(
+  selfRef: TSchema,
+  pluginSchemas: TSchema[] = []
+): TSchema[] {
+  // Phase 1: Build leaf (non-container) component schemas — no children
+  const leafSchemas = new Map<string, TSchema>();
+  for (const comp of PPTX_STANDARD_COMPONENTS_REGISTRY) {
+    if (!comp.hasChildren) {
+      leafSchemas.set(
+        comp.name,
+        createPptxComponentSchemaObject(comp, undefined, selfRef)
+      );
+    }
+  }
+
+  // Phase 2: Resolve containers in dependency order
+  const containers = PPTX_STANDARD_COMPONENTS_REGISTRY.filter(
+    (c) => c.hasChildren
+  );
+  const resolved = new Map<string, TSchema>();
+  const pending = [...containers];
+
+  while (pending.length > 0) {
+    const before = pending.length;
+    for (let i = pending.length - 1; i >= 0; i--) {
+      const comp = pending[i];
+
+      if (!comp.allowedChildren) {
+        // No allowedChildren declared — fallback to full recursive ref
+        resolved.set(
+          comp.name,
+          createPptxComponentSchemaObject(comp, selfRef, selfRef)
+        );
+        pending.splice(i, 1);
+        continue;
+      }
+
+      // Check if all container dependencies are resolved
+      const containerDeps = comp.allowedChildren.filter((name) =>
+        containers.some((c) => c.name === name)
+      );
+      if (!containerDeps.every((d) => resolved.has(d))) continue;
+
+      // Build narrowed children union
+      const childSchemas = comp.allowedChildren
+        .map((name) => resolved.get(name) ?? leafSchemas.get(name))
+        .filter((s): s is TSchema => s !== undefined);
+
+      const allChildSchemas = [...childSchemas, ...pluginSchemas];
+      const childrenType =
+        allChildSchemas.length === 1
+          ? allChildSchemas[0]
+          : Type.Union(allChildSchemas);
+
+      resolved.set(
+        comp.name,
+        createPptxComponentSchemaObject(comp, childrenType, selfRef)
+      );
+      pending.splice(i, 1);
+    }
+
+    if (pending.length === before) {
+      throw new Error(
+        `Circular allowedChildren among: ${pending.map((c) => c.name).join(', ')}`
+      );
+    }
+  }
+
+  // Combine: containers (resolved) + leaves
+  return [...resolved.values(), ...leafSchemas.values()];
 }

--- a/packages/shared-pptx/src/schemas/component-union.ts
+++ b/packages/shared-pptx/src/schemas/component-union.ts
@@ -7,7 +7,10 @@
  */
 
 import { Type, Static } from '@sinclair/typebox';
-import { createAllPptxComponentSchemas } from './component-registry';
+import {
+  createAllPptxComponentSchemas,
+  createAllPptxComponentSchemasNarrowed,
+} from './component-registry';
 
 export const PptxStandardComponentDefinitionSchema = Type.Union(
   [...createAllPptxComponentSchemas(Type.Any())],
@@ -18,13 +21,12 @@ export const PptxStandardComponentDefinitionSchema = Type.Union(
 );
 
 export const PptxComponentDefinitionSchema = Type.Recursive((This) =>
-  Type.Union(
-    [...createAllPptxComponentSchemas(This)],
-    {
-      discriminator: { propertyName: 'name' },
-      description: 'PPTX component definition with discriminated union',
-    }
-  )
+  Type.Union([...createAllPptxComponentSchemasNarrowed(This)], {
+    discriminator: { propertyName: 'name' },
+    description: 'PPTX component definition with discriminated union',
+  })
 );
 
-export type PptxComponentDefinition = Static<typeof PptxComponentDefinitionSchema>;
+export type PptxComponentDefinition = Static<
+  typeof PptxComponentDefinitionSchema
+>;

--- a/packages/shared-pptx/src/schemas/generator.ts
+++ b/packages/shared-pptx/src/schemas/generator.ts
@@ -6,8 +6,8 @@
  */
 import { Type, TSchema } from '@sinclair/typebox';
 import {
-  PPTX_STANDARD_COMPONENTS_REGISTRY,
   createPptxComponentSchemaObject,
+  createAllPptxComponentSchemasNarrowed,
   type PptxStandardComponentDefinition,
 } from './component-registry';
 
@@ -38,13 +38,9 @@ export function generateUnifiedDocumentSchema(
   const { customComponents = [] } = options;
 
   return Type.Recursive((Self) => {
-    const componentSchemas: TSchema[] = [];
+    // ── Phase 1: Build plugin schemas (plugins get Self for arbitrary nesting) ──
+    const pluginSchemas: TSchema[] = [];
 
-    for (const entry of PPTX_STANDARD_COMPONENTS_REGISTRY) {
-      componentSchemas.push(createPptxComponentSchemaObject(entry, Self));
-    }
-
-    // Add custom plugin components
     for (const custom of customComponents) {
       if (custom.versions.length > 0) {
         const latest = custom.versions.reduce((a, b) =>
@@ -57,9 +53,17 @@ export function generateUnifiedDocumentSchema(
           category: 'content',
           description: custom.name,
         };
-        componentSchemas.push(createPptxComponentSchemaObject(customDef, Self));
+        pluginSchemas.push(createPptxComponentSchemaObject(customDef, Self));
       }
     }
+
+    // ── Phase 2: Build standard components with narrowed children ──
+    const standardSchemas = createAllPptxComponentSchemasNarrowed(
+      Self,
+      pluginSchemas
+    );
+
+    const componentSchemas = [...standardSchemas, ...pluginSchemas];
 
     if (componentSchemas.length === 0) {
       return Type.Object({});


### PR DESCRIPTION
## Summary
- Each container declares `allowedChildren`; schema generator builds per-container children unions instead of one flat recursive union. Monaco now flags invalid nesting (e.g. heading inside docx).
- Editor skips auto-builds when JSON is syntactically invalid or has schema validation errors, preventing wasted roundtrips during typing.
- Deduplicates `TablePropsSchema` via `createTablePropsSchema` factory; returns `byName` map from `createAllComponentSchemasNarrowed` to avoid brittle TypeBox internal introspection.

## Test plan
- [ ] Verify Monaco shows errors for invalid nesting (e.g. `heading` as direct child of `docx`)
- [ ] Verify valid documents still build and preview correctly
- [ ] Verify auto-build does not fire while typing invalid JSON
- [ ] Run `allowed-children.test.ts` for both shared-docx and shared-pptx

🤖 Generated with [Claude Code](https://claude.com/claude-code)