### PR TITLE
fix(jto): include prompt files in npm package

### DIFF
--- a/.changeset/fix-prompts-missing.md
+++ b/.changeset/fix-prompts-missing.md
@@ -1,0 +1,5 @@
+---
+'@json-to-office/jto': patch
+---
+
+fix(jto): include prompt .md files in published package via tsup onSuccess copy

--- a/packages/jto/tsup.config.ts
+++ b/packages/jto/tsup.config.ts
@@ -78,5 +78,6 @@ export default defineConfig([
       options.platform = 'node';
       options.target = 'node18';
     },
+    onSuccess: 'cp -r src/server/prompts dist/prompts',
   },
 ]);


### PR DESCRIPTION
## Summary
- `/api/ai/chat` returns 500 because `prompts/system.md` is missing from the installed npm package
- tsup bundles JS only; `files` in package.json ships `dist/` but prompts never get copied there
- Added `onSuccess` hook in tsup config to copy `src/server/prompts/*.md` → `dist/prompts/`
- prompt-loader already resolves `dist/prompts` — no loader changes needed

## Test plan
- [ ] `pnpm build:server` → verify `dist/prompts/system.md` exists
- [ ] `npm pack --dry-run` → verify `dist/prompts/*.md` in file list
- [ ] Start server, hit `/api/ai/chat` → no 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)