### PR TITLE
fix: auto-wrap raw document body & cross-platform scripts

### DIFF
--- a/.changeset/fix-auto-wrap-raw-document.md
+++ b/.changeset/fix-auto-wrap-raw-document.md
@@ -1,0 +1,5 @@
+---
+'@json-to-office/jto': patch
+---
+
+Auto-wrap raw document JSON body and include paths in validation errors; replace shell cp with cross-platform Node.js equivalents

--- a/packages/core-docx/package.json
+++ b/packages/core-docx/package.json
@@ -30,7 +30,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
-    "prepublishOnly": "cp ../../LICENSE ."
+    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
   },
   "dependencies": {
     "@json-to-office/shared": "workspace:^",

--- a/packages/core-pptx/package.json
+++ b/packages/core-pptx/package.json
@@ -30,7 +30,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
-    "prepublishOnly": "cp ../../LICENSE ."
+    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
   },
   "dependencies": {
     "@json-to-office/shared": "workspace:^",

--- a/packages/json-to-docx/package.json
+++ b/packages/json-to-docx/package.json
@@ -34,7 +34,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
-    "prepublishOnly": "cp ../../LICENSE ."
+    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
   },
   "dependencies": {
     "@json-to-office/core-docx": "workspace:^",

--- a/packages/json-to-pptx/package.json
+++ b/packages/json-to-pptx/package.json
@@ -34,7 +34,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
-    "prepublishOnly": "cp ../../LICENSE ."
+    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
   },
   "dependencies": {
     "@json-to-office/core-pptx": "workspace:^",

--- a/packages/jto/package.json
+++ b/packages/jto/package.json
@@ -34,7 +34,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "cli": "tsx src/cli.ts",
-    "prepublishOnly": "cp ../../LICENSE ."
+    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.143",

--- a/packages/jto/src/server/lib/typebox-validator.ts
+++ b/packages/jto/src/server/lib/typebox-validator.ts
@@ -3,6 +3,23 @@ import { Value } from '@sinclair/typebox/value';
 import { Context, Env, ValidationTargets, MiddlewareHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 
+/**
+ * Auto-detect raw document JSON (has `name` + `children` but no `jsonDefinition`)
+ * and wrap it so callers can POST the document tree directly.
+ */
+function autoWrapDocumentBody(value: unknown): unknown {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'name' in value &&
+    'children' in value &&
+    !('jsonDefinition' in value)
+  ) {
+    return { jsonDefinition: value };
+  }
+  return value;
+}
+
 export function tbValidator<
   T extends TSchema,
   E extends Env = Env,
@@ -19,6 +36,8 @@ export function tbValidator<
       });
     }
 
+    value = autoWrapDocumentBody(value);
+
     const isValid = Value.Check(schema, value);
 
     if (isValid) {
@@ -33,7 +52,7 @@ export function tbValidator<
         value: error.value,
       }));
 
-      const errorMessages = errors.map((e) => e.message);
+      const errorMessages = errors.map((e) => `${e.path || '/'}: ${e.message}`);
 
       throw new HTTPException(400, {
         message:

--- a/packages/jto/tsup.config.ts
+++ b/packages/jto/tsup.config.ts
@@ -78,6 +78,7 @@ export default defineConfig([
       options.platform = 'node';
       options.target = 'node18';
     },
-    onSuccess: 'cp -r src/server/prompts dist/prompts',
+    onSuccess:
+      "node -e \"const fs=require('fs');fs.cpSync('src/server/prompts','dist/prompts',{recursive:true,force:true})\"",
   },
 ]);

--- a/packages/shared-docx/package.json
+++ b/packages/shared-docx/package.json
@@ -38,7 +38,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
-    "prepublishOnly": "cp ../../LICENSE ."
+    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
   },
   "dependencies": {
     "@json-to-office/shared": "workspace:^",

--- a/packages/shared-pptx/package.json
+++ b/packages/shared-pptx/package.json
@@ -33,7 +33,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
-    "prepublishOnly": "cp ../../LICENSE ."
+    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
   },
   "dependencies": {
     "@json-to-office/shared": "workspace:^",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -53,7 +53,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
-    "prepublishOnly": "cp ../../LICENSE ."
+    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.38",

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs/promises';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -13,13 +13,15 @@ const SHARED_PPTX = path.join(ROOT, 'packages/shared-pptx/dist/index.js');
 async function main() {
   await fs.mkdir(OUTPUT_DIR, { recursive: true });
 
-  const { convertToJsonSchema, exportSchemaToFile } = await import(SHARED);
+  const { convertToJsonSchema, exportSchemaToFile } = await import(
+    pathToFileURL(SHARED).href
+  );
 
   // DOCX document schema
   const {
     generateUnifiedDocumentSchema: generateDocx,
     ThemeConfigSchema: DocxThemeSchema,
-  } = await import(SHARED_DOCX);
+  } = await import(pathToFileURL(SHARED_DOCX).href);
 
   const docxSchema = generateDocx({
     includeStandardComponents: true,
@@ -57,7 +59,7 @@ async function main() {
 
   // PPTX presentation schema
   const { generateUnifiedDocumentSchema: generatePptx } = await import(
-    SHARED_PPTX
+    pathToFileURL(SHARED_PPTX).href
   );
   const pptxSchema = generatePptx({ customComponents: [] });
   const pptxJson = convertToJsonSchema(pptxSchema, {


### PR DESCRIPTION
## Summary
- Auto-wrap raw document JSON (with `name` + `children`) so callers can POST the document tree directly without the `jsonDefinition` envelope
- Include paths in validation error messages for easier debugging
- Replace shell `cp` commands with cross-platform Node.js equivalents

Closes #50

## Test plan
- [ ] POST raw document JSON without `jsonDefinition` wrapper — should succeed
- [ ] POST invalid JSON — error messages include property paths
- [ ] `pnpm build` succeeds on Windows/macOS/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)