### PR TITLE
feat: monaco built-in JSON schema validation for theme editor

### DIFF
--- a/.changeset/theme-monaco-validation.md
+++ b/.changeset/theme-monaco-validation.md
@@ -1,0 +1,8 @@
+---
+'@json-to-office/jto': patch
+'@json-to-office/shared-docx': patch
+---
+
+feat: use Monaco built-in JSON schema validation for theme editor
+
+Replace custom `validateThemeJson` marker-setting with Monaco's native `onValidate`, add ValidationPanel/StatusBar UI, and tighten theme schemas with `additionalProperties: false`.

--- a/packages/jto/src/client/components/json-editor/editor-monaco-theme.tsx
+++ b/packages/jto/src/client/components/json-editor/editor-monaco-theme.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTheme } from '../theme-provider';
 import { constrainedEditor } from 'constrained-editor-plugin';
 import MonacoEditor, { Monaco, DiffEditor } from '@monaco-editor/react';
 import type { editor as MonacoEditorType } from 'monaco-editor';
 import type { TextFile } from '../../lib/types';
-import { validateThemeJson } from '../../lib/theme-validation';
+import { type JsonEditorError } from '../../lib/json-types';
+import { FORMAT } from '../../lib/env';
 import { useDocumentsStore } from '../../store/documents-store-provider';
 import { Button } from '../ui/button';
 import { useEditorRefsStore } from '../../store/editor-refs-store';
@@ -12,6 +13,18 @@ import {
   getSelectionContext,
   createContextSnippet,
 } from '../../lib/monaco-selection-utils';
