### PR TITLE
feat(core-docx): preserveCustomComponents + surface standardDefinition

### DIFF
--- a/.changeset/preserved-custom-components.md
+++ b/.changeset/preserved-custom-components.md
@@ -1,0 +1,6 @@
+---
+'@json-to-office/shared': minor
+'@json-to-office/core-docx': minor
+---
+
+feat(core-docx): per-call `preserveCustomComponents` option on `generate` / `generateBuffer` / `generateFile`. Listed component names are kept verbatim (un-expanded) in a new `preservedDefinition` field on the result; `standardDefinition` and the rendered DOCX are unchanged. `generateFile` also writes a JSON sidecar (default `<out>-preserved.json`, override via `preservedOutputPath`). Unknown names throw `UnknownPreservedComponentError` (exported from `@json-to-office/shared` and `@json-to-office/core-docx`).

--- a/.changeset/surface-standard-definition.md
+++ b/.changeset/surface-standard-definition.md
@@ -1,0 +1,8 @@
+---
+'@json-to-office/core-docx': major
+'@json-to-office/json-to-docx': major
+'@json-to-office/jto-cli': minor
+'@json-to-office/jto': minor
+---
+
+refactor(core-docx)!: surface `standardDefinition` from `generate` / `generateBuffer` / `generateFile`; remove `getStandardComponentsDefinition`. Plugin `render()` previously ran twice when callers used both the inspection method and a generate call, duplicating side effects (e.g. external API hits). The post-expansion JSON tree is now returned alongside the document/buffer at no extra cost. Adapter `generateBuffer` returns `{ buffer, standardDefinition }`.

