### PR TITLE
fix(core-pptx): plugin path honors props.theme over constructor default

### DIFF
--- a/.changeset/fix-pptx-plugin-theme-shadowing.md
+++ b/.changeset/fix-pptx-plugin-theme-shadowing.md
@@ -1,0 +1,7 @@
+---
+'@json-to-office/core-pptx': patch
+---
+
+fix(core-pptx): plugin path now honors `props.theme` over constructor default
+
+Plugin-aware presentation generator unconditionally used a constructor-supplied `state.theme` object, shadowing `customThemes[doc.props.theme]`. Playground sessions with any plugin loaded rendered docs with the wrong theme (e.g. `props.theme: "wiseair"` falling back to `themes.minimal`). Resolution now mirrors the non-plugin path and the DOCX side: doc-level theme name wins, customThemes is consulted first, constructor `state.theme` is the fallback only.

--- a/packages/core-pptx/src/plugin/__tests__/createPresentationGenerator.test.ts
+++ b/packages/core-pptx/src/plugin/__tests__/createPresentationGenerator.test.ts
@@ -323,6 +323,74 @@ describe('createPresentationGenerator', () => {
     expect(result.buffer).toBeInstanceOf(Buffer);
   });
 
+  it('prefers customThemes[doc.props.theme] over constructor-supplied state.theme', async () => {
+    // Regression: in the playground/CLI plugin path, a default theme passed
+    // to the constructor used to shadow customThemes — so a doc with
+    // `props.theme: "wiseair"` rendered as the constructor default even
+    // though the wiseair theme was supplied. Spy via a custom component's
+    // render args to capture the theme actually used.
+    let observedTheme: any = null;
+    const spy = createComponent({
+      name: 'theme-spy' as const,
+      versions: {
+        '1.0.0': createVersion({
+          propsSchema: Type.Object({}),
+          render: async ({ theme }) => {
+            observedTheme = theme;
+            return [];
+          },
+        }),
+      },
+    });
+
+    const constructorTheme = {
+      name: 'minimal-fallback',
+      colors: {
+        primary: '#111111',
+        secondary: '#222222',
+        accent: '#333333',
+        background: '#FFFFFF',
+        text: '#000000',
+      },
+      fonts: { heading: 'Arial', body: 'Arial' },
+      defaults: { fontSize: 12, fontColor: '#000000' },
+    } as any;
+
+    const customWiseair = {
+      name: 'wiseair',
+      colors: {
+        primary: '#1D2130',
+        secondary: '#383F5D',
+        accent: '#586CC9',
+        background: '#FAFAFA',
+        text: '#1D2130',
+      },
+      fonts: { heading: 'Inter', body: 'Inter' },
+      defaults: { fontSize: 16, fontColor: '#1D2130' },
+    } as any;
+
+    const gen = createPresentationGenerator({
+      theme: constructorTheme,
+      customThemes: { wiseair: customWiseair },
+    }).addComponent(spy);
+
+    await gen.generate({
+      name: 'pptx',
+      props: { theme: 'wiseair' },
+      children: [
+        {
+          name: 'slide',
+          props: {},
+          children: [{ name: 'theme-spy', props: {} }],
+        },
+      ],
+    });
+
+    expect(observedTheme).not.toBeNull();
+    expect(observedTheme.colors.accent).toBe('#586CC9');
+    expect(observedTheme.colors.primary).toBe('#1D2130');
+  });
+
   it('generates and saves to file', async () => {
     const gen = createPresentationGenerator().addComponent(bannerComponent);
     const fs = await import('fs/promises');

--- a/packages/core-pptx/src/plugin/createPresentationGenerator.ts
+++ b/packages/core-pptx/src/plugin/createPresentationGenerator.ts
@@ -273,15 +273,20 @@ function createBuilderImpl<
         throw new Error('Top-level component must be a pptx component');
       }
 
-      // Resolve theme for render context
+      // Resolve theme: doc-level `props.theme` wins (matches non-plugin path
+      // and DOCX). A constructor-supplied `state.theme` object only acts as
+      // the fallback when the doc names a theme we can't find — otherwise a
+      // playground/CLI default theme would silently shadow customThemes
+      // entries (e.g. `props.theme: "wiseair"` rendering as `themes.minimal`).
+      const docThemeName = internalDocument.props.theme;
       const baseThemeName =
-        typeof state.theme === 'string'
-          ? state.theme
-          : internalDocument.props.theme ?? 'default';
+        docThemeName ??
+        (typeof state.theme === 'string' ? state.theme : 'default');
       let resolvedTheme =
-        typeof state.theme === 'object'
+        state.customThemes?.[baseThemeName] ??
+        (typeof state.theme === 'object' && state.theme !== null
           ? state.theme
-          : state.customThemes?.[baseThemeName] ?? getPptxTheme(baseThemeName);
+          : getPptxTheme(baseThemeName));
 
       const warnings: PipelineWarning[] = [];
 


### PR DESCRIPTION
## Summary

- Plugin-aware presentation generator unconditionally used `state.theme` (a constructor-supplied object) for theme resolution, shadowing `customThemes[doc.props.theme]`. Any playground session with at least one plugin loaded rendered docs with the wrong theme — e.g. `props.theme: "wiseair"` silently fell back to `themes.minimal`.
- Resolution now mirrors the non-plugin path and the DOCX `createDocumentGenerator`: doc-level `props.theme` wins, `customThemes` is consulted first, constructor `state.theme` only acts as fallback.
- Added regression test using a spy custom component that captures the theme its render() receives.

## Test plan

- [x] `pnpm -C packages/core-pptx test` — 47/47 pass, including new regression
- [ ] Reload local playground with a plugin loaded; confirm wiseair-themed deck renders with `accent: #586CC9` / `primary: #1D2130` instead of grayscale fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)