### PR TITLE
fix(docs): correct CLI usage for generate and dev commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,12 +371,12 @@ await pptx(
 
 ```bash
 # Start the visual playground with live preview
-jto docx dev ./my-template.json
-jto pptx dev ./my-template.json
+jto docx dev
+jto pptx dev
 
 # Generate files directly
-jto docx generate --input ./my-template.json --output ./report.docx
-jto pptx generate --input ./my-template.json --output ./deck.pptx
+jto docx generate ./my-template.json -o ./report.docx
+jto pptx generate ./my-template.json -o ./deck.pptx
 ```
 
 ### Visual playground

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,11 +14,11 @@ More templates are available in the visual playground — run `jto pptx dev` or 
 ```bash
 # With the CLI
 npm install -g @json-to-office/jto
-jto docx generate --input ./invoice.docx.json --output ./invoice.docx
-jto pptx generate --input ./pitch-deck.pptx.json --output ./deck.pptx
+jto docx generate ./invoice.docx.json -o ./invoice.docx
+jto pptx generate ./pitch-deck.pptx.json -o ./deck.pptx
 
 # Or open in the visual playground
-jto docx dev --input ./invoice.docx.json
+jto docx dev
 ```
 
 ## Render programmatically

--- a/packages/jto/README.md
+++ b/packages/jto/README.md
@@ -22,8 +22,8 @@ jto pptx dev
 ### `dev`: visual playground
 
 ```bash
-jto docx dev --input ./template.json
-jto pptx dev --input ./template.json
+jto docx dev
+jto pptx dev
 ```
 
 Opens a browser-based IDE at `localhost:3000` with:
@@ -41,8 +41,8 @@ Opens a browser-based IDE at `localhost:3000` with:
 ### `generate`: render files
 
 ```bash
-jto docx generate --input ./template.json --output ./report.docx
-jto pptx generate --input ./template.json --output ./deck.pptx
+jto docx generate ./template.json -o ./report.docx
+jto pptx generate ./template.json -o ./deck.pptx
 ```
 
 Reads a JSON document definition and writes a `.docx` or `.pptx` file. Works in CI/CD pipelines, cron jobs, and scripts.


### PR DESCRIPTION
## Summary
- Remove non-existent `--input` flag from `generate` docs — input is a positional arg
- Replace `--output` with short `-o` flag in examples
- Remove phantom file arg from `dev` command docs (it accepts no input file)

Closes #53

## Test plan
- [x] `grep --input **/*.md` returns no hits
- [x] All 53 tests pass (`pnpm test --filter jto`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)