### PR TITLE
fix: Windows build — eliminate shell-escaped node -e scripts

### DIFF
--- a/.changeset/fix-windows-build.md
+++ b/.changeset/fix-windows-build.md
@@ -1,0 +1,5 @@
+---
+'@json-to-office/jto': patch
+---
+
+Fix Windows build: replace shell-escaped inline Node scripts with cross-platform path.join

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,11 @@ jobs:
 
   test:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [20, 22]
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/packages/core-docx/package.json
+++ b/packages/core-docx/package.json
@@ -30,7 +30,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
-    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
+    "prepublishOnly": "node ../../scripts/copy-license.cjs"
   },
   "dependencies": {
     "@json-to-office/shared": "workspace:^",

--- a/packages/core-pptx/package.json
+++ b/packages/core-pptx/package.json
@@ -30,7 +30,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
-    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
+    "prepublishOnly": "node ../../scripts/copy-license.cjs"
   },
   "dependencies": {
     "@json-to-office/shared": "workspace:^",

--- a/packages/json-to-docx/package.json
+++ b/packages/json-to-docx/package.json
@@ -34,7 +34,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
-    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
+    "prepublishOnly": "node ../../scripts/copy-license.cjs"
   },
   "dependencies": {
     "@json-to-office/core-docx": "workspace:^",

--- a/packages/json-to-pptx/package.json
+++ b/packages/json-to-pptx/package.json
@@ -34,7 +34,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
-    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
+    "prepublishOnly": "node ../../scripts/copy-license.cjs"
   },
   "dependencies": {
     "@json-to-office/core-pptx": "workspace:^",

--- a/packages/jto/package.json
+++ b/packages/jto/package.json
@@ -34,7 +34,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "cli": "tsx src/cli.ts",
-    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
+    "prepublishOnly": "node ../../scripts/copy-license.cjs"
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.143",

--- a/packages/jto/tsup.config.ts
+++ b/packages/jto/tsup.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsup';
-import { readFileSync } from 'fs';
+import { cpSync, readFileSync } from 'fs';
 import { join } from 'path';
 
 const packageJson = JSON.parse(
@@ -78,7 +78,11 @@ export default defineConfig([
       options.platform = 'node';
       options.target = 'node18';
     },
-    onSuccess:
-      "node -e \"const fs=require('fs');fs.cpSync('src/server/prompts','dist/prompts',{recursive:true,force:true})\"",
+    onSuccess: async () => {
+      cpSync(join('src', 'server', 'prompts'), join('dist', 'prompts'), {
+        recursive: true,
+        force: true,
+      });
+    },
   },
 ]);

--- a/packages/shared-docx/package.json
+++ b/packages/shared-docx/package.json
@@ -38,7 +38,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
-    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
+    "prepublishOnly": "node ../../scripts/copy-license.cjs"
   },
   "dependencies": {
     "@json-to-office/shared": "workspace:^",

--- a/packages/shared-pptx/package.json
+++ b/packages/shared-pptx/package.json
@@ -33,7 +33,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
-    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
+    "prepublishOnly": "node ../../scripts/copy-license.cjs"
   },
   "dependencies": {
     "@json-to-office/shared": "workspace:^",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -53,7 +53,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --passWithNoTests",
-    "prepublishOnly": "node -e \"require('fs').copyFileSync('../../LICENSE','LICENSE')\""
+    "prepublishOnly": "node ../../scripts/copy-license.cjs"
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.38",

--- a/scripts/copy-license.cjs
+++ b/scripts/copy-license.cjs
@@ -1,0 +1,4 @@
+const { copyFileSync } = require('fs');
+const { join } = require('path');
+
+copyFileSync(join(__dirname, '..', 'LICENSE'), 'LICENSE');


### PR DESCRIPTION
## Summary
- Replace inline `node -e` with `onSuccess` function in `tsup.config.ts` using `path.join`
- Extract `prepublishOnly` LICENSE copy into shared `scripts/copy-license.cjs`
- Add `windows-latest` to CI test matrix

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)