### PR TITLE
Fix event loop leak in MemoryCache cleanup timer

### DIFF
--- a/.changeset/fix-memory-cache-timer-leak.md
+++ b/.changeset/fix-memory-cache-timer-leak.md
@@ -1,0 +1,10 @@
+---
+'@json-to-office/shared': patch
+---
+
+fix(shared): unref `MemoryCache` cleanup timer so the CLI exits promptly
+
+The component-cache cleanup `setInterval` (5-minute period) kept the Node
+event loop alive after work finished, making `jto-cli docx generate` hang
+for up to 5 minutes per run. The interval is now `.unref()`-ed so it no
+longer blocks process exit.

--- a/packages/jto-cli/src/commands/__tests__/generate-exit.test.ts
+++ b/packages/jto-cli/src/commands/__tests__/generate-exit.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, writeFileSync, existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, '../../..');
+const repoRoot = path.resolve(packageRoot, '../..');
+
+// Minimal docx fixture that exercises rendering without external font fetches.
+const fixture = {
+  name: 'docx',
+  props: { theme: 'minimal' },
+  children: [
+    {
+      name: 'section',
+      children: [
+        { name: 'heading', props: { level: 1, text: 'Exit test' } },
+        { name: 'paragraph', props: { text: 'Hello.' } },
+      ],
+    },
+  ],
+};
+
+// Regression guard for the MemoryCache cleanup setInterval leak that kept
+// `jto-cli docx generate` alive for ~5 minutes after the buffer was written
+// (packages/shared/src/cache/memory-cache.ts startCleanupTimer).
+describe('jto-cli docx generate exits promptly', () => {
+  it('exits within 30s of writing the output file', async () => {
+    const cliPath = path.join(packageRoot, 'dist', 'cli.js');
+    if (!existsSync(cliPath)) {
+      // Tests don't auto-build the package; build is `pnpm --filter @json-to-office/jto-cli build`.
+      console.warn(`Skipping: ${cliPath} not built`);
+      return;
+    }
+
+    const tmp = mkdtempSync(path.join(os.tmpdir(), 'jto-cli-exit-'));
+    const inputPath = path.join(tmp, 'fixture.json');
+    const outputPath = path.join(tmp, 'out.docx');
+    writeFileSync(inputPath, JSON.stringify(fixture));
+
+    const child = spawn(
+      process.execPath,
+      [
+        cliPath,
+        'docx',
+        'generate',
+        inputPath,
+        '-o',
+        outputPath,
+        '--no-google-fonts',
+      ],
+      { cwd: repoRoot, stdio: 'pipe' }
+    );
+
+    let stderr = '';
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.stdout.on('data', () => {});
+
+    const start = Date.now();
+    const exitCode: number = await new Promise((resolve, reject) => {
+      const killTimer = setTimeout(() => {
+        child.kill('SIGKILL');
+        reject(
+          new Error(
+            `jto-cli did not exit within 30s (likely a leaked handle keeping the event loop alive). stderr:\n${stderr}`
+          )
+        );
+      }, 30_000);
+      child.on('exit', (code) => {
+        clearTimeout(killTimer);
+        resolve(code ?? -1);
+      });
+      child.on('error', (err) => {
+        clearTimeout(killTimer);
+        reject(err);
+      });
+    });
+
+    expect(exitCode, `stderr:\n${stderr}`).toBe(0);
+    expect(existsSync(outputPath)).toBe(true);
+    // Sanity: the example renders in well under a second on the build machine;
+    // anything close to 30s indicates the hang has regressed.
+    expect(Date.now() - start).toBeLessThan(30_000);
+  }, 35_000);
+});

--- a/packages/jto-cli/src/commands/__tests__/generate-exit.test.ts
+++ b/packages/jto-cli/src/commands/__tests__/generate-exit.test.ts
@@ -32,7 +32,14 @@ describe('jto-cli docx generate exits promptly', () => {
   it('exits within 30s of writing the output file', async () => {
     const cliPath = path.join(packageRoot, 'dist', 'cli.js');
     if (!existsSync(cliPath)) {
-      // Tests don't auto-build the package; build is `pnpm --filter @json-to-office/jto-cli build`.
+      // In CI, dist/cli.js must exist — turbo's test task depends on ^build,
+      // so a missing artifact is a real failure, not a skip. Locally we still
+      // tolerate it (warn + return) so `pnpm test` works before `pnpm build`.
+      if (process.env.CI) {
+        throw new Error(
+          `jto-cli artifact missing at ${cliPath}; run \`pnpm --filter @json-to-office/jto-cli build\` first`
+        );
+      }
       console.warn(`Skipping: ${cliPath} not built`);
       return;
     }

--- a/packages/shared/src/cache/memory-cache.ts
+++ b/packages/shared/src/cache/memory-cache.ts
@@ -46,7 +46,8 @@ export class MemoryCache extends ComponentCacheManager {
     if (!node) {
       // Try to get component name from our mapping first, then from the key itself
       const componentName =
-        this.keyToComponentName.get(key) || this.extractComponentNameFromKey(key);
+        this.keyToComponentName.get(key) ||
+        this.extractComponentNameFromKey(key);
       this.updateMissStats(key, componentName);
       return undefined;
     }
@@ -137,7 +138,9 @@ export class MemoryCache extends ComponentCacheManager {
     this.stats.totalSize = this.currentSize;
 
     // Update component stats
-    const componentStats = this.stats.componentStats.get(node.value.componentName);
+    const componentStats = this.stats.componentStats.get(
+      node.value.componentName
+    );
     if (componentStats && componentStats.entries > 0) {
       componentStats.entries--;
     }
@@ -273,6 +276,10 @@ export class MemoryCache extends ComponentCacheManager {
       },
       (this.config.memory?.cleanupInterval || 300) * 1000
     );
+    // Opportunistic housekeeping should never keep the event loop alive — a
+    // short-lived CLI run shouldn't wait 5 minutes for the next sweep before
+    // exiting (#hang-on-exit).
+    this.cleanupTimer.unref?.();
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes a regression where `jto-cli docx generate` would hang for ~5 minutes after writing the output file due to a leaked `setInterval` handle in the MemoryCache cleanup timer keeping the event loop alive.

The fix calls `unref()` on the cleanup timer to allow the process to exit normally when there are no other active handles, while still performing opportunistic cache cleanup if the process remains running longer.

## Changes

- **packages/shared/src/cache/memory-cache.ts**: Call `unref()` on the cleanup timer to prevent it from keeping the event loop alive
- **packages/jto-cli/src/commands/__tests__/generate-exit.test.ts**: Added regression test that verifies the CLI exits within 30 seconds of writing output

## Checklist

- [ ] Added a changeset (`pnpm changeset`)
- [ ] Tests pass (`pnpm check`)
- [ ] Docs updated (if applicable)

https://claude.ai/code/session_011HkZR1HsfbQQrycZUyxotb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test verifying the CLI document-generation command exits promptly after writing output, enforcing a 30s watchdog and capturing diagnostics on failure.

* **Chores**
  * Prevented the in-memory cache cleanup timer from keeping the process alive (now unref()'d), improving shutdown so CLI commands exit promptly; added a changeset documenting the fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wiseair-srl/json-to-office/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->