+import { ValidationPanel, ValidationStatusBar } from './validation-panel';
+
+/** Ensure defaultPath matches the schema fileMatch pattern (*.FORMAT.theme.json) */
+function resolveThemeDefaultPath(name: string): string {
+  const ext = `.${FORMAT}.theme.json`;
+  if (name.endsWith(ext)) return name;
+  const base = name
+    .replace(/\.\w+\.theme\.json$/, '')
+    .replace(/\.theme\.json$/, '')
+    .replace(/\.json$/, '');
+  return base + ext;
+}
 
 /**
  * EditorMonacoTheme component for editing JSON theme files with schema validation
@@ -29,7 +42,13 @@ function EditorMonacoTheme({
   const monacoRef = useRef<Monaco | null>(null);
   const modelRef = useRef<MonacoEditorType.ITextModel | null>(null);
   const { theme } = useTheme();
-  const [isReady, setIsReady] = React.useState(false);
+  const [validationErrors, setValidationErrors] = useState<JsonEditorError[]>(
+    []
+  );
+  const [showValidationPanel, setShowValidationPanel] = useState(true);
+  const [isValidationPanelMinimized, setIsValidationPanelMinimized] =
+    useState(false);
+  const userDismissedRef = useRef(false);
   const pendingDiff = useDocumentsStore((s) => s.pendingDiffs[document.name]);
   const clearPendingDiff = useDocumentsStore((s) => s.clearPendingDiff);
   const saveDocument = useDocumentsStore((s) => s.saveDocument);
@@ -46,15 +65,10 @@ function EditorMonacoTheme({
 
   // Initialize Monaco editor
   const handleEditorWillMount = useCallback((monaco: Monaco) => {
-    console.log('Monaco theme editor will mount');
     monacoRef.current = monaco;
-
-    // Ensure global schemas (report + theme) are configured.
     // Don't call setDiagnosticsOptions here — it would clobber the global
     // config. The theme schema is already registered by configureMonacoInstance
     // and matched via defaultPath → fileMatch.
-
-    setIsReady(true);
   }, []);
 
   // Handle editor mount
@@ -184,39 +198,51 @@ function EditorMonacoTheme({
     [onChange]
   );
 
-  // Validate theme content
-  useEffect(() => {
-    if (
-      !editorRef.current ||
-      !monacoRef.current ||
-      !modelRef.current ||
-      !isReady
-    ) {
-      return;
-    }
-
-    const monaco = monacoRef.current;
-    const model = modelRef.current;
-
-    // Clear existing markers
-    monaco.editor.setModelMarkers(model, 'theme-validation', []);
-
-    // Validate theme JSON
-    const validationResult = validateThemeJson(document.text);
-    if (!validationResult.valid && validationResult.errors) {
-      const markers = validationResult.errors.map((error) => ({
-        severity: monaco.MarkerSeverity.Error,
-        startLineNumber: error.line || 1,
-        startColumn: error.column || 1,
-        endLineNumber: error.line || 1,
-        endColumn: error.column || 1000,
-        message: error.message,
-        source: 'theme-validation',
+  // Handle Monaco's built-in schema validation markers
+  const handleEditorValidation = useCallback(
+    (markers: MonacoEditorType.IMarker[]) => {
+      const errors: JsonEditorError[] = markers.map((marker) => ({
+        path: '',
+        message: marker.message,
+        code:
+          typeof marker.code === 'string'
+            ? marker.code
+            : marker.code?.value || 'validation_error',
+        startLineNumber: marker.startLineNumber,
+        startColumn: marker.startColumn,
+        endLineNumber: marker.endLineNumber,
+        endColumn: marker.endColumn,
+        severity:
+          marker.severity >= 8
+            ? 'error'
+            : marker.severity >= 4
+              ? 'warning'
+              : 'info',
       }));
 
-      monaco.editor.setModelMarkers(model, 'theme-validation', markers);
+      setValidationErrors(errors);
+
+      if (errors.length > 0 && !userDismissedRef.current) {
+        setShowValidationPanel(true);
+        setIsValidationPanelMinimized(false);
+      }
+      if (errors.length === 0) {
+        userDismissedRef.current = false;
+      }
+    },
+    []
+  );
+
+  const handleErrorClick = useCallback((error: JsonEditorError) => {
+    if (editorRef.current && error.startLineNumber && error.startColumn) {
+      editorRef.current.setPosition({
+        lineNumber: error.startLineNumber,
+        column: error.startColumn,
+      });
+      editorRef.current.revealLineInCenter(error.startLineNumber);
+      editorRef.current.focus();
     }
-  }, [document.text, isReady]);
+  }, []);
 
   // Update theme
   useEffect(() => {
@@ -274,12 +300,13 @@ function EditorMonacoTheme({
         <MonacoEditor
           height="100%"
           language="json"
-          defaultPath={document.name}
+          defaultPath={resolveThemeDefaultPath(document.name)}
           value={document.text}
           theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs'}
           onChange={handleChange}
           beforeMount={handleEditorWillMount}
           onMount={handleEditorMount}
+          onValidate={handleEditorValidation}
           options={{
             readOnly,
             lineNumbers: 'on',
@@ -304,6 +331,34 @@ function EditorMonacoTheme({
             scrollBeyondLastLine: true,
             wordWrap: 'on',
           }}
+        />
+      )}
+
+      {/* Validation Status Bar */}
+      <div className="absolute top-0 right-0">
+        <ValidationStatusBar
+          errors={validationErrors}
+          onClick={() => {
+            setShowValidationPanel(true);
+            setIsValidationPanelMinimized(false);
+          }}
+        />
+      </div>
+
+      {/* Validation Panel */}
+      {showValidationPanel && validationErrors.length > 0 && (
+        <ValidationPanel
+          errors={validationErrors}
+          isMinimized={isValidationPanelMinimized}
+          onToggleMinimize={() =>
+            setIsValidationPanelMinimized(!isValidationPanelMinimized)
+          }
+          onErrorClick={handleErrorClick}
+          onClose={() => {
+            setShowValidationPanel(false);
+            userDismissedRef.current = true;
+          }}
+          className="z-40"
         />
       )}
     </div>