--- a/packages/core-docx/src/index.ts
+++ b/packages/core-docx/src/index.ts
@@ -145,6 +145,7 @@ export {
   validateDocument,
   cleanComponentProps,
   ComponentValidationError,
+  UnknownPreservedComponentError,
 
   // Schema utilities
   generatePluginDocumentSchema,
@@ -160,6 +161,8 @@ export {
   type RenderContext as ComponentRenderContext,
   type DocumentGenerator,
   type DocumentGeneratorOptions,
+  type GenerateOptions,
+  type GenerateFileOptions,
   type GenerationResult,
   type BufferGenerationResult,
   type FileGenerationResult,

--- a/packages/core-docx/src/plugin/__tests__/generate-standard-definition.test.ts
+++ b/packages/core-docx/src/plugin/__tests__/generate-standard-definition.test.ts
@@ -6,26 +6,15 @@ import { DuplicateComponentError } from '../validation';
 import { ensureThemeDefaults } from '../../themes/defaults';
 import type { ComponentDefinition } from '../../types';
 
-/**
- * Test: getStandardComponentsDefinition
- *
- * This test demonstrates that custom components are properly converted to standard components
- * and that the document is normalized correctly.
- */
-
-// Create a simple test theme
 const testTheme = ensureThemeDefaults({
   name: 'test',
   displayName: 'Test Theme',
   description: 'Simple theme for testing',
 });
 
-// Define a simple custom component: "greeting"
 const GreetingPropsSchema = Type.Object(
   {
-    name: Type.String({
-      description: 'Name to greet',
-    }),
+    name: Type.String({ description: 'Name to greet' }),
     style: Type.Optional(
       Type.Union([Type.Literal('formal'), Type.Literal('casual')], {
         default: 'casual',
@@ -33,15 +22,10 @@ const GreetingPropsSchema = Type.Object(
       })
     ),
     includeDate: Type.Optional(
-      Type.Boolean({
-        default: false,
-        description: 'Include current date',
-      })
+      Type.Boolean({ default: false, description: 'Include current date' })
     ),
   },
-  {
-    additionalProperties: false,
-  }
+  { additionalProperties: false }
 );
 
 const greetingComponent = createComponent({
@@ -50,61 +34,39 @@ const greetingComponent = createComponent({
     '1.0.0': createVersion({
       propsSchema: GreetingPropsSchema,
       description: 'Generates a personalized greeting message',
-
       render: async ({ props }): Promise<ComponentDefinition[]> => {
         const components: ComponentDefinition[] = [];
-
-        // Create greeting text based on style
         const greetingText =
           props.style === 'formal'
             ? `Dear ${props.name},`
             : `Hello ${props.name}!`;
-
-        // Add greeting as a heading
         components.push({
           name: 'heading',
-          props: {
-            level: 2,
-            text: greetingText,
-          },
+          props: { level: 2, text: greetingText },
         });
-
-        // Add date if requested
         if (props.includeDate) {
           const currentDate = new Date().toLocaleDateString('en-US', {
             year: 'numeric',
             month: 'long',
             day: 'numeric',
           });
-
           components.push({
             name: 'paragraph',
-            props: {
-              text: `Date: ${currentDate}`,
-              font: { italic: true },
-            },
+            props: { text: `Date: ${currentDate}`, font: { italic: true } },
           });
         }
-
         return components;
       },
     }),
   },
 });
 
-// Define another custom component that generates a summary
 const SummaryPropsSchema = Type.Object(
   {
-    title: Type.String({
-      description: 'Summary title',
-    }),
-    points: Type.Array(Type.String(), {
-      description: 'Summary points',
-    }),
+    title: Type.String({ description: 'Summary title' }),
+    points: Type.Array(Type.String(), { description: 'Summary points' }),
   },
-  {
-    additionalProperties: false,
-  }
+  { additionalProperties: false }
 );
 
 const summaryComponent = createComponent({
@@ -113,31 +75,18 @@ const summaryComponent = createComponent({
     '1.0.0': createVersion({
       propsSchema: SummaryPropsSchema,
       description: 'Generates a summary section with key points',
-
       render: async ({ props }): Promise<ComponentDefinition[]> => {
         return [
-          {
-            name: 'heading',
-            props: {
-              level: 3,
-              text: props.title,
-            },
-          },
-          {
-            name: 'list',
-            props: {
-              items: props.points,
-            },
-          },
+          { name: 'heading', props: { level: 3, text: props.title } },
+          { name: 'list', props: { items: props.points } },
         ];
       },
     }),
   },
 });
 
-describe('getStandardComponentsDefinition', () => {
+describe('generate().standardDefinition', () => {
   it('should convert custom components to standard components', async () => {
-    // Create a document generator with custom components using builder pattern
     const generator = createDocumentGenerator({
       theme: testTheme,
       debug: false,
@@ -145,8 +94,6 @@ describe('getStandardComponentsDefinition', () => {
       .addComponent(greetingComponent)
       .addComponent(summaryComponent);
 
-    // Define a document using custom components - no type annotation needed!
-    // TypeScript infers the correct type from the generator
     const documentWithCustomComponents = {
       name: 'docx' as const,
       props: {
@@ -156,11 +103,7 @@ describe('getStandardComponentsDefinition', () => {
       children: [
         {
           name: 'greeting' as const,
-          props: {
-            name: 'Alice',
-            style: 'formal' as const,
-            includeDate: true,
-          },
+          props: { name: 'Alice', style: 'formal' as const, includeDate: true },
         },
         {
           name: 'paragraph' as const,
@@ -175,19 +118,17 @@ describe('getStandardComponentsDefinition', () => {
             points: [
               'Custom components work correctly',
               'Standard components are preserved',
-              'getStandardComponentsDefinition normalizes the output',
+              'standardDefinition normalizes the output',
             ],
           },
         },
       ],
     };
 
-    // Get the standard components definition
-    const standardDefinition = await generator.getStandardComponentsDefinition(
+    const { standardDefinition } = await generator.generate(
       documentWithCustomComponents
     );
 
-    // Verify the result
     expect(standardDefinition).toBeDefined();
     expect(standardDefinition.name).toBe('docx');
     expect(standardDefinition.props?.metadata?.title).toBe(
@@ -196,52 +137,35 @@ describe('getStandardComponentsDefinition', () => {
     expect(standardDefinition.children).toBeDefined();
     expect(Array.isArray(standardDefinition.children)).toBe(true);
 
-    // Verify that custom components have been replaced with standard components
     const componentNames = standardDefinition.children!.map((m: any) => m.name);
 
-    // Should NOT contain custom component names
     expect(componentNames).not.toContain('greeting');
     expect(componentNames).not.toContain('summary');
 
-    // Should contain the standard components that custom components expanded to
-    expect(componentNames).toContain('heading'); // From greeting and summary
-    expect(componentNames).toContain('paragraph'); // Original + from greeting (date)
-    expect(componentNames).toContain('list'); // From summary
+    expect(componentNames).toContain('heading');
+    expect(componentNames).toContain('paragraph');
+    expect(componentNames).toContain('list');
 
-    // Count the components (should be more than original 3 because custom components expand)
-    // greeting -> heading + paragraph (because includeDate is true)
+    // greeting -> heading + paragraph (includeDate: true)
     // paragraph -> paragraph
     // summary -> heading + list
-    // Total: 5 components
     expect(standardDefinition.children!.length).toBe(5);
   });
 
-  it('should preserve standard components unchanged', async () => {
+  it('should expand a single custom component', async () => {
     const generator = createDocumentGenerator({
       theme: testTheme,
     }).addComponent(greetingComponent);
 
-    // Use explicit typing to avoid inference issues with standard-only components
-    const standardDefinition = await generator.getStandardComponentsDefinition({
+    const { standardDefinition } = await generator.generate({
       name: 'docx',
       props: {
-        metadata: {
-          title: 'Standard Components Only',
-        },
+        metadata: { title: 'Standard Components Only' },
         theme: 'minimal',
       },
-      children: [
-        {
-          name: 'greeting',
-          props: {
-            name: 'John',
-          },
-        },
-      ],
+      children: [{ name: 'greeting', props: { name: 'John' } }],
     });
 
-    // Should have the greeting component expanded to standard components
-    // greeting without includeDate only produces a heading
     expect(standardDefinition.children).toBeDefined();
     expect(standardDefinition.children!.length).toBe(1);
     expect(standardDefinition.children![0].name).toBe('heading');
@@ -254,61 +178,38 @@ describe('getStandardComponentsDefinition', () => {
       .addComponent(greetingComponent)
       .addComponent(summaryComponent);
 
-    // Note: Nested custom components in sections work at runtime, but TypeScript
-    // doesn't fully support this because ExtendedComponentDefinition isn't applied
-    // recursively in section.children. We use 'as any' for the nested children.
-    const standardDefinition = await generator.getStandardComponentsDefinition({
+    const { standardDefinition } = await generator.generate({
       name: 'docx',
-      props: {
-        metadata: { title: 'Nested Custom Components' },
-      },
+      props: { metadata: { title: 'Nested Custom Components' } },
       children: [
         {
           name: 'section',
-          props: {
-            title: 'Introduction',
-          },
+          props: { title: 'Introduction' },
           children: [
             {
               name: 'greeting',
-              props: {
-                name: 'Bob',
-                style: 'casual',
-                includeDate: false,
-              },
+              props: { name: 'Bob', style: 'casual', includeDate: false },
             },
             {
               name: 'summary',
-              props: {
-                title: 'Overview',
-                points: ['Point 1', 'Point 2'],
-              },
+              props: { title: 'Overview', points: ['Point 1', 'Point 2'] },
             },
           ],
         },
       ] as any,
     });
 
-    // Verify the section is preserved
     expect(standardDefinition.children).toBeDefined();
     expect(standardDefinition.children!.length).toBe(1);
     expect(standardDefinition.children![0].name).toBe('section');
 
-    // Verify nested components are converted
     const sectionComponent = standardDefinition.children![0] as any;
     expect(sectionComponent.children).toBeDefined();
     expect(Array.isArray(sectionComponent.children)).toBe(true);
 
     const nestedNames = sectionComponent.children.map((m: any) => m.name);
-
-    // Should NOT contain custom names
     expect(nestedNames).not.toContain('greeting');
     expect(nestedNames).not.toContain('summary');
-
-    // Should contain expanded standard names
-    // greeting (casual, no date) -> heading only
-    // summary -> heading + list
-    // Total: 3 components
     expect(nestedNames).toContain('heading');
     expect(nestedNames).toContain('list');
     expect(sectionComponent.children.length).toBe(3);
@@ -321,23 +222,16 @@ describe('getStandardComponentsDefinition', () => {
 
     const invalidDocument = {
       name: 'docx' as const,
-      props: {
-        metadata: { title: 'Invalid Config' },
-      },
+      props: { metadata: { title: 'Invalid Config' } },
       children: [
         {
           name: 'greeting' as const,
-          props: {
-            // Missing required 'name' field
-            style: 'formal' as const,
-          } as any,
+          props: { style: 'formal' as const } as any,
         },
       ],
     };
 
-    await expect(
-      generator.getStandardComponentsDefinition(invalidDocument)
-    ).rejects.toThrow();
+    await expect(generator.generate(invalidDocument)).rejects.toThrow();
   });
 
   it('should normalize the document structure', async () => {
@@ -347,9 +241,7 @@ describe('getStandardComponentsDefinition', () => {
 
     const document = {
       name: 'docx' as const,
-      props: {
-        metadata: { title: 'Normalization Test' },
-      },
+      props: { metadata: { title: 'Normalization Test' } },
       children: [
         {
           name: 'greeting' as const,
@@ -362,31 +254,26 @@ describe('getStandardComponentsDefinition', () => {
       ],
     };
 
-    const standardDefinition =
-      await generator.getStandardComponentsDefinition(document);
+    const { standardDefinition } = await generator.generate(document);
 
-    // The normalized document should have proper structure
     expect(standardDefinition).toHaveProperty('name', 'docx');
     expect(standardDefinition).toHaveProperty('props');
     expect(standardDefinition).toHaveProperty('children');
 
-    // All components should be fully expanded and normalized
     standardDefinition.children!.forEach((component: any) => {
       expect(component).toHaveProperty('name');
       expect(component).toHaveProperty('props');
     });
   });
 
-  it('should work with the same document that generate() uses', async () => {
+  it('should expose the same expansion the rendered document is built from', async () => {
     const generator = createDocumentGenerator({
       theme: testTheme,
     }).addComponent(greetingComponent);
 
     const document = {
       name: 'docx' as const,
-      props: {
-        metadata: { title: 'Consistency Test' },
-      },
+      props: { metadata: { title: 'Consistency Test' } },
       children: [
         {
           name: 'greeting' as const,
@@ -399,25 +286,18 @@ describe('getStandardComponentsDefinition', () => {
       ],
     };
 
-    // Both should work without errors
-    const standardDefinition =
-      await generator.getStandardComponentsDefinition(document);
-    const generatedDoc = await generator.generate(document);
+    const result = await generator.generate(document);
 
-    // Both should succeed
-    expect(standardDefinition).toBeDefined();
-    expect(generatedDoc).toBeDefined();
-
-    // The standard definition should contain the same expanded components
-    // that generate() would use internally
-    expect(standardDefinition.children).toBeDefined();
-    expect(standardDefinition.children!.length).toBe(2); // heading + paragraph (with date)
+    expect(result.document).toBeDefined();
+    expect(result.standardDefinition).toBeDefined();
+    expect(result.standardDefinition.children).toBeDefined();
+    // greeting (formal, with date) -> heading + paragraph
+    expect(result.standardDefinition.children!.length).toBe(2);
   });
 
   it('should throw DuplicateComponentError when same component name is registered twice', () => {
-    // Create a duplicate component with the same name
     const duplicateGreetingComponent = createComponent({
-      name: 'greeting', // Same name as greetingComponent
+      name: 'greeting',
       versions: {
         '1.0.0': {
           propsSchema: Type.Object({ message: Type.String() }),
@@ -427,9 +307,7 @@ describe('getStandardComponentsDefinition', () => {
     });
 
     expect(() => {
-      createDocumentGenerator({
-        theme: testTheme,
-      })
+      createDocumentGenerator({ theme: testTheme })
         .addComponent(greetingComponent)
         .addComponent(duplicateGreetingComponent);
     }).toThrow(DuplicateComponentError);
@@ -447,9 +325,7 @@ describe('getStandardComponentsDefinition', () => {
     });
 
     try {
-      createDocumentGenerator({
-        theme: testTheme,
-      })
+      createDocumentGenerator({ theme: testTheme })
         .addComponent(greetingComponent)
         .addComponent(duplicateComponent);
       expect.fail('Should have thrown DuplicateComponentError');
@@ -463,7 +339,6 @@ describe('getStandardComponentsDefinition', () => {
   });
 
   it('should allow adding the same component instance to different generators', () => {
-    // This should work - different generators can have the same component
     const generator1 = createDocumentGenerator({
       theme: testTheme,
     }).addComponent(greetingComponent);

--- a/packages/core-docx/src/plugin/__tests__/preserved-components.test.ts
+++ b/packages/core-docx/src/plugin/__tests__/preserved-components.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { Type } from '@sinclair/typebox';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { createComponent, createVersion } from '../createComponent';
+import { createDocumentGenerator } from '../createDocumentGenerator';
+import { UnknownPreservedComponentError } from '../validation';
+import { ensureThemeDefaults } from '../../themes/defaults';
+import type { ComponentDefinition } from '../../types';
+
+const testTheme = ensureThemeDefaults({
+  name: 'test',
+  displayName: 'Test Theme',
+  description: 'Simple theme for testing',
+});
+
+const greetingComponent = createComponent({
+  name: 'greeting',
+  versions: {
+    '1.0.0': createVersion({
+      propsSchema: Type.Object(
+        { name: Type.String() },
+        { additionalProperties: false }
+      ),
+      render: async ({ props }): Promise<ComponentDefinition[]> => [
+        { name: 'heading', props: { level: 2, text: `Hello ${props.name}!` } },
+      ],
+    }),
+  },
+});
+
+const summaryComponent = createComponent({
+  name: 'summary',
+  versions: {
+    '1.0.0': createVersion({
+      propsSchema: Type.Object(
+        { points: Type.Array(Type.String()) },
+        { additionalProperties: false }
+      ),
+      render: async ({ props }): Promise<ComponentDefinition[]> => [
+        { name: 'list', props: { items: props.points } },
+      ],
+    }),
+  },
+});
+
+const tempPaths: string[] = [];
+afterEach(async () => {
+  await Promise.all(
+    tempPaths.splice(0).map((p) =>
+      fs.rm(p, { force: true }).catch(() => {
+        /* best-effort */
+      })
+    )
+  );
+});
+
+function tmpPath(suffix: string): string {
+  const p = path.join(
+    os.tmpdir(),
+    `preserved-${Date.now()}-${Math.random().toString(36).slice(2)}${suffix}`
+  );
+  tempPaths.push(p);
+  return p;
+}
+
+describe('preserveCustomComponents', () => {
+  it('omitting the option produces no preservedDefinition', async () => {
+    const generator = createDocumentGenerator({ theme: testTheme })
+      .addComponent(greetingComponent)
+      .addComponent(summaryComponent);
+
+    const result = await generator.generate({
+      name: 'docx',
+      props: { metadata: { title: 't' } },
+      children: [{ name: 'greeting', props: { name: 'Alice' } }],
+    });
+
+    expect(result.preservedDefinition).toBeUndefined();
+    expect(result.standardDefinition.children!.length).toBe(1);
+    expect(result.standardDefinition.children![0].name).toBe('heading');
+  });
+
+  it('empty preserveCustomComponents array produces no preservedDefinition', async () => {
+    const generator = createDocumentGenerator({
+      theme: testTheme,
+    }).addComponent(greetingComponent);
+
+    const result = await generator.generate(
+      {
+        name: 'docx',
+        props: {},
+        children: [{ name: 'greeting', props: { name: 'Bob' } }],
+      },
+      { preserveCustomComponents: [] }
+    );
+
+    expect(result.preservedDefinition).toBeUndefined();
+  });
+
+  it('preserves only listed components, expands the rest', async () => {
+    const generator = createDocumentGenerator({ theme: testTheme })
+      .addComponent(greetingComponent)
+      .addComponent(summaryComponent);
+
+    const result = await generator.generate(
+      {
+        name: 'docx',
+        props: {},
+        children: [
+          { name: 'greeting', props: { name: 'Alice' } },
+          { name: 'summary', props: { points: ['p1', 'p2'] } },
+        ],
+      },
+      { preserveCustomComponents: ['greeting'] }
+    );
+
+    expect(result.preservedDefinition).toBeDefined();
+    const children = result.preservedDefinition!.children!;
+    expect(children).toHaveLength(2);
+    // Greeting kept verbatim
+    expect(children[0]).toMatchObject({
+      name: 'greeting',
+      props: { name: 'Alice' },
+    });
+    // Summary expanded
+    expect((children[1] as any).name).toBe('list');
+
+    // standardDefinition unchanged: both customs fully expanded
+    expect(result.standardDefinition.children!.map((c: any) => c.name)).toEqual(
+      ['heading', 'list']
+    );
+  });
+
+  it('preserved subtree children are NOT recursed (verbatim)', async () => {
+    // 'container' is a custom component that has authored children including
+    // a non-preserved 'summary'. When 'container' is preserved, the summary
+    // inside it must remain un-expanded.
+    const containerComponent = createComponent({
+      name: 'container',
+      versions: {
+        '1.0.0': createVersion({
+          hasChildren: true,
+          propsSchema: Type.Object({}, { additionalProperties: false }),
+          render: async ({ children }): Promise<ComponentDefinition[]> =>
+            (children ?? []) as ComponentDefinition[],
+        }),
+      },
+    });
+
+    const generator = createDocumentGenerator({ theme: testTheme })
+      .addComponent(containerComponent)
+      .addComponent(summaryComponent);
+
+    const result = await generator.generate(
+      {
+        name: 'docx',
+        props: {},
+        children: [
+          {
+            name: 'container',
+            props: {},
+            children: [{ name: 'summary', props: { points: ['x'] } } as any],
+          },
+        ],
+      } as any,
+      { preserveCustomComponents: ['container'] }
+    );
+
+    const container: any = result.preservedDefinition!.children![0];
+    expect(container.name).toBe('container');
+    // Verbatim: child still says 'summary', NOT expanded to 'list'
+    expect(container.children).toHaveLength(1);
+    expect(container.children[0].name).toBe('summary');
+  });
+
+  it('throws UnknownPreservedComponentError for unregistered names', async () => {
+    const generator = createDocumentGenerator({
+      theme: testTheme,
+    }).addComponent(greetingComponent);
+
+    await expect(
+      generator.generate(
+        {
+          name: 'docx',
+          props: {},
+          children: [{ name: 'greeting', props: { name: 'A' } }],
+        },
+        { preserveCustomComponents: ['greeting', 'typo-name'] }
+      )
+    ).rejects.toBeInstanceOf(UnknownPreservedComponentError);
+
+    try {
+      await generator.generate(
+        {
+          name: 'docx',
+          props: {},
+          children: [{ name: 'greeting', props: { name: 'A' } }],
+        },
+        { preserveCustomComponents: ['typo-name'] }
+      );
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(UnknownPreservedComponentError);
+      const e = err as UnknownPreservedComponentError;
+      expect(e.unknownNames).toEqual(['typo-name']);
+      expect(e.registeredNames).toEqual(['greeting']);
+      expect(e.code).toBe('UNKNOWN_PRESERVED_COMPONENT');
+    }
+  });
+
+  it('preserves nested customs inside standard containers', async () => {
+    const generator = createDocumentGenerator({ theme: testTheme })
+      .addComponent(greetingComponent)
+      .addComponent(summaryComponent);
+
+    const result = await generator.generate(
+      {
+        name: 'docx',
+        props: {},
+        children: [
+          {
+            name: 'section',
+            props: { title: 'S' },
+            children: [
+              { name: 'greeting', props: { name: 'Alice' } },
+              { name: 'summary', props: { points: ['a'] } },
+            ],
+          },
+        ] as any,
+      },
+      { preserveCustomComponents: ['greeting'] }
+    );
+
+    const section: any = result.preservedDefinition!.children![0];
+    expect(section.name).toBe('section');
+    expect(section.children).toHaveLength(2);
+    expect(section.children[0].name).toBe('greeting');
+    expect(section.children[1].name).toBe('list');
+  });
+
+  it('generateFile writes sidecar at default path', async () => {
+    const generator = createDocumentGenerator({
+      theme: testTheme,
+    }).addComponent(greetingComponent);
+
+    const outPath = tmpPath('.docx');
+    const result = await generator.generateFile(
+      {
+        name: 'docx',
+        props: {},
+        children: [{ name: 'greeting', props: { name: 'A' } }],
+      },
+      outPath,
+      { preserveCustomComponents: ['greeting'] }
+    );
+
+    const expectedSidecar = outPath.replace(/\.docx$/, '-preserved.json');
+    tempPaths.push(expectedSidecar);
+    expect(result.preservedOutputPath).toBe(expectedSidecar);
+
+    const sidecarContents = await fs.readFile(expectedSidecar, 'utf8');
+    const parsed = JSON.parse(sidecarContents);
+    expect(parsed.children[0]).toMatchObject({
+      name: 'greeting',
+      props: { name: 'A' },
+    });
+  });
+
+  it('generateFile honors preservedOutputPath override', async () => {
+    const generator = createDocumentGenerator({
+      theme: testTheme,
+    }).addComponent(greetingComponent);
+
+    const outPath = tmpPath('.docx');
+    const sidecarPath = tmpPath('-custom.json');
+    const result = await generator.generateFile(
+      {
+        name: 'docx',
+        props: {},
+        children: [{ name: 'greeting', props: { name: 'A' } }],
+      },
+      outPath,
+      {
+        preserveCustomComponents: ['greeting'],
+        preservedOutputPath: sidecarPath,
+      }
+    );
+
+    expect(result.preservedOutputPath).toBe(sidecarPath);
+    const sidecarContents = await fs.readFile(sidecarPath, 'utf8');
+    expect(JSON.parse(sidecarContents).children[0].name).toBe('greeting');
+
+    // Default path NOT written
+    const defaultPath = outPath.replace(/\.docx$/, '-preserved.json');
+    await expect(fs.access(defaultPath)).rejects.toBeDefined();
+  });
+
+  it('generateFile writes no sidecar when option is omitted', async () => {
+    const generator = createDocumentGenerator({
+      theme: testTheme,
+    }).addComponent(greetingComponent);
+
+    const outPath = tmpPath('.docx');
+    const result = await generator.generateFile(
+      {
+        name: 'docx',
+        props: {},
+        children: [{ name: 'greeting', props: { name: 'A' } }],
+      },
+      outPath
+    );
+
+    expect(result.preservedDefinition).toBeUndefined();
+    expect(result.preservedOutputPath).toBeUndefined();
+    const defaultPath = outPath.replace(/\.docx$/, '-preserved.json');
+    await expect(fs.access(defaultPath)).rejects.toBeDefined();
+  });
+
+  it('generateBuffer returns preservedDefinition', async () => {
+    const generator = createDocumentGenerator({
+      theme: testTheme,
+    }).addComponent(greetingComponent);
+
+    const result = await generator.generateBuffer(
+      {
+        name: 'docx',
+        props: {},
+        children: [{ name: 'greeting', props: { name: 'A' } }],
+      },
+      { preserveCustomComponents: ['greeting'] }
+    );
+
+    expect(result.buffer).toBeInstanceOf(Buffer);
+    expect(result.preservedDefinition).toBeDefined();
+    expect((result.preservedDefinition as any).children[0].name).toBe(
+      'greeting'
+    );
+  });
+});

--- a/packages/core-docx/src/plugin/createDocumentGenerator.ts
+++ b/packages/core-docx/src/plugin/createDocumentGenerator.ts
@@ -10,6 +10,8 @@ import { resolveDocumentFonts } from '../core/fontResolution';
 import type {
   ExtendedReportComponent,
   DocumentGeneratorBuilder,
+  GenerateOptions,
+  GenerateFileOptions,
   GenerationResult,
   BufferGenerationResult,
   FileGenerationResult,
@@ -21,6 +23,7 @@ import {
   ComponentValidationError,
   DuplicateComponentError,
 } from './validation';
+import { UnknownPreservedComponentError } from '@json-to-office/shared/plugin';
 import { resolveComponentVersion } from './version-resolver';
 import { generatePluginDocumentSchema, exportPluginSchema } from './schema';
 import { processDocument } from '../core/structure';
@@ -91,27 +94,41 @@ function createBuilderImpl<
   }
 
   /**
-   * Process custom components in the document
+   * Process custom components in the document.
+   *
+   * Returns two parallel trees built in a single pass:
+   * - `standard`: fully expanded — every custom component resolved to standard primitives.
+   * - `preserved`: partially expanded — nodes whose name is in `preserveSet` are kept
+   *   verbatim (children NOT recursed); everything else is expanded the same as `standard`.
+   *
+   * `render()` always runs, even for preserved components, because the docx pipeline
+   * builds from `standard` and we still need their warnings/font registrations.
    */
   async function processDocumentComponents(
     components: ComponentDefinition[],
+    preserveSet: ReadonlySet<string> | undefined,
     warningsCollector: GenerationWarning[],
     resolvedTheme: ThemeConfig,
     depth = 0
-  ): Promise<ComponentDefinition[]> {
+  ): Promise<{
+    standard: ComponentDefinition[];
+    preserved: ComponentDefinition[];
+  }> {
     if (depth > 20) {
       throw new Error(
         'Maximum component nesting depth exceeded (20). Check for circular component references.'
       );
     }
-    const processedComponents: ComponentDefinition[] = [];
+    const standardOut: ComponentDefinition[] = [];
+    const preservedOut: ComponentDefinition[] = [];
 
     for (const componentData of components) {
       // Safe type narrowing for custom component detection
       const componentName = (componentData as { name?: string })?.name;
 
       if (!componentName) {
-        processedComponents.push(componentData);
+        standardOut.push(componentData);
+        preservedOut.push(componentData);
         continue;
       }
 
@@ -146,18 +163,21 @@ function createBuilderImpl<
             componentWithName.props
           );
 
-          // Process nested children if this is a container
+          // Process nested children if this is a container.
+          // For the standard tree we need the fully-expanded children to feed render().
           let nestedChildren: unknown[] | undefined;
           if (
             componentWithName.children &&
             Array.isArray(componentWithName.children)
           ) {
-            nestedChildren = await processDocumentComponents(
+            const nested = await processDocumentComponents(
               componentWithName.children as ComponentDefinition[],
+              preserveSet,
               warningsCollector,
               resolvedTheme,
               depth + 1
             );
+            nestedChildren = nested.standard;
           }
 
           // Create addWarning callback for this component
@@ -193,16 +213,28 @@ function createBuilderImpl<
           // Recursively process the result in case it contains more custom components
           const processedResult = await processDocumentComponents(
             resultComponents,
+            preserveSet,
             warningsCollector,
             resolvedTheme,
             depth + 1
           );
-          processedComponents.push(...processedResult);
+          standardOut.push(...processedResult.standard);
+
+          if (preserveSet && preserveSet.has(componentName)) {
+            // Keep this custom node verbatim in the preserved tree.
+            // Per spec: do NOT recurse into authored children — leave the
+            // entire subtree as the user wrote it.
+            preservedOut.push(componentData);
+          } else {
+            // Non-preserved custom: emit the recursed expansion (which itself
+            // honors preserveSet for any nested customs).
+            preservedOut.push(...processedResult.preserved);
+          }
 
           if (state.debug) {
             console.log(
               `Processed custom component '${versionLabel}':`,
-              processedResult
+              processedResult.standard
             );
           }
         } catch (error) {
@@ -223,21 +255,27 @@ function createBuilderImpl<
         ) {
           const processedNested = await processDocumentComponents(
             componentData.children,
+            preserveSet,
             warningsCollector,
             resolvedTheme,
             depth + 1
           );
-          processedComponents.push({
+          standardOut.push({
             ...componentData,
-            children: processedNested,
+            children: processedNested.standard,
+          });
+          preservedOut.push({
+            ...componentData,
+            children: processedNested.preserved,
           });
         } else {
-          processedComponents.push(componentData);
+          standardOut.push(componentData);
+          preservedOut.push(componentData);
         }
       }
     }
 
-    return processedComponents;
+    return { standard: standardOut, preserved: preservedOut };
   }
 
   /**
@@ -276,12 +314,38 @@ function createBuilderImpl<
   }
 
   /**
+   * Resolve and validate the preserve set for a per-call options object.
+   * Returns `undefined` when the caller did not opt in.
+   * Throws `UnknownPreservedComponentError` when any listed name is not registered.
+   */
+  function resolvePreserveSet(
+    options?: GenerateOptions
+  ): ReadonlySet<string> | undefined {
+    const list = options?.preserveCustomComponents;
+    if (!list || list.length === 0) {
+      return undefined;
+    }
+    const registered = new Set(state.componentNames);
+    const unknown = list.filter((n) => !registered.has(n));
+    if (unknown.length > 0) {
+      throw new UnknownPreservedComponentError(
+        unknown,
+        Array.from(state.componentNames)
+      );
+    }
+    return new Set(list);
+  }
+
+  /**
    * Generate a document
    */
   async function generate(
-    document: ExtendedReportComponent<TComponents>
-  ): Promise<GenerationResult> {
+    document: ExtendedReportComponent<TComponents>,
+    options?: GenerateOptions
+  ): Promise<GenerationResult<TComponents>> {
     try {
+      const preserveSet = resolvePreserveSet(options);
+
       // Cast to ReportComponentDefinition for internal processing
       const internalDocument = document as unknown as ReportComponentDefinition;
 
@@ -320,9 +384,11 @@ function createBuilderImpl<
         });
       }
 
-      // Process custom components to convert them to standard components
-      const processedComponents = await processDocumentComponents(
+      // Process custom components to convert them to standard components.
+      // Builds standard (fully expanded) and preserved (partial) trees in one pass.
+      const processed = await processDocumentComponents(
         mode.doc.children || [],
+        preserveSet,
         warnings,
         modedTheme
       );
@@ -330,7 +396,7 @@ function createBuilderImpl<
       // Create a new document definition with processed components
       const processedDocument: ReportComponentDefinition = {
         ...mode.doc,
-        children: processedComponents,
+        children: processed.standard,
       };
 
       // Normalize components (handle shorthand notations and nested structures)
@@ -350,10 +416,21 @@ function createBuilderImpl<
         services: state.services,
       });
 
+      // Build preservedDefinition iff the caller opted in. Reuses the same
+      // doc shell as standardDefinition but with partially-expanded children.
+      // Not normalized — preserved subtrees are meant to be "as authored".
+      const preservedDefinition = preserveSet
+        ? ({
+            ...mode.doc,
+            children: processed.preserved,
+          } as unknown as ExtendedReportComponent<TComponents>)
+        : undefined;
+
       return {
         document: generatedDocument,
         warnings: warnings.length > 0 ? warnings : null,
         standardDefinition: modedDoc,
+        preservedDefinition,
       };
     } catch (error) {
       if (state.debug) {
@@ -367,15 +444,17 @@ function createBuilderImpl<
    * Generate a document and return as buffer
    */
   async function generateBuffer(
-    document: ExtendedReportComponent<TComponents>
-  ): Promise<BufferGenerationResult> {
+    document: ExtendedReportComponent<TComponents>,
+    options?: GenerateOptions
+  ): Promise<BufferGenerationResult<TComponents>> {
     const {
       document: doc,
       warnings,
       standardDefinition,
-    } = await generate(document);
+      preservedDefinition,
+    } = await generate(document, options);
     const buffer = (await Packer.toBuffer(doc)) as Buffer;
-    return { buffer, warnings, standardDefinition };
+    return { buffer, warnings, standardDefinition, preservedDefinition };
   }
 
   /**
@@ -383,13 +462,37 @@ function createBuilderImpl<
    */
   async function generateFile(
     document: ExtendedReportComponent<TComponents>,
-    outputPath: string
-  ): Promise<FileGenerationResult> {
-    const { buffer, warnings, standardDefinition } =
-      await generateBuffer(document);
+    outputPath: string,
+    options?: GenerateFileOptions
+  ): Promise<FileGenerationResult<TComponents>> {
+    const { buffer, warnings, standardDefinition, preservedDefinition } =
+      await generateBuffer(document, options);
     const fs = await import('fs/promises');
     await fs.writeFile(outputPath, new Uint8Array(buffer));
-    return { warnings, standardDefinition };
+
+    let preservedOutputPath: string | undefined;
+    if (preservedDefinition !== undefined) {
+      const path = await import('path');
+      preservedOutputPath =
+        options?.preservedOutputPath ??
+        (() => {
+          const ext = path.extname(outputPath);
+          const base = ext ? outputPath.slice(0, -ext.length) : outputPath;
+          return `${base}-preserved.json`;
+        })();
+      await fs.writeFile(
+        preservedOutputPath,
+        JSON.stringify(preservedDefinition, null, 2),
+        'utf8'
+      );
+    }
+
+    return {
+      warnings,
+      standardDefinition,
+      preservedDefinition,
+      preservedOutputPath,
+    };
   }
 
   /**

--- a/packages/core-docx/src/plugin/createDocumentGenerator.ts
+++ b/packages/core-docx/src/plugin/createDocumentGenerator.ts
@@ -353,6 +353,7 @@ function createBuilderImpl<
       return {
         document: generatedDocument,
         warnings: warnings.length > 0 ? warnings : null,
+        standardDefinition: modedDoc,
       };
     } catch (error) {
       if (state.debug) {
@@ -368,9 +369,13 @@ function createBuilderImpl<
   async function generateBuffer(
     document: ExtendedReportComponent<TComponents>
   ): Promise<BufferGenerationResult> {
-    const { document: doc, warnings } = await generate(document);
+    const {
+      document: doc,
+      warnings,
+      standardDefinition,
+    } = await generate(document);
     const buffer = (await Packer.toBuffer(doc)) as Buffer;
-    return { buffer, warnings };
+    return { buffer, warnings, standardDefinition };
   }
 
   /**
@@ -380,10 +385,11 @@ function createBuilderImpl<
     document: ExtendedReportComponent<TComponents>,
     outputPath: string
   ): Promise<FileGenerationResult> {
-    const { buffer, warnings } = await generateBuffer(document);
+    const { buffer, warnings, standardDefinition } =
+      await generateBuffer(document);
     const fs = await import('fs/promises');
     await fs.writeFile(outputPath, new Uint8Array(buffer));
-    return { warnings };
+    return { warnings, standardDefinition };
   }
 
   /**
@@ -456,66 +462,6 @@ function createBuilderImpl<
     );
   }
 
-  /**
-   * Get the compiled standard components definition
-   */
-  async function getStandardComponentsDefinition(
-    document: ExtendedReportComponent<TComponents>
-  ): Promise<ReportComponentDefinition> {
-    try {
-      // Cast to ReportComponentDefinition for internal processing
-      const internalDocument = document as unknown as ReportComponentDefinition;
-
-      // Validate the document first
-      validateDocument(
-        internalDocument,
-        state.components as unknown as CustomComponent<TSchema>[]
-      );
-
-      // Resolve theme for plugin component rendering
-      const themeName = internalDocument.props.theme || 'minimal';
-      const docTheme = resolveDocumentTheme(themeName);
-
-      // Initialize warnings collector (not returned by this function)
-      const warnings: GenerationWarning[] = [];
-
-      // Export-mode pre-pass so callers inspecting the expanded components
-      // see substituted families when fonts.mode === 'substitute', matching
-      // the `generate()` path.
-      const mode = applyExportMode({
-        doc: internalDocument,
-        theme: docTheme,
-        fonts: state.fonts,
-      });
-      const modedTheme = mode.theme;
-
-      // Process custom components to convert them to standard components
-      const processedComponents = await processDocumentComponents(
-        mode.doc.children || [],
-        warnings,
-        modedTheme
-      );
-
-      // Create a new document definition with processed components
-      const processedDocument: ReportComponentDefinition = {
-        ...mode.doc,
-        children: processedComponents,
-      };
-
-      // Normalize components (handle shorthand notations and nested structures)
-      // We bypass JSON validation since we've already validated with custom schemas
-      const [finalReportComponent] = normalizeDocument(processedDocument);
-
-      // Return the normalized document with all custom components resolved to standard components
-      return finalReportComponent;
-    } catch (error) {
-      if (state.debug) {
-        console.error('Error getting standard components definition:', error);
-      }
-      throw error;
-    }
-  }
-
   // Return frozen builder object
   return Object.freeze({
     addComponent,
@@ -526,7 +472,6 @@ function createBuilderImpl<
     validate,
     generateSchema,
     exportSchema: exportSchemaToFile,
-    getStandardComponentsDefinition,
   });
 }
 

--- a/packages/core-docx/src/plugin/index.ts
+++ b/packages/core-docx/src/plugin/index.ts
@@ -45,6 +45,8 @@ export {
 export {
   type DocumentGenerator,
   type DocumentGeneratorBuilder,
+  type GenerateOptions,
+  type GenerateFileOptions,
   type GenerationResult,
   type BufferGenerationResult,
   type FileGenerationResult,
@@ -65,6 +67,7 @@ export {
   cleanComponentProps,
   ComponentValidationError,
   DuplicateComponentError,
+  UnknownPreservedComponentError,
   type ValidationError,
 } from './validation';
 

--- a/packages/core-docx/src/plugin/types.ts
+++ b/packages/core-docx/src/plugin/types.ts
@@ -115,37 +115,97 @@ export type InferCustomComponents<T> = T extends { customComponents: infer M }
 // ============================================================================
 
 /**
+ * Per-call options shared by generate/generateBuffer/generateFile.
+ *
+ * `preserveCustomComponents`: list of registered custom-component names whose
+ * `{ name, props, children? }` nodes should be kept verbatim in the returned
+ * `preservedDefinition`. The DOCX output is unaffected — it always renders
+ * the fully-expanded tree.
+ */
+export interface GenerateOptions {
+  preserveCustomComponents?: string[];
+}
+
+/**
+ * Per-call options for `generateFile` only — adds a sidecar-path override.
+ */
+export interface GenerateFileOptions extends GenerateOptions {
+  /**
+   * Override path for the preserved-tree sidecar JSON.
+   * Default: `<outputPath without extension>-preserved.json`.
+   * Only used when `preserveCustomComponents` is set.
+   */
+  preservedOutputPath?: string;
+}
+
+/**
  * Result of document generation
  */
-export interface GenerationResult {
+export interface GenerationResult<
+  TCustomComponents extends readonly CustomComponent<
+    any,
+    any,
+    any
+  >[] = readonly [],
+> {
   /** The generated document */
   document: Document;
   /** Warnings collected during generation, null if no warnings */
   warnings: GenerationWarning[] | null;
   /** Post-expansion, post-normalization standard JSON tree (custom plugins resolved). */
   standardDefinition: ReportComponentDefinition;
+  /**
+   * Partially-expanded tree honoring `preserveCustomComponents`.
+   * Present iff the option was passed. Custom-component subtrees listed in
+   * the option are kept verbatim (children not recursed); others are expanded.
+   */
+  preservedDefinition?: ExtendedReportComponent<TCustomComponents>;
 }
 
 /**
  * Result of buffer generation
  */
-export interface BufferGenerationResult {
+export interface BufferGenerationResult<
+  TCustomComponents extends readonly CustomComponent<
+    any,
+    any,
+    any
+  >[] = readonly [],
+> {
   /** The generated buffer */
   buffer: Buffer;
   /** Warnings collected during generation, null if no warnings */
   warnings: GenerationWarning[] | null;
   /** Post-expansion, post-normalization standard JSON tree (custom plugins resolved). */
   standardDefinition: ReportComponentDefinition;
+  /**
+   * Partially-expanded tree honoring `preserveCustomComponents`.
+   * Present iff the option was passed.
+   */
+  preservedDefinition?: ExtendedReportComponent<TCustomComponents>;
 }
 
 /**
  * Result of file generation
  */
-export interface FileGenerationResult {
+export interface FileGenerationResult<
+  TCustomComponents extends readonly CustomComponent<
+    any,
+    any,
+    any
+  >[] = readonly [],
+> {
   /** Warnings collected during generation, null if no warnings */
   warnings: GenerationWarning[] | null;
   /** Post-expansion, post-normalization standard JSON tree (custom plugins resolved). */
   standardDefinition: ReportComponentDefinition;
+  /**
+   * Partially-expanded tree honoring `preserveCustomComponents`.
+   * Present iff the option was passed; also written as a JSON sidecar file.
+   */
+  preservedDefinition?: ExtendedReportComponent<TCustomComponents>;
+  /** Resolved path of the preserved-tree sidecar, if written. */
+  preservedOutputPath?: string;
 }
 
 /**
@@ -170,17 +230,20 @@ export interface DocumentGenerator<
   >[] = readonly [],
 > {
   generate: (
-    document: ExtendedReportComponent<TCustomComponents>
-  ) => Promise<GenerationResult>;
+    document: ExtendedReportComponent<TCustomComponents>,
+    options?: GenerateOptions
+  ) => Promise<GenerationResult<TCustomComponents>>;
 
   generateBuffer: (
-    document: ExtendedReportComponent<TCustomComponents>
-  ) => Promise<BufferGenerationResult>;
+    document: ExtendedReportComponent<TCustomComponents>,
+    options?: GenerateOptions
+  ) => Promise<BufferGenerationResult<TCustomComponents>>;
 
   generateFile: (
     document: ExtendedReportComponent<TCustomComponents>,
-    outputPath: string
-  ) => Promise<FileGenerationResult>;
+    outputPath: string,
+    options?: GenerateFileOptions
+  ) => Promise<FileGenerationResult<TCustomComponents>>;
 
   getComponentNames: () => string[];
 

--- a/packages/core-docx/src/plugin/types.ts
+++ b/packages/core-docx/src/plugin/types.ts
@@ -122,6 +122,8 @@ export interface GenerationResult {
   document: Document;
   /** Warnings collected during generation, null if no warnings */
   warnings: GenerationWarning[] | null;
+  /** Post-expansion, post-normalization standard JSON tree (custom plugins resolved). */
+  standardDefinition: ReportComponentDefinition;
 }
 
 /**
@@ -132,6 +134,8 @@ export interface BufferGenerationResult {
   buffer: Buffer;
   /** Warnings collected during generation, null if no warnings */
   warnings: GenerationWarning[] | null;
+  /** Post-expansion, post-normalization standard JSON tree (custom plugins resolved). */
+  standardDefinition: ReportComponentDefinition;
 }
 
 /**
@@ -140,6 +144,8 @@ export interface BufferGenerationResult {
 export interface FileGenerationResult {
   /** Warnings collected during generation, null if no warnings */
   warnings: GenerationWarning[] | null;
+  /** Post-expansion, post-normalization standard JSON tree (custom plugins resolved). */
+  standardDefinition: ReportComponentDefinition;
 }
 
 /**
@@ -191,10 +197,6 @@ export interface DocumentGenerator<
       prettyPrint?: boolean;
     }
   ) => Promise<void>;
-
-  getStandardComponentsDefinition: (
-    document: ExtendedReportComponent<TCustomComponents>
-  ) => Promise<ReportComponentDefinition>;
 }
 
 /**

--- a/packages/core-docx/src/plugin/validation.ts
+++ b/packages/core-docx/src/plugin/validation.ts
@@ -17,6 +17,7 @@ import type { ValidationResult } from '@json-to-office/shared';
 export {
   DuplicateComponentError,
   ComponentValidationError,
+  UnknownPreservedComponentError,
 } from '@json-to-office/shared/plugin';
 
 /**

--- a/packages/jto-cli/src/format-adapter.ts
+++ b/packages/jto-cli/src/format-adapter.ts
@@ -32,8 +32,11 @@ interface GeneratorBuilder {
     valid: boolean;
     errors?: { path: string; message: string }[];
   };
-  generateBuffer(document: any): Promise<{ buffer: Buffer; warnings: any }>;
-  getStandardComponentsDefinition?: (document: any) => Promise<any>;
+  generateBuffer(document: any): Promise<{
+    buffer: Buffer;
+    warnings: any;
+    standardDefinition?: any;
+  }>;
 }
 
 export interface GeneratorOptions {
@@ -48,8 +51,10 @@ export interface GeneratorOptions {
 }
 
 export interface GeneratorResult {
-  generateBuffer: (document: any) => Promise<Buffer>;
-  getStandardComponentsDefinition?: (config: any) => Promise<any>;
+  generateBuffer: (document: any) => Promise<{
+    buffer: Buffer;
+    standardDefinition?: any;
+  }>;
   hasPlugins: boolean;
   pluginNames: string[];
 }
@@ -119,11 +124,13 @@ export class DocxFormatAdapter implements FormatAdapter {
           const docDefinition =
             typeof document === 'string' ? JSON.parse(document) : document;
           const customThemes = await this.loadCustomThemes(options);
-          return await core.generateBufferFromJson(docDefinition, {
+          const buffer = await core.generateBufferFromJson(docDefinition, {
             customThemes,
             services,
             fonts: options.fonts,
           });
+          // No plugin expansion: input JSON already is the standard definition.
+          return { buffer, standardDefinition: docDefinition };
         },
         hasPlugins: false,
         pluginNames: [],
@@ -158,12 +165,11 @@ export class DocxFormatAdapter implements FormatAdapter {
           );
         }
         const result = await generator.generateBuffer(docDefinition);
-        // generateBuffer returns BufferGenerationResult { buffer, warnings }
-        return result.buffer;
+        return {
+          buffer: result.buffer,
+          standardDefinition: result.standardDefinition,
+        };
       },
-      getStandardComponentsDefinition: generator.getStandardComponentsDefinition
-        ? (config: any) => generator.getStandardComponentsDefinition!(config)
-        : undefined,
       hasPlugins: true,
       pluginNames,
     };
@@ -387,11 +393,12 @@ export class PptxFormatAdapter implements FormatAdapter {
           const docDefinition =
             typeof document === 'string' ? JSON.parse(document) : document;
           const customThemes = await this.loadCustomThemes(options);
-          return await core.generateBufferFromJson(docDefinition, {
+          const buffer = await core.generateBufferFromJson(docDefinition, {
             customThemes,
             services,
             fonts: options.fonts,
           });
+          return { buffer, standardDefinition: docDefinition };
         },
         hasPlugins: false,
         pluginNames: [],
@@ -426,7 +433,10 @@ export class PptxFormatAdapter implements FormatAdapter {
           );
         }
         const result = await generator.generateBuffer(docDefinition);
-        return result.buffer;
+        return {
+          buffer: result.buffer,
+          standardDefinition: (result as any).standardDefinition,
+        };
       },
       hasPlugins: true,
       pluginNames,

--- a/packages/jto-cli/src/services/generator-factory.ts
+++ b/packages/jto-cli/src/services/generator-factory.ts
@@ -13,7 +13,10 @@ export class GeneratorFactory {
   }
 
   async createGenerator(options: GeneratorOptions = {}): Promise<{
-    generateBuffer: (document: ComponentDefinition | string) => Promise<Buffer>;
+    generateBuffer: (document: ComponentDefinition | string) => Promise<{
+      buffer: Buffer;
+      standardDefinition?: any;
+    }>;
     hasPlugins: boolean;
     pluginNames: string[];
   }> {
@@ -26,7 +29,8 @@ export class GeneratorFactory {
     options: GeneratorOptions = {}
   ): Promise<Buffer> {
     const generator = await this.createGenerator(options);
-    return await generator.generateBuffer(document);
+    const { buffer } = await generator.generateBuffer(document);
+    return buffer;
   }
 
   getPluginInfo(): {

--- a/packages/jto/src/server/routes/format.ts
+++ b/packages/jto/src/server/routes/format.ts
@@ -335,7 +335,10 @@ export function createFormatRouter(adapter: FormatAdapter) {
             ? JSON.parse(jsonDefinition)
             : jsonDefinition;
 
-        // If plugins are loaded, use plugin-aware generator to resolve custom components
+        // If plugins are loaded, use plugin-aware generator to resolve custom components.
+        // generate path runs render() side-effects; standardDefinition is surfaced
+        // as a by-product of generateBuffer, which is the only available expansion
+        // entry point now that getStandardComponentsDefinition has been removed.
         const registry = PluginRegistry.getInstance();
         if (registry.hasPlugins()) {
           const plugins = registry.getPlugins();
@@ -343,15 +346,13 @@ export function createFormatRouter(adapter: FormatAdapter) {
             theme: customThemes ? Object.values(customThemes)[0] : undefined,
           });
 
-          if (generatorResult.getStandardComponentsDefinition) {
-            const standardComponents =
-              await generatorResult.getStandardComponentsDefinition(config);
-            return c.json({
-              success: true,
-              data: standardComponents,
-              meta: { timestamp: new Date().toISOString(), requestId },
-            });
-          }
+          const { standardDefinition } =
+            await generatorResult.generateBuffer(config);
+          return c.json({
+            success: true,
+            data: standardDefinition ?? config,
+            meta: { timestamp: new Date().toISOString(), requestId },
+          });
         }
 
         // No plugins — config is already standard components

--- a/packages/jto/src/server/services/generator.ts
+++ b/packages/jto/src/server/services/generator.ts
@@ -412,7 +412,8 @@ export class GeneratorService {
         customThemes,
         fonts: fontOpts,
       });
-      buffer = await generator.generateBuffer(config);
+      const result = await generator.generateBuffer(config);
+      buffer = result.buffer;
     } else {
       buffer = await this.adapter.generateBuffer(config, {
         customThemes,

--- a/packages/jto/src/server/types/plugin.ts
+++ b/packages/jto/src/server/types/plugin.ts
@@ -12,12 +12,12 @@ export interface ValidationError {
 export interface BufferGenerationResult {
   buffer: Buffer;
   warnings: any[] | null;
+  standardDefinition?: any;
 }
 
 export interface PluginAwareGenerator {
   validate(config: any): ValidationResult;
   generateBuffer(config: any): Promise<BufferGenerationResult>;
-  getStandardComponentsDefinition(config: any): Promise<any>;
 }
 
 export function isCustomComponent(component: unknown): boolean {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -57,6 +57,7 @@ export {
   resolveComponentVersion,
   DuplicateComponentError,
   ComponentValidationError,
+  UnknownPreservedComponentError,
   validateCustomComponentProps,
   isValidationSuccess,
   getValidationSummary,

--- a/packages/shared/src/plugin/errors.ts
+++ b/packages/shared/src/plugin/errors.ts
@@ -22,6 +22,36 @@ export class DuplicateComponentError extends Error {
 }
 
 /**
+ * Error thrown when `preserveCustomComponents` lists names not registered on the generator.
+ *
+ * Listed names must match a component registered via `.addComponent()` — a typo is a
+ * programmer error, so we throw before generation starts.
+ */
+export class UnknownPreservedComponentError extends Error {
+  public readonly unknownNames: string[];
+  public readonly registeredNames: string[];
+  public readonly code = 'UNKNOWN_PRESERVED_COMPONENT';
+
+  constructor(unknownNames: string[], registeredNames: string[]) {
+    const unknownList = unknownNames.map((n) => `"${n}"`).join(', ');
+    const registeredList = registeredNames.length
+      ? registeredNames.map((n) => `"${n}"`).join(', ')
+      : '(none)';
+    super(
+      `preserveCustomComponents lists unregistered component name(s): ${unknownList}. ` +
+        `Registered components: ${registeredList}.`
+    );
+    this.name = 'UnknownPreservedComponentError';
+    this.unknownNames = [...unknownNames];
+    this.registeredNames = [...registeredNames];
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, UnknownPreservedComponentError);
+    }
+  }
+}
+
+/**
  * Custom validation error class
  */
 export class ComponentValidationError extends Error {

--- a/packages/shared/src/plugin/index.ts
+++ b/packages/shared/src/plugin/index.ts
@@ -13,7 +13,11 @@ export {
 export { resolveComponentVersion } from './version-resolver';
 
 // Errors
-export { DuplicateComponentError, ComponentValidationError } from './errors';
+export {
+  DuplicateComponentError,
+  ComponentValidationError,
+  UnknownPreservedComponentError,
+} from './errors';
 
 // Validation
 export {


### PR DESCRIPTION
## Summary

Two changes against `core-docx`:

- **`preserveCustomComponents` per-call option** on `generate` / `generateBuffer` / `generateFile`. Listed custom-component names are kept verbatim (un-expanded) in a new `preservedDefinition` result field. `standardDefinition` and the rendered DOCX are unchanged. `generateFile` also writes a JSON sidecar (default `<out>-preserved.json`, override via `preservedOutputPath`). Unknown names throw `UnknownPreservedComponentError` before generation. Preserved subtrees are kept entirely as authored — no recursion into their children, even if those contain non-preserved customs or standard nodes. `render()` still runs for every custom (including preserved), so the docx pipeline is unaffected.
- **(BREAKING) Surface `standardDefinition` from generate**. `generate` / `generateBuffer` / `generateFile` now return the post-expansion JSON tree as `standardDefinition` (free — same object the renderer uses). The standalone `getStandardComponentsDefinition` is removed; previously calling both ran each plugin's `render()` twice, duplicating side effects (e.g. external API hits). Adapter `generateBuffer` returns `{ buffer, standardDefinition }`.

Targets: LLM-handoff / alternative-renderer use cases that want to receive the user's authored JSON for some components rather than pre-rendered tables/blobs.

## Test plan

- [x] All 392 existing core-docx tests pass
- [x] 10 new tests in `preserved-components.test.ts` cover: opt-out (omitted/empty array), partial expansion, verbatim children rule, unknown-name validation, nested-in-section, sidecar default + override + omitted, `generateBuffer` return shape
- [x] `tsc --noEmit` clean across all workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)