### PR TITLE
feat: default to LibreOffice renderer, add docxjs fidelity warning

### DIFF
--- a/.changeset/libreoffice-default-renderer.md
+++ b/.changeset/libreoffice-default-renderer.md
@@ -1,0 +1,5 @@
+---
+'@json-to-office/jto': patch
+---
+
+feat: default to LibreOffice renderer in both docx and pptx playgrounds, add fidelity warning for docxjs

--- a/packages/jto/src/client/components/playground/preview-header.tsx
+++ b/packages/jto/src/client/components/playground/preview-header.tsx
@@ -52,12 +52,10 @@ import { FORMAT, FORMAT_EXT } from '../../lib/env';
 import type { RenderingLibrary } from '../../lib/types';
 
 const RENDERING_LIBRARIES: RenderingLibrary[] =
-  FORMAT === 'docx'
-    ? ['docxjs', 'LibreOffice']
-    : ['LibreOffice'];
+  FORMAT === 'docx' ? ['docxjs', 'LibreOffice'] : ['LibreOffice'];
 
 const tooltips: Record<RenderingLibrary, [string, string]> = {
-  docxjs: ['⚡', '(Recommended) works in the browser'],
+  docxjs: ['⚡', '(Fast) works in the browser — lower fidelity'],
   LibreOffice: [
     '🖨️',
     '(High fidelity) converts to PDF locally with LibreOffice',
@@ -105,8 +103,7 @@ function PreviewHeader({
   onTogglePreview?: () => void;
   previewOpen?: boolean;
 }) {
-  const usesManualRenderByDefault =
-    renderingLibrary !== 'docxjs';
+  const usesManualRenderByDefault = renderingLibrary !== 'docxjs';
   const [isDownloading, setIsDownloading] = useState(false);
   const [isDownloadingWarnings, setIsDownloadingWarnings] = useState(false);
   const [isReloading, setIsReloading] = useState(false);
@@ -344,8 +341,11 @@ function PreviewHeader({
             </TooltipTrigger>
             <TooltipContent className="max-w-sm">
               <p className="text-sm">
-                Preview uses {FORMAT === 'docx' ? 'docx-preview' : 'LibreOffice PDF conversion'}. Download the {FORMAT_EXT} to
-                verify fidelity.
+                Preview uses{' '}
+                {FORMAT === 'docx'
+                  ? 'docx-preview'
+                  : 'LibreOffice PDF conversion'}
+                . Download the {FORMAT_EXT} to verify fidelity.
               </p>
             </TooltipContent>
           </Tooltip>
@@ -361,15 +361,27 @@ function PreviewHeader({
                   className="gap-1.5 h-7 px-2.5"
                   onClick={onManualRender}
                   aria-label="Render preview"
-                  disabled={isGenerating || isRendering || previewOpen === false}
+                  disabled={
+                    isGenerating || isRendering || previewOpen === false
+                  }
                 >
-                  {isRendering ? <Spinner size="sm" /> : <PlayIcon className="h-3.5 w-3.5" />}
-                  <span className="text-xs font-medium hidden sm:inline">Run</span>
+                  {isRendering ? (
+                    <Spinner size="sm" />
+                  ) : (
+                    <PlayIcon className="h-3.5 w-3.5" />
+                  )}
+                  <span className="text-xs font-medium hidden sm:inline">
+                    Run
+                  </span>
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
                 <p>
-                  {previewOpen === false ? 'Open preview to run' : isRendering ? 'Rendering preview...' : 'Render preview'}
+                  {previewOpen === false
+                    ? 'Open preview to run'
+                    : isRendering
+                      ? 'Rendering preview...'
+                      : 'Render preview'}
                 </p>
               </TooltipContent>
             </Tooltip>
@@ -407,7 +419,11 @@ function PreviewHeader({
                   onClick={handleReload}
                   disabled={isReloading || isGenerating || isRendering}
                 >
-                  {isReloading ? <Spinner size="sm" /> : <RefreshCwIcon className="h-3.5 w-3.5" />}
+                  {isReloading ? (
+                    <Spinner size="sm" />
+                  ) : (
+                    <RefreshCwIcon className="h-3.5 w-3.5" />
+                  )}
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
@@ -429,8 +445,14 @@ function PreviewHeader({
                 disabled={!blob || isDownloading || isGenerating}
                 onClick={handleDownload}
               >
-                {isDownloading ? <Spinner size="sm" /> : <SaveIcon className="h-3.5 w-3.5" />}
-                <span className="text-xs font-medium hidden sm:inline">Download</span>
+                {isDownloading ? (
+                  <Spinner size="sm" />
+                ) : (
+                  <SaveIcon className="h-3.5 w-3.5" />
+                )}
+                <span className="text-xs font-medium hidden sm:inline">
+                  Download
+                </span>
               </Button>
             </TooltipTrigger>
             <TooltipContent>
@@ -463,7 +485,10 @@ function PreviewHeader({
           )}
 
           {renderingLibrary && setRenderingLibrary && (
-            <Select value={renderingLibrary} onValueChange={setRenderingLibrary}>
+            <Select
+              value={renderingLibrary}
+              onValueChange={setRenderingLibrary}
+            >
               <Tooltip>
                 <TooltipTrigger asChild>
                   <SelectTrigger className="w-[140px] h-7 text-xs hidden lg:flex">
@@ -481,9 +506,7 @@ function PreviewHeader({
                       <TooltipTrigger tabIndex={-1}>
                         {tooltips[library][0]}
                       </TooltipTrigger>
-                      <TooltipContent>
-                        {tooltips[library][1]}
-                      </TooltipContent>
+                      <TooltipContent>{tooltips[library][1]}</TooltipContent>
                     </Tooltip>{' '}
                     {library}
                   </SelectItem>
@@ -527,7 +550,9 @@ function PreviewHeader({
                 disabled={!documentText || isCopyingStandardComponents}
               >
                 <Code2 className="h-4 w-4 mr-2" />
-                {isCopyingStandardComponents ? 'Copying...' : 'Copy standard components'}
+                {isCopyingStandardComponents
+                  ? 'Copying...'
+                  : 'Copy standard components'}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
@@ -548,7 +573,9 @@ function PreviewHeader({
                       className="lg:hidden"
                       onClick={() => setRenderingLibrary(library)}
                     >
-                      <span className="mr-2">{renderingLibrary === library ? '●' : '○'}</span>
+                      <span className="mr-2">
+                        {renderingLibrary === library ? '●' : '○'}
+                      </span>
                       {tooltips[library][0]} {library}
                     </DropdownMenuItem>
                   ))}
@@ -567,11 +594,18 @@ function PreviewHeader({
                   className="h-7 w-7"
                   onClick={onTogglePreview}
                 >
-                  {previewOpen ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+                  {previewOpen ? (
+                    <Eye className="h-3.5 w-3.5" />
+                  ) : (
+                    <EyeOff className="h-3.5 w-3.5" />
+                  )}
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
-                <span className="flex items-center gap-1.5">{previewOpen ? 'Hide' : 'Show'} Preview <KbdShortcut shortcut="mod+shift+p" /></span>
+                <span className="flex items-center gap-1.5">
+                  {previewOpen ? 'Hide' : 'Show'} Preview{' '}
+                  <KbdShortcut shortcut="mod+shift+p" />
+                </span>
               </TooltipContent>
             </Tooltip>
           )}
@@ -590,7 +624,10 @@ function PreviewHeader({
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
-                <span className="flex items-center gap-1.5">{chatOpen ? 'Close' : 'Open'} AI Chat <KbdShortcut shortcut="mod+shift+j" /></span>
+                <span className="flex items-center gap-1.5">
+                  {chatOpen ? 'Close' : 'Open'} AI Chat{' '}
+                  <KbdShortcut shortcut="mod+shift+j" />
+                </span>
               </TooltipContent>
             </Tooltip>
           )}
@@ -603,11 +640,16 @@ function PreviewHeader({
           <DialogHeader>
             <DialogTitle>Clear all caches?</DialogTitle>
             <DialogDescription>
-              This will clear document and component caches. Next generation will be uncached.
+              This will clear document and component caches. Next generation
+              will be uncached.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" size="sm" onClick={() => setShowClearConfirm(false)}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowClearConfirm(false)}
+            >
               Cancel
             </Button>
             <Button

--- a/packages/jto/src/client/components/playground/preview.tsx
+++ b/packages/jto/src/client/components/playground/preview.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState, memo } from 'react';
+import { InfoIcon } from 'lucide-react';
 import { PreviewFrameMemoized } from './preview-frame';
 import { PreviewHeaderMemoized } from './preview-header';
 import { WarningsPanel } from './warnings-panel';
@@ -9,7 +10,7 @@ import { useSettingsStore } from '../../store/settings-store-provider';
 import { renderDocument } from '../../lib/render';
 import { useDocumentsStore } from '../../store/documents-store-provider';
 import { CacheMetrics } from '../cache-metrics';
-import { FORMAT_LABEL } from '../../lib/env';
+import { FORMAT, FORMAT_LABEL } from '../../lib/env';
 
 /**
  * Tiny live countdown that ticks every 100ms and shows the
@@ -224,6 +225,15 @@ export function Preview() {
             />
           )}
         <Separator />
+        {FORMAT === 'docx' && renderingLibrary === 'docxjs' && (
+          <div className="px-3 py-1.5 flex items-center gap-2 border-b bg-blue-500/10 border-blue-500/30 text-xs text-blue-700 dark:text-blue-300">
+            <InfoIcon className="h-3.5 w-3.5 shrink-0" />
+            <span>
+              The docxjs renderer is not 100% representative of the actual
+              .docx. Use LibreOffice for higher fidelity.
+            </span>
+          </div>
+        )}
         {/* Status Bar: cache + stale combined */}
         {(() => {
           const hasUnsyncedEdits =

--- a/packages/jto/src/client/store/settings-store.ts
+++ b/packages/jto/src/client/store/settings-store.ts
@@ -1,7 +1,6 @@
 import { devtools, persist } from 'zustand/middleware';
 import { createStore } from 'zustand/vanilla';
 import type { Settings } from '../lib/types';
-import { FORMAT } from '../lib/env';
 
 export type SettingsState = Settings;
 
@@ -15,7 +14,7 @@ export const initSettingsStore = (): SettingsState => {
   return {
     saveDocumentDebounceWait: 300,
     autoReload: true,
-    renderingLibrary: FORMAT === 'docx' ? 'docxjs' : 'LibreOffice',
+    renderingLibrary: 'LibreOffice',
     // UI preference to use a single preview header spanning editor + preview
     useGlobalPreviewHeader: true,
   };


### PR DESCRIPTION
## Summary
- Default renderer changed from `docxjs` to `LibreOffice` for both docx and pptx playgrounds
- Added blue info banner when `docxjs` is selected warning about lower fidelity
- Updated docxjs tooltip from "(Recommended)" to "(Fast) — lower fidelity"

## Test plan
- [ ] Open DOCX playground → renderer defaults to LibreOffice
- [ ] Switch to docxjs → blue info banner appears
- [ ] Switch back to LibreOffice → banner disappears
- [ ] Open PPTX playground → defaults to LibreOffice, no banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)