--- a/packages/jto/src/client/components/json-editor/validation-panel.tsx
+++ b/packages/jto/src/client/components/json-editor/validation-panel.tsx
@@ -142,9 +142,7 @@ function CopyErrorsButton({ errors }: { errors: JsonEditorError[] }) {
       onClick={handleCopy}
       className={cn(
         'flex items-center gap-1 px-1.5 py-1 rounded transition-all duration-200 cursor-pointer',
-        copied
-          ? 'bg-green-500/15 text-green-500'
-          : 'hover:bg-destructive/20'
+        copied ? 'bg-green-500/15 text-green-500' : 'hover:bg-destructive/20'
       )}
       aria-label="Copy all errors"
     >
@@ -168,16 +166,16 @@ interface ErrorItemProps {
 function ErrorItem({ error, onClick }: ErrorItemProps) {
   const getSeverityIcon = (severity: string) => {
     switch (severity) {
-    case 'error':
-      return (
-        <AlertCircle className="w-4 h-4 text-destructive flex-shrink-0" />
-      );
-    case 'warning':
-      return (
-        <AlertTriangle className="w-4 h-4 text-yellow-500 flex-shrink-0" />
-      );
-    default:
-      return <AlertCircle className="w-4 h-4 text-blue-500 flex-shrink-0" />;
+      case 'error':
+        return (
+          <AlertCircle className="w-4 h-4 text-destructive flex-shrink-0" />
+        );
+      case 'warning':
+        return (
+          <AlertTriangle className="w-4 h-4 text-yellow-500 flex-shrink-0" />
+        );
+      default:
+        return <AlertCircle className="w-4 h-4 text-blue-500 flex-shrink-0" />;
     }
   };
 
@@ -252,4 +250,6 @@ export function ValidationStatusBar({
       </div>
     );
   }
+
+  return null;
 }

--- a/packages/jto/src/client/components/playground/preview-header.tsx
+++ b/packages/jto/src/client/components/playground/preview-header.tsx
@@ -141,7 +141,7 @@ function PreviewHeader({
         return;
       }
 
-      // Generate PPTX from warnings document JSON
+      // Generate document from warnings document JSON
       // Pass empty customThemes to ensure we use built-in themes only
       const result = await generatePresentation(
         'warnings',

--- a/packages/jto/src/client/components/ui/loading-states.tsx
+++ b/packages/jto/src/client/components/ui/loading-states.tsx
@@ -95,7 +95,9 @@ export function DocumentGenerationLoader({
                         ? 'bg-primary animate-pulse'
                         : 'bg-transparent'
                   )}
-                  style={{ width: isCompleted ? '100%' : isActive ? '100%' : '0%' }}
+                  style={{
+                    width: isCompleted ? '100%' : isActive ? '100%' : '0%',
+                  }}
                 />
               </div>
             </div>
@@ -117,23 +119,23 @@ export function PreviewLoading({
 }: PreviewLoadingProps) {
   const getLibraryInfo = (library?: string) => {
     switch (library) {
-    case 'LibreOffice':
-      return {
-        name: 'LibreOffice',
-        description: 'Converting PPTX to PDF locally...',
-      };
-    case 'Office':
-      return {
-        name: 'Microsoft Office',
-        description: 'Uploading file and loading Office viewer...',
-      };
-    case 'Docs':
-      return {
-        name: 'Google Docs',
-        description: 'Uploading file and loading Docs viewer...',
-      };
-    default:
-      return { name: 'Default', description: 'Processing document...' };
+      case 'LibreOffice':
+        return {
+          name: 'LibreOffice',
+          description: 'Converting document to PDF locally...',
+        };
+      case 'Office':
+        return {
+          name: 'Microsoft Office',
+          description: 'Uploading file and loading Office viewer...',
+        };
+      case 'Docs':
+        return {
+          name: 'Google Docs',
+          description: 'Uploading file and loading Docs viewer...',
+        };
+      default:
+        return { name: 'Default', description: 'Processing document...' };
     }
   };
 

--- a/packages/jto/src/client/lib/file-system.ts
+++ b/packages/jto/src/client/lib/file-system.ts
@@ -8,7 +8,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type { TextFile } from './types';
 
-export const TMP_DIR = path.join(os.tmpdir(), 'pptx');
+export const TMP_DIR = path.join(os.tmpdir(), 'jto');
 
 export function loadTextFile(filePath: string): TextFile {
   const fileContent = fs.readFileSync(filePath, 'utf8');

--- a/packages/jto/src/client/lib/json-schema-generator.ts
+++ b/packages/jto/src/client/lib/json-schema-generator.ts
@@ -132,7 +132,7 @@ export function generateThemeConfigSchema(): any {
   const source =
     FORMAT === 'docx' ? DocxThemeConfigSchema : PptxThemeConfigSchema;
   const schema = JSON.parse(JSON.stringify(source));
-  cleanupTypeBoxIds(schema);
+  cleanupTypeBoxIds(schema, false);
 
   const label = FORMAT === 'docx' ? 'DOCX' : 'PPTX';
   return {
@@ -287,9 +287,7 @@ export function generateComponentSchemas(): Record<string, any> {
  * Creates Monaco editor schema configuration for document/presentation definitions
  */
 export function createReportSchemaConfig(
-  filePatterns: string[] = FORMAT === 'docx'
-    ? ['*.docx.json']
-    : ['*.pptx.json']
+  filePatterns: string[] = FORMAT === 'docx' ? ['*.docx.json'] : ['*.pptx.json']
 ): MonacoSchemaConfig {
   return {
     uri: 'https://json-to-office.dev/schema/report/v1.0.0',
@@ -315,10 +313,7 @@ export function createThemeSchemaConfig(
  * Generates a complete schema configuration for Monaco editor
  */
 export function generateMonacoSchemaConfigs(): MonacoSchemaConfig[] {
-  return [
-    createReportSchemaConfig(),
-    createThemeSchemaConfig(),
-  ];
+  return [createReportSchemaConfig(), createThemeSchemaConfig()];
 }
 
 // ---------------------------------------------------------------------------
@@ -364,13 +359,10 @@ function getComponentDescription(type: string): string {
     footer: 'Page footer - content displayed at the bottom of each page.',
     'text-box': 'Text box element - a positioned box with text content.',
     // pptx
-    pptx:
-      'Main presentation container - defines the overall presentation structure.',
-    slide:
-      'Slide container - groups content elements within a single slide.',
+    pptx: 'Main presentation container - defines the overall presentation structure.',
+    slide: 'Slide container - groups content elements within a single slide.',
     text: 'Text element - displays text with formatting and positioning.',
-    shape:
-      'Shape element - geometric shapes with optional text and styling.',
+    shape: 'Shape element - geometric shapes with optional text and styling.',
     // shared
     image: 'Image element - displays images with sizing and positioning.',
     table: 'Table element - displays tabular data with headers and rows.',
@@ -431,7 +423,7 @@ function enhancePropsDescriptions(
   }
 }
 
-function cleanupTypeBoxIds(schema: any): void {
+function cleanupTypeBoxIds(schema: any, hasDefinitions = true): void {
   if (typeof schema !== 'object' || schema === null) return;
 
   if (schema.$id && /^T\d+$/.test(schema.$id)) {
@@ -439,17 +431,22 @@ function cleanupTypeBoxIds(schema: any): void {
   }
 
   if (schema.$ref && /^T\d+$/.test(schema.$ref)) {
-    schema.$ref = '#/definitions/ComponentDefinition';
+    if (hasDefinitions) {
+      schema.$ref = '#/definitions/ComponentDefinition';
+    } else {
+      // Theme schemas have no $ref — this is a safety guard
+      delete schema.$ref;
+    }
   }
 
   if (Array.isArray(schema)) {
-    schema.forEach((item) => cleanupTypeBoxIds(item));
+    schema.forEach((item) => cleanupTypeBoxIds(item, hasDefinitions));
     return;
   }
 
   Object.keys(schema).forEach((key) => {
     if (typeof schema[key] === 'object' && schema[key] !== null) {
-      cleanupTypeBoxIds(schema[key]);
+      cleanupTypeBoxIds(schema[key], hasDefinitions);
     }
   });
 }

--- a/packages/jto/src/client/lib/theme-validation.ts
+++ b/packages/jto/src/client/lib/theme-validation.ts
@@ -11,7 +11,8 @@ export interface ThemeValidationResult {
 }
 
 /**
- * Validates a theme JSON string - checks structure without requiring format-specific schemas
+ * Basic structural validation for theme JSON (used by themes store).
+ * Full schema validation is handled by Monaco's JSON language service.
  */
 export function validateThemeJson(jsonString: string): ThemeValidationResult {
   try {

--- a/packages/jto/src/client/store/output-store.ts
+++ b/packages/jto/src/client/store/output-store.ts
@@ -10,10 +10,10 @@ export interface GenerationWarning {
 
 export type OutputState = {
   name?: string; // last success => document name
-  text?: string; // last success => code used to generate the pptx
-  blob?: Blob; // last success => generated pptx
+  text?: string; // last success => code used to generate the document
+  blob?: Blob; // last success => generated document
   globalError?: string; // last failed => global error message
-  isGenerating?: boolean; // presentation generation in progress
+  isGenerating?: boolean; // document generation in progress
   generationProgress?: {
     stage: 'parsing' | 'building' | 'rendering' | 'finalizing';
     message?: string;

--- a/packages/jto/src/server/utils/file-system.ts
+++ b/packages/jto/src/server/utils/file-system.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { globSync } from 'glob';
-export const TMP_DIR = path.join(os.tmpdir(), 'pptx');
+export const TMP_DIR = path.join(os.tmpdir(), 'jto');
 
 export interface TextFile {
   name: string;

--- a/packages/shared-docx/src/schemas/theme.ts
+++ b/packages/shared-docx/src/schemas/theme.ts
@@ -4,7 +4,11 @@
  */
 
 import { Type, Static } from '@sinclair/typebox';
-import { FontDefinitionSchema, TextFormattingPropertiesSchema, HexColorSchema } from './font';
+import {
+  FontDefinitionSchema,
+  TextFormattingPropertiesSchema,
+  HexColorSchema,
+} from './font';
 import { IndentSchema } from './components/common';
 
 // ============================================================================
@@ -21,7 +25,7 @@ export const DocumentMarginsSchema = Type.Object(
     footer: Type.Number({ minimum: 0 }),
     gutter: Type.Number({ minimum: 0 }),
   },
-  { description: 'Document margin configuration' }
+  { additionalProperties: false, description: 'Document margin configuration' }
 );
 
 // ============================================================================
@@ -33,7 +37,7 @@ export const PageDimensionsSchema = Type.Object(
     width: Type.Number({ minimum: 0 }),
     height: Type.Number({ minimum: 0 }),
   },
-  { description: 'Page dimensions in twips' }
+  { additionalProperties: false, description: 'Page dimensions in twips' }
 );
 
 // ============================================================================
@@ -48,10 +52,13 @@ export const PageSchema = Type.Object(
         Type.Literal('A3'),
         Type.Literal('LETTER'),
         Type.Literal('LEGAL'),
-        Type.Object({
-          width: Type.Number({ minimum: 0 }),
-          height: Type.Number({ minimum: 0 }),
-        }),
+        Type.Object(
+          {
+            width: Type.Number({ minimum: 0 }),
+            height: Type.Number({ minimum: 0 }),
+          },
+          { additionalProperties: false }
+        ),
       ],
       { description: 'Standard page size or custom dimensions' }
     ),
@@ -77,7 +84,10 @@ export const FontsSchema = Type.Object(
     mono: FontDefinitionSchema,
     light: FontDefinitionSchema,
   },
-  { description: 'Font definitions for different text types' }
+  {
+    additionalProperties: false,
+    description: 'Font definitions for different text types',
+  }
 );
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Replace custom `validateThemeJson` marker-setting with Monaco's native `onValidate` callback
- Add ValidationPanel and StatusBar UI for schema validation feedback
- Tighten theme schemas with `additionalProperties: false`

## Changeset
`@json-to-office/jto`: patch
`@json-to-office/shared-docx`: patch

## Test plan
- [ ] Open theme editor, verify JSON validation errors appear inline via Monaco
- [ ] Confirm ValidationPanel shows error list and StatusBar reflects validation state
- [ ] Test with invalid theme JSON — verify `additionalProperties` rejects unknown keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)