### PR TITLE
feat(jto): deploy playground on Render

### DIFF
--- a/.changeset/deploy-playground-render.md
+++ b/.changeset/deploy-playground-render.md
@@ -1,0 +1,5 @@
+---
+'@json-to-office/jto': minor
+---
+
+feat(jto): add AI feature flag (AI_ENABLED / VITE_AI_ENABLED env vars), fix prod static serving, respect NODE_ENV for config mode, add Render blueprint for DOCX + PPTX deployment

--- a/packages/jto/src/client/components/playground/dev-env.tsx
+++ b/packages/jto/src/client/components/playground/dev-env.tsx
@@ -18,6 +18,10 @@ import { Button } from '../ui/button';
 import { cn } from '../../lib/utils';
 import type { DiscoveryResult } from '../../hooks/useDiscovery';
 
+// Compile-time constant: __AI_ENABLED__ is replaced by Vite at build time.
+// The conditional hook calls below are safe because the branch never changes at runtime.
+const noop = () => {};
+
 type MobilePanel = 'editor' | 'preview' | 'chat';
 
 export function DevEnv({
@@ -28,8 +32,9 @@ export function DevEnv({
   const isMobile = useIsMobile();
   const isNarrow = useIsNarrow();
 
-  const chatOpen = useChatStore((s) => s.chatOpen);
-  const toggleChat = useChatStore((s) => s.toggleChat);
+  const chatOpen = __AI_ENABLED__ ? useChatStore((s) => s.chatOpen) : false;
+
+  const toggleChat = __AI_ENABLED__ ? useChatStore((s) => s.toggleChat) : noop;
 
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(() => {
     try {
@@ -110,9 +115,15 @@ export function DevEnv({
   const toggleChatRef = useRef(toggleChat);
   const toggleSidebarRef = useRef(toggleSidebar);
   const togglePreviewRef = useRef(togglePreview);
-  useEffect(() => { toggleChatRef.current = toggleChat; });
-  useEffect(() => { toggleSidebarRef.current = toggleSidebar; });
-  useEffect(() => { togglePreviewRef.current = togglePreview; });
+  useEffect(() => {
+    toggleChatRef.current = toggleChat;
+  });
+  useEffect(() => {
+    toggleSidebarRef.current = toggleSidebar;
+  });
+  useEffect(() => {
+    togglePreviewRef.current = togglePreview;
+  });
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -136,16 +147,33 @@ export function DevEnv({
     return () => window.removeEventListener('keydown', onKey, true);
   }, []);
 
+  const AiWrapper = __AI_ENABLED__
+    ? ChatSessionProvider
+    : ({ children }: { children: React.ReactNode }) => <>{children}</>;
+
+  const mobileTabs: { key: MobilePanel; icon: typeof Code2; label: string }[] =
+    [
+      { key: 'editor', icon: Code2, label: 'Editor' },
+      { key: 'preview', icon: Eye, label: 'Preview' },
+      ...(__AI_ENABLED__
+        ? [{ key: 'chat' as const, icon: MessageSquare, label: 'Chat' }]
+        : []),
+    ];
+
   // Mobile layout: Sheet sidebar + tabbed panels
   if (isMobile) {
     return (
-      <ChatSessionProvider>
+      <AiWrapper>
         <div className="flex flex-col h-full w-full overflow-hidden">
           {/* Mobile header: sidebar trigger + panel tabs */}
           <div className="flex items-center gap-1 px-2 py-1.5 border-b bg-sidebar shrink-0">
             <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
               <SheetTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 shrink-0"
+                >
                   <PanelLeftOpen className="h-4 w-4" />
                 </Button>
               </SheetTrigger>
@@ -159,11 +187,7 @@ export function DevEnv({
             </Sheet>
 
             <div className="flex gap-0.5 flex-1 min-w-0">
-              {([
-                { key: 'editor' as const, icon: Code2, label: 'Editor' },
-                { key: 'preview' as const, icon: Eye, label: 'Preview' },
-                { key: 'chat' as const, icon: MessageSquare, label: 'Chat' },
-              ]).map(({ key, icon: Icon, label }) => (
+              {mobileTabs.map(({ key, icon: Icon, label }) => (
                 <Button
                   key={key}
                   variant={mobilePanel === key ? 'default' : 'ghost'}
@@ -180,7 +204,10 @@ export function DevEnv({
 
           {/* Toolbar — only show when not in chat */}
           {mobilePanel !== 'chat' && (
-            <GlobalPreviewHeader previewOpen={previewOpen} onTogglePreview={togglePreview} />
+            <GlobalPreviewHeader
+              previewOpen={previewOpen}
+              onTogglePreview={togglePreview}
+            />
           )}
 
           {/* Active panel */}
@@ -195,16 +222,16 @@ export function DevEnv({
                 <Preview />
               </div>
             )}
-            {mobilePanel === 'chat' && <ChatPanel />}
+            {__AI_ENABLED__ && mobilePanel === 'chat' && <ChatPanel />}
           </div>
         </div>
-      </ChatSessionProvider>
+      </AiWrapper>
     );
   }
 
   // Desktop layout
   return (
-    <ChatSessionProvider>
+    <AiWrapper>
       <div className="flex h-full w-full overflow-hidden">
         {/* Fixed-width, collapsible sidebar */}
         <div
@@ -229,13 +256,21 @@ export function DevEnv({
         </div>
         {/* Main editor/preview area with resizable split */}
         <div className="flex-1 min-w-0 flex flex-col h-full">
-          <GlobalPreviewHeader previewOpen={previewOpen} onTogglePreview={togglePreview} />
+          <GlobalPreviewHeader
+            previewOpen={previewOpen}
+            onTogglePreview={togglePreview}
+          />
           <ResizablePanelGroup
             direction="horizontal"
             autoSaveId="layout-main"
             className="flex-1 min-h-0"
           >
-            <ResizablePanel defaultSize={previewOpen ? 50 : 100} minSize={20} id="editor" order={1}>
+            <ResizablePanel
+              defaultSize={previewOpen ? 50 : 100}
+              minSize={20}
+              id="editor"
+              order={1}
+            >
               <div className="h-full bg-surface-editor">
                 <Editor />
               </div>
@@ -243,14 +278,19 @@ export function DevEnv({
             {previewOpen && (
               <>
                 <ResizableHandle withHandle />
-                <ResizablePanel defaultSize={50} minSize={20} id="preview" order={2}>
+                <ResizablePanel
+                  defaultSize={50}
+                  minSize={20}
+                  id="preview"
+                  order={2}
+                >
                   <div className="h-full bg-surface-preview">
                     <Preview />
                   </div>
                 </ResizablePanel>
               </>
             )}
-            {chatOpen && (
+            {__AI_ENABLED__ && chatOpen && (
               <>
                 <ResizableHandle withHandle />
                 <ResizablePanel
@@ -267,6 +307,6 @@ export function DevEnv({
           </ResizablePanelGroup>
         </div>
       </div>
-    </ChatSessionProvider>
+    </AiWrapper>
   );
 }

--- a/packages/jto/src/client/components/playground/global-preview-header.tsx
+++ b/packages/jto/src/client/components/playground/global-preview-header.tsx
@@ -6,6 +6,8 @@ import { SchemaDialog } from './schema-dialog';
 import { useDocumentsStore } from '../../store/documents-store-provider';
 import { useChatStore } from '../../store/chat-store-provider';
 
+const noop = () => {};
+
 export function GlobalPreviewHeader({
   previewOpen,
   onTogglePreview,
@@ -35,8 +37,9 @@ export function GlobalPreviewHeader({
       ? 'theme'
       : 'document';
 
-  const chatOpen = useChatStore((s) => s.chatOpen);
-  const toggleChat = useChatStore((s) => s.toggleChat);
+  const chatOpen = __AI_ENABLED__ ? useChatStore((s) => s.chatOpen) : false;
+
+  const toggleChat = __AI_ENABLED__ ? useChatStore((s) => s.toggleChat) : noop;
 
   const [schemaOpen, setSchemaOpen] = React.useState(false);
 
@@ -80,9 +83,11 @@ export function GlobalPreviewHeader({
         documentText={text}
         warnings={warnings}
         renderingLibrary={renderingLibrary}
-        setRenderingLibrary={(lib) => setSettings({ renderingLibrary: lib } as any)}
-        onToggleChat={toggleChat}
-        chatOpen={chatOpen}
+        setRenderingLibrary={(lib) =>
+          setSettings({ renderingLibrary: lib } as any)
+        }
+        onToggleChat={__AI_ENABLED__ ? toggleChat : undefined}
+        chatOpen={__AI_ENABLED__ ? chatOpen : undefined}
         onTogglePreview={onTogglePreview}
         previewOpen={previewOpen}
       />

--- a/packages/jto/src/client/vite-env.d.ts
+++ b/packages/jto/src/client/vite-env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+declare const __AI_ENABLED__: boolean;
+
 interface ImportMetaEnv {
   readonly VITE_API_URL: string;
   readonly VITE_IMAGEKIT_PUBLIC_KEY: string;

--- a/packages/jto/src/client/vite.config.ts
+++ b/packages/jto/src/client/vite.config.ts
@@ -5,6 +5,9 @@ import path from 'path';
 export default defineConfig({
   root: path.resolve(__dirname, '.'),
   plugins: [react()],
+  define: {
+    __AI_ENABLED__: JSON.stringify(process.env.VITE_AI_ENABLED !== 'false'),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '.'),

--- a/packages/jto/src/config/loader.ts
+++ b/packages/jto/src/config/loader.ts
@@ -35,6 +35,10 @@ export async function loadConfig(configPath?: string): Promise<Config> {
 
   const config = deepMerge(defaultConfig, userConfig);
 
+  if (process.env.NODE_ENV === 'production') {
+    config.mode = 'production';
+  }
+
   if (!Value.Check(ConfigSchema, config)) {
     const errors = [...Value.Errors(ConfigSchema, config)];
     console.warn('Warning: Invalid configuration detected:', errors);

--- a/packages/jto/src/server/app.ts
+++ b/packages/jto/src/server/app.ts
@@ -67,14 +67,17 @@ export function createAPIApp(adapter: FormatAdapter) {
   honoApp.route(`/api/${adapter.name}`, formatRouter);
 
   // Also mount at /api/documents or /api/presentations for backward compat
-  const legacyPath = adapter.name === 'docx' ? '/api/documents' : '/api/presentations';
+  const legacyPath =
+    adapter.name === 'docx' ? '/api/documents' : '/api/presentations';
   honoApp.route(legacyPath, formatRouter);
 
   // Discovery routes
   honoApp.route('/api/discovery', discoveryRouter);
 
-  // AI chat routes
-  honoApp.route('/api/ai', createAiRouter());
+  // AI chat routes (disabled via AI_ENABLED=false)
+  if (process.env.AI_ENABLED !== 'false') {
+    honoApp.route('/api/ai', createAiRouter());
+  }
 
   // Root endpoint
   honoApp.get('/', async (c) => {

--- a/packages/jto/src/server/unified-server.ts
+++ b/packages/jto/src/server/unified-server.ts
@@ -104,15 +104,25 @@ export class UnifiedServer {
     // Check env var
     if (process.env.JTO_CLIENT_PATH) {
       const envClientPath = process.env.JTO_CLIENT_PATH;
-      if (existsSync(envClientPath) && existsSync(resolve(envClientPath, 'index.html'))) {
+      if (
+        existsSync(envClientPath) &&
+        existsSync(resolve(envClientPath, 'index.html'))
+      ) {
         clientPath = envClientPath;
-        serverLogger.debug('[Dev Server] Using client from JTO_CLIENT_PATH', { path: clientPath });
+        serverLogger.debug('[Dev Server] Using client from JTO_CLIENT_PATH', {
+          path: clientPath,
+        });
       }
     } else if (isBundled) {
       const bundledClientPath = resolve(__dirname, 'client');
-      if (existsSync(bundledClientPath) && existsSync(resolve(bundledClientPath, 'index.html'))) {
+      if (
+        existsSync(bundledClientPath) &&
+        existsSync(resolve(bundledClientPath, 'index.html'))
+      ) {
         clientPath = bundledClientPath;
-        serverLogger.debug('[Dev Server] Using bundled client at', { path: clientPath });
+        serverLogger.debug('[Dev Server] Using bundled client at', {
+          path: clientPath,
+        });
       }
     } else {
       const possiblePaths = [
@@ -123,7 +133,9 @@ export class UnifiedServer {
       for (const p of possiblePaths) {
         if (existsSync(p)) {
           if (p.replace(/\\/g, '/').includes('/src/client')) {
-            serverLogger.debug('[Dev Server] Using Vite dev server for', { path: p });
+            serverLogger.debug('[Dev Server] Using Vite dev server for', {
+              path: p,
+            });
             try {
               const { createServer: createViteServer } = await import('vite');
               this.viteServer = await createViteServer({
@@ -140,7 +152,9 @@ export class UnifiedServer {
             break;
           } else if (existsSync(resolve(p, 'index.html'))) {
             clientPath = p;
-            serverLogger.debug('[Dev Server] Using pre-built client at', { path: clientPath });
+            serverLogger.debug('[Dev Server] Using pre-built client at', {
+              path: clientPath,
+            });
             break;
           }
         }
@@ -172,7 +186,10 @@ export class UnifiedServer {
       this.app.use('*', async (c, next) => {
         const path = c.req.path;
 
-        if ((path.startsWith('/api') || path === '/health') && !/\.(ts|tsx|js|jsx|css|map)$/.test(path)) {
+        if (
+          (path.startsWith('/api') || path === '/health') &&
+          !/\.(ts|tsx|js|jsx|css|map)$/.test(path)
+        ) {
           return next();
         }
 
@@ -202,10 +219,13 @@ export class UnifiedServer {
     const format = this.adapter.name.replace(/[^a-zA-Z0-9]/g, '');
 
     // Serve static assets
-    this.app.use('/assets/*', serveStatic({
-      root: clientPath,
-      rewriteRequestPath: (path) => path.replace(/^\/assets/, '/assets'),
-    }));
+    this.app.use(
+      '/assets/*',
+      serveStatic({
+        root: clientPath,
+        rewriteRequestPath: (path) => path.replace(/^\/assets/, '/assets'),
+      })
+    );
 
     // Handle file requests
     this.app.use('/*', async (c, next) => {
@@ -229,7 +249,8 @@ export class UnifiedServer {
     // SPA fallback - inject format into HTML
     this.app.get('*', async (c) => {
       const reqPath = c.req.path;
-      if (reqPath.startsWith('/api') || reqPath === '/health') return c.notFound();
+      if (reqPath.startsWith('/api') || reqPath === '/health')
+        return c.notFound();
 
       const indexPath = resolve(clientPath, 'index.html');
       if (fs.existsSync(indexPath)) {
@@ -247,33 +268,8 @@ export class UnifiedServer {
   }
 
   private async setupProdClient() {
-    const { serveStatic } = await import('@hono/node-server/serve-static');
-    const format = this.adapter.name.replace(/[^a-zA-Z0-9]/g, '');
-
-    this.app.use('/*', async (c, next) => {
-      const path = c.req.path;
-      if (path.startsWith('/api') || path === '/health') return next();
-      return serveStatic({ root: './dist/client' })(c, next);
-    });
-
-    this.app.get('*', (c) => {
-      const path = c.req.path;
-      if (path.startsWith('/api') || path === '/health') return c.notFound();
-
-      return c.html(`<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>JSON to Office</title>
-  <script>window.__JTO_FORMAT__ = '${format}';</script>
-  <script>window.location.href = '/';</script>
-</head>
-<body>
-  <noscript>You need to enable JavaScript to run this app.</noscript>
-</body>
-</html>`);
-    });
+    const clientPath = resolve(__dirname, 'client');
+    return this.setupBuiltClient(clientPath);
   }
 
   async start(): Promise<void> {

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,38 @@
+services:
+  - type: web
+    name: jto-playground-docx
+    runtime: node
+    plan: starter
+    buildCommand: pnpm install && pnpm build
+    startCommand: node packages/jto/dist/cli.js docx dev --host 0.0.0.0 --port 10000
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: AI_ENABLED
+        value: "false"
+      - key: VITE_AI_ENABLED
+        value: "false"
+      - key: ENABLE_COREPACK
+        value: "1"
+      - key: NODE_VERSION
+        value: "20"
+    healthCheckPath: /health
+
+  - type: web
+    name: jto-playground-pptx
+    runtime: node
+    plan: starter
+    buildCommand: pnpm install && pnpm build
+    startCommand: node packages/jto/dist/cli.js pptx dev --host 0.0.0.0 --port 10000
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: AI_ENABLED
+        value: "false"
+      - key: VITE_AI_ENABLED
+        value: "false"
+      - key: ENABLE_COREPACK
+        value: "1"
+      - key: NODE_VERSION
+        value: "20"
+    healthCheckPath: /health


### PR DESCRIPTION
## Summary
- Add AI feature flag (`AI_ENABLED` server, `VITE_AI_ENABLED` client) to conditionally disable AI chat
- Fix prod static serving to use `__dirname` instead of relative CWD path
- Respect `NODE_ENV=production` for config mode selection
- Add `render.yaml` blueprint with DOCX + PPTX web services

## Test plan
- [x] `VITE_AI_ENABLED=false pnpm build` succeeds
- [x] Prod server starts, `/health` returns `mode: production`
- [x] `/api/ai/chat` returns 404 when `AI_ENABLED=false`
- [x] SPA serves correctly from `__dirname`-based path
- [ ] Deploy to Render via blueprint

🤖 Generated with [Claude Code](https://claude.com/claude-code)