### PR TITLE
fix(jto): reinforce { name, props } format in PPTX AI prompts

### DIFF
--- a/.changeset/fix-ai-component-format.md
+++ b/.changeset/fix-ai-component-format.md
@@ -1,0 +1,5 @@
+---
+'@json-to-office/jto': patch
+---
+
+fix(jto): reinforce `{ name, props }` component format in all PPTX AI prompts to prevent non-compliant template output

--- a/packages/jto/src/server/prompts/instructions-edit-document-pptx-slides.md
+++ b/packages/jto/src/server/prompts/instructions-edit-document-pptx-slides.md
@@ -1,14 +1,17 @@
 ## Presentation: {{documentName}}
 
 ### Available Templates (reference only — do not output these)
+
 {{templatesSummary}}
 
 ### Current Slides
+
 ```json
 {{slidesText}}
 ```
 
 You are EDITING the slides of this presentation. Return ONLY the modified slides array:
+
 ```json
 {
   "children": [ ...all slides including unmodified ones... ]
@@ -24,17 +27,35 @@ You are EDITING the slides of this presentation. Return ONLY the modified slides
 - Preserve unmodified slides exactly as they appear above.
 - When editing a slide, keep its `template` reference and only change `placeholders` content.
 - If the presentation uses templates, new slides should also use templates for consistency.
+- **Component format:** every component MUST be `{ "name": "<type>", "props": { ... } }`. Never use `{ "type": "...", ... }` with flat props.
 
 ### Example
 
 **User request:** "Add a slide about pricing"
 
 **Correct output (complete children array with new slide appended):**
+
 ```json
 {
   "children": [
-    { "name": "slide", "props": { "template": "CONTENT_TEMPLATE", "placeholders": { "heading": { "name": "text", "props": { "text": "Overview" } } } } },
-    { "name": "slide", "props": { "template": "CONTENT_TEMPLATE", "placeholders": { "heading": { "name": "text", "props": { "text": "Pricing" } } } } }
+    {
+      "name": "slide",
+      "props": {
+        "template": "CONTENT_TEMPLATE",
+        "placeholders": {
+          "heading": { "name": "text", "props": { "text": "Overview" } }
+        }
+      }
+    },
+    {
+      "name": "slide",
+      "props": {
+        "template": "CONTENT_TEMPLATE",
+        "placeholders": {
+          "heading": { "name": "text", "props": { "text": "Pricing" } }
+        }
+      }
+    }
   ]
 }
 ```

--- a/packages/jto/src/server/prompts/instructions-edit-document-pptx-templates.md
+++ b/packages/jto/src/server/prompts/instructions-edit-document-pptx-templates.md
@@ -1,14 +1,17 @@
 ## Presentation: {{documentName}}
 
 ### Current Templates
+
 ```json
 {{templatesText}}
 ```
 
 ### Slides Using These Templates (reference only — do not output these)
+
 {{slidesSummary}}
 
 You are EDITING the template slides of this presentation. Output **only new or modified** templates:
+
 ```json
 {
   "templates": [ ...only new/changed templates... ]
@@ -27,12 +30,14 @@ Unchanged templates are automatically preserved — do NOT echo them back.
 - When adding a new template, use SCREAMING_SNAKE_CASE naming (e.g. `FULLSCREEN_IMAGE_TEMPLATE`).
 - Each template needs: `name`, `placeholders[]`, and optionally `background`, `objects[]`, `grid`.
 - For page numbers, add a text component with `"text": "{PAGE_NUMBER}"` inside `objects[]` — do NOT use a `slideNumber` key.
+- **Object format:** every item in `objects[]` MUST be `{ "name": "<type>", "props": { ... } }`. Never use `{ "type": "...", ... }` with flat props. Wrong: `{ "type": "image", "src": "logo.svg" }`. Correct: `{ "name": "image", "props": { "src": "logo.svg" } }`. Same applies to `placeholders[].defaults`.
 
 ### Example
 
 **User request:** "Add a divider bar to CONTENT_TEMPLATE"
 
 **Correct output (only the modified template):**
+
 ```json
 {
   "templates": [
@@ -40,7 +45,17 @@ Unchanged templates are automatically preserved — do NOT echo them back.
       "name": "CONTENT_TEMPLATE",
       "placeholders": [{ "name": "heading" }, { "name": "body" }],
       "objects": [
-        { "name": "shape", "props": { "type": "line", "x": "5%", "y": "20%", "w": "90%", "h": "0%", "line": { "color": "accent", "width": 1 } } }
+        {
+          "name": "shape",
+          "props": {
+            "type": "line",
+            "x": "5%",
+            "y": "20%",
+            "w": "90%",
+            "h": "0%",
+            "line": { "color": "accent", "width": 1 }
+          }
+        }
       ]
     }
   ]

--- a/packages/jto/src/server/prompts/instructions-edit-document-pptx.md
+++ b/packages/jto/src/server/prompts/instructions-edit-document-pptx.md
@@ -1,5 +1,7 @@
 ## Current {{contentLabel}} ({{documentName}})
+
 The user already has this {{contentLabelLower}} open in the editor:
+
 ```json
 {{documentText}}
 ```
@@ -12,20 +14,37 @@ IMPORTANT: This {{contentLabelLower}} already exists. You are EDITING it, not ge
 - When adding new slides, **reference existing template names** — do not invent new templates unless the user asks for a new layout.
 - When editing a slide, keep its `template` reference and only change the `placeholders` content.
 - If the presentation uses templates, new slides should also use templates for consistency.
+- **Component format:** every component MUST be `{ "name": "<type>", "props": { ... } }`. Never use `{ "type": "...", ... }` with flat props.
 
 ### Example
 
 **Current presentation (abbreviated):**
+
 ```json
 {
   "name": "pptx",
   "props": {
     "templates": [
-      { "name": "CONTENT_TEMPLATE", "placeholders": [{ "name": "heading", "type": "title" }, { "name": "body", "type": "body" }] }
+      {
+        "name": "CONTENT_TEMPLATE",
+        "placeholders": [
+          { "name": "heading", "type": "title" },
+          { "name": "body", "type": "body" }
+        ]
+      }
     ]
   },
   "children": [
-    { "name": "slide", "props": { "template": "CONTENT_TEMPLATE", "placeholders": { "heading": { "name": "text", "props": { "text": "Overview" } }, "body": { "name": "text", "props": { "text": "Content here." } } } } }
+    {
+      "name": "slide",
+      "props": {
+        "template": "CONTENT_TEMPLATE",
+        "placeholders": {
+          "heading": { "name": "text", "props": { "text": "Overview" } },
+          "body": { "name": "text", "props": { "text": "Content here." } }
+        }
+      }
+    }
   ]
 }
 ```
@@ -33,17 +52,52 @@ IMPORTANT: This {{contentLabelLower}} already exists. You are EDITING it, not ge
 **User request:** "Add a slide about pricing"
 
 **Correct output (full document with new slide appended, using existing template):**
+
 ```json
 {
   "name": "pptx",
   "props": {
     "templates": [
-      { "name": "CONTENT_TEMPLATE", "placeholders": [{ "name": "heading", "type": "title" }, { "name": "body", "type": "body" }] }
+      {
+        "name": "CONTENT_TEMPLATE",
+        "placeholders": [
+          { "name": "heading", "type": "title" },
+          { "name": "body", "type": "body" }
+        ]
+      }
     ]
   },
   "children": [
-    { "name": "slide", "props": { "template": "CONTENT_TEMPLATE", "placeholders": { "heading": { "name": "text", "props": { "text": "Overview" } }, "body": { "name": "text", "props": { "text": "Content here." } } } } },
-    { "name": "slide", "props": { "template": "CONTENT_TEMPLATE", "placeholders": { "heading": { "name": "text", "props": { "text": "Pricing" } }, "body": { "name": "table", "props": { "rows": [["Plan", "Price"], ["Starter", "$9/mo"], ["Pro", "$29/mo"]], "grid": { "column": 0, "row": 2, "columnSpan": 12, "rowSpan": 3 } } } } } }
+    {
+      "name": "slide",
+      "props": {
+        "template": "CONTENT_TEMPLATE",
+        "placeholders": {
+          "heading": { "name": "text", "props": { "text": "Overview" } },
+          "body": { "name": "text", "props": { "text": "Content here." } }
+        }
+      }
+    },
+    {
+      "name": "slide",
+      "props": {
+        "template": "CONTENT_TEMPLATE",
+        "placeholders": {
+          "heading": { "name": "text", "props": { "text": "Pricing" } },
+          "body": {
+            "name": "table",
+            "props": {
+              "rows": [
+                ["Plan", "Price"],
+                ["Starter", "$9/mo"],
+                ["Pro", "$29/mo"]
+              ],
+              "grid": { "column": 0, "row": 2, "columnSpan": 12, "rowSpan": 3 }
+            }
+          }
+        }
+      }
+    }
   ]
 }
 ```

--- a/packages/jto/src/server/prompts/instructions-generate-pptx.md
+++ b/packages/jto/src/server/prompts/instructions-generate-pptx.md
@@ -3,7 +3,8 @@ The user wants you to generate a complete presentation JSON from scratch.
 Produce a full PPTX JSON wrapped in a ```json code block:
 
 - Define 2–3 template slides (TITLE_TEMPLATE, CONTENT_TEMPLATE, and optionally TWO_COLUMN_TEMPLATE)
-- Templates should include header bars, footer bars, and branding text as `objects` (same `{ name, props }` component format as slide children)
+- Templates should include header bars, footer bars, and branding text as `objects`
+- **Every component** (in `objects[]`, `placeholders`, `children[]`) MUST use `{ "name": "<type>", "props": { ... } }`. Never `{ "type": "...", ... }` with flat props
 - The presentation MUST include a `"grid"` prop on `pptx.props` (e.g. `"grid": { "columns": 12, "rows": 6, "margin": 0.5, "gutter": 0.2 }`)
 - Templates with header/footer bars MUST set `"grid": { "margin": { "top": <header-height + 0.2> } }` so row 0 starts below the header
 - Generate 5–8 slides that reference these templates and fill their placeholders
@@ -13,6 +14,7 @@ Produce a full PPTX JSON wrapped in a ```json code block:
 - For refined/elegant designs, use light font variants (e.g. `"Inter Light"`) via `fontFace` instead of relying on bold alone
 
 Before finalizing, verify:
+
 - [ ] No two text/shape components share the same position
 - [ ] Headings fit their container (short text or reduced fontSize)
 - [ ] `slideNumber` is in the bottom-right, not overlapping content


### PR DESCRIPTION
## Summary
- AI chat was generating non-compliant template objects (`{ "type": "image", "src": "..." }` instead of `{ "name": "image", "props": { "src": "..." } }`)
- Added explicit wrong/correct format warnings to all 4 PPTX prompt paths: generate, edit-document, edit-slides, edit-templates

## Test plan
- [ ] Open playground, templates scope, ask AI to add a template with images/shapes
- [ ] Verify generated JSON passes schema validation (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)