### PR TITLE
feat(docx): bump docx 9.5.1 → 9.7.0; surface TOC cached entries, table look, paragraph indent

### DIFF
--- a/.changeset/bump-docx-9-7-0-with-new-fields.md
+++ b/.changeset/bump-docx-9-7-0-with-new-fields.md
@@ -1,0 +1,14 @@
+---
+'@json-to-office/core-docx': minor
+'@json-to-office/shared-docx': minor
+'@json-to-office/json-to-docx': minor
+---
+
+feat(docx): bump docx to 9.7.0; surface TOC cached entries, table look, and paragraph indent
+
+- Bump `docx` peer/dep from 9.5.1 to 9.7.0 across core-docx, shared-docx, and json-to-docx (plus pnpm override).
+- TOC: add `cachedEntries` + `beginDirty` props. When `cachedEntries` are supplied, Word displays the TOC immediately on open instead of the "right-click to update field" placeholder.
+- Table: add `tableLook` block (`firstRow`, `lastRow`, `firstColumn`, `lastColumn`, `bandedRows`, `bandedColumns`) for Word's conditional table formatting. Internally inverted to docx's `noHBand`/`noVBand`.
+- Paragraph: add `indent` block (`left`, `right`, `firstLine`, `hanging`, `firstLineChars`). `firstLineChars` is the CJK-friendly char-grid companion to `firstLine`.
+
+All new fields are optional — no breaking changes to existing `.docx.json` documents.

--- a/.changeset/bump-docx-9-7-0-with-new-fields.md
+++ b/.changeset/bump-docx-9-7-0-with-new-fields.md
@@ -4,11 +4,11 @@
 '@json-to-office/json-to-docx': minor
 ---
 
-feat(docx): bump docx to 9.7.0; surface TOC cached entries, table look, and paragraph indent
+feat(docx): bump docx to 9.7.0; auto-populate TOC, surface table look + paragraph indent
 
 - Bump `docx` peer/dep from 9.5.1 to 9.7.0 across core-docx, shared-docx, and json-to-docx (plus pnpm override).
-- TOC: add `cachedEntries` + `beginDirty` props. When `cachedEntries` are supplied, Word displays the TOC immediately on open instead of the "right-click to update field" placeholder.
+- TOC: cached entries are now auto-populated from the document's headings during the structure pass. Word displays the TOC body immediately on open instead of the "right-click to update field" placeholder, and (with `beginDirty` defaulting to false) the macOS "update fields?" popup no longer fires. JSON authors only set `beginDirty: true` if they want Word to prompt for a refresh on open.
 - Table: add `tableLook` block (`firstRow`, `lastRow`, `firstColumn`, `lastColumn`, `bandedRows`, `bandedColumns`) for Word's conditional table formatting. Internally inverted to docx's `noHBand`/`noVBand`.
-- Paragraph: add `indent` block (`left`, `right`, `firstLine`, `hanging`, `firstLineChars`). `firstLineChars` is the CJK-friendly char-grid companion to `firstLine`.
+- Paragraph: add `indent` block (`left`, `right`, `firstLine`, `hanging`, `firstLineChars`). `firstLine` and `hanging` are mutually exclusive (schema-enforced via union). `firstLineChars` is the CJK-friendly char-grid companion to `firstLine`.
 
 All new fields are optional — no breaking changes to existing `.docx.json` documents.

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "packageManager": "pnpm@9.15.9",
   "pnpm": {
     "overrides": {
-      "docx": "9.5.1",
+      "docx": "9.7.0",
       "typescript": "5.3.3",
       "eslint": "8.56.0",
       "prettier": "3.2.4",

--- a/packages/core-docx/package.json
+++ b/packages/core-docx/package.json
@@ -41,7 +41,7 @@
     "probe-image-size": "7.2.3"
   },
   "peerDependencies": {
-    "docx": "9.5.1"
+    "docx": "9.7.0"
   },
   "devDependencies": {
     "@types/adm-zip": "0.5.7",

--- a/packages/core-docx/src/components/__tests__/paragraph.test.ts
+++ b/packages/core-docx/src/components/__tests__/paragraph.test.ts
@@ -381,6 +381,33 @@ describe('components/text', () => {
       });
     });
 
+    it('should forward indent (twips + firstLineChars) into the paragraph XML', () => {
+      const component: ComponentDefinition = {
+        name: 'paragraph',
+        props: {
+          text: 'Indented body text',
+          indent: {
+            left: 720, // 0.5"
+            firstLine: 360,
+            firstLineChars: 200, // 2 chars (CJK)
+          },
+        },
+      };
+
+      const result = renderParagraphComponent(
+        component,
+        createMockTheme(),
+        'minimal'
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(Paragraph);
+
+      const serialized = JSON.stringify(result[0]);
+      expect(serialized).toContain('firstLineChars');
+      expect(serialized).toContain('firstLine');
+      expect(serialized).toContain('720');
+    });
+
     it('should handle floating text without wrap config', () => {
       const component: ComponentDefinition = {
         name: 'paragraph',

--- a/packages/core-docx/src/components/__tests__/table.test.ts
+++ b/packages/core-docx/src/components/__tests__/table.test.ts
@@ -231,6 +231,35 @@ describe('components/table', () => {
       expect(result[0]).toBeInstanceOf(Table);
     });
 
+    it('should forward tableLook flags into the table properties XML', async () => {
+      const baseConfig = createTableConfig(['H1', 'H2'], [['A', 'B']]);
+      const component: ComponentDefinition = {
+        name: 'table',
+        props: {
+          ...baseConfig,
+          tableLook: {
+            firstRow: true,
+            lastRow: false,
+            bandedRows: true,
+            bandedColumns: false,
+          },
+        },
+      };
+
+      const result = await renderTableComponent(
+        component,
+        {} as ThemeConfig,
+        'minimal'
+      );
+      expect(result[0]).toBeInstanceOf(Table);
+
+      const serialized = JSON.stringify(result[0]);
+      expect(serialized).toContain('firstRow');
+      // bandedRows → noHBand:false (banding enabled); bandedColumns false → noVBand:true
+      expect(serialized).toContain('noHBand');
+      expect(serialized).toContain('noVBand');
+    });
+
     it('should handle complex data types in cells', async () => {
       const component: ComponentDefinition = {
         name: 'table',

--- a/packages/core-docx/src/components/__tests__/toc-scope.test.ts
+++ b/packages/core-docx/src/components/__tests__/toc-scope.test.ts
@@ -454,17 +454,17 @@ describe('TOC Scope Integration', () => {
       expect(result).toHaveLength(2);
     });
 
-    it('should embed cachedEntries so Word shows the TOC immediately on open', () => {
-      const component: TocComponentDefinition = {
+    it('should embed auto-injected cached entries when present on the component', () => {
+      // Simulate what injectTocCachedEntries does during the structure pass:
+      // attach a private resolved list on the component.
+      const component = {
         name: 'toc',
-        props: {
-          title: 'Contents',
-          cachedEntries: [
-            { title: 'Introduction', level: 1, page: 1 },
-            { title: 'Background', level: 2, page: 2, href: 'bg' },
-          ],
-        },
-      };
+        props: { title: 'Contents' },
+        __resolvedCachedEntries: [
+          { title: 'Introduction', level: 1 },
+          { title: 'Background', level: 2 },
+        ],
+      } as unknown as TocComponentDefinition;
 
       const result = renderTocComponent(
         component,
@@ -475,21 +475,19 @@ describe('TOC Scope Integration', () => {
       const toc = result[1] as TableOfContents;
       expect(toc).toBeInstanceOf(TableOfContents);
 
-      // Serialize the TOC element and confirm the cached entry titles made it
-      // into the body XML — without this, Word renders "right-click to update".
+      // The cached titles must appear in the serialized field body so Word
+      // displays them on first open instead of "right-click to update".
       const serialized = JSON.stringify(toc);
       expect(serialized).toContain('Introduction');
       expect(serialized).toContain('Background');
     });
 
-    it('should respect beginDirty=true alongside cachedEntries', () => {
-      const component: TocComponentDefinition = {
+    it('should default beginDirty to false (no Word "update fields?" popup)', () => {
+      const component = {
         name: 'toc',
-        props: {
-          cachedEntries: [{ title: 'Only Entry', level: 1 }],
-          beginDirty: true,
-        },
-      };
+        props: {},
+        __resolvedCachedEntries: [{ title: 'Only Entry', level: 1 }],
+      } as unknown as TocComponentDefinition;
 
       const result = renderTocComponent(
         component,
@@ -497,8 +495,29 @@ describe('TOC Scope Integration', () => {
         mockContext
       );
 
-      expect(result[0]).toBeInstanceOf(TableOfContents);
-      expect(JSON.stringify(result[0])).toContain('Only Entry');
+      // The dirty bit on the begin <w:fldChar> is what triggers the popup.
+      // Serialized as `"dirty":{"key":"w:dirty","value":true}` when set;
+      // with our default, the value pair should be absent.
+      const serialized = JSON.stringify(result[0]);
+      expect(serialized).toContain('Only Entry');
+      expect(serialized).not.toContain('"key":"w:dirty","value":true');
+    });
+
+    it('should pass beginDirty=true through when user opts in', () => {
+      const component = {
+        name: 'toc',
+        props: { beginDirty: true },
+        __resolvedCachedEntries: [{ title: 'Entry', level: 1 }],
+      } as unknown as TocComponentDefinition;
+
+      const result = renderTocComponent(
+        component,
+        createMockTheme(),
+        mockContext
+      );
+
+      const serialized = JSON.stringify(result[0]);
+      expect(serialized).toContain('"key":"w:dirty","value":true');
     });
 
     it('should handle multiple TOCs in same section', async () => {

--- a/packages/core-docx/src/components/__tests__/toc-scope.test.ts
+++ b/packages/core-docx/src/components/__tests__/toc-scope.test.ts
@@ -454,6 +454,53 @@ describe('TOC Scope Integration', () => {
       expect(result).toHaveLength(2);
     });
 
+    it('should embed cachedEntries so Word shows the TOC immediately on open', () => {
+      const component: TocComponentDefinition = {
+        name: 'toc',
+        props: {
+          title: 'Contents',
+          cachedEntries: [
+            { title: 'Introduction', level: 1, page: 1 },
+            { title: 'Background', level: 2, page: 2, href: 'bg' },
+          ],
+        },
+      };
+
+      const result = renderTocComponent(
+        component,
+        createMockTheme(),
+        mockContext
+      );
+
+      const toc = result[1] as TableOfContents;
+      expect(toc).toBeInstanceOf(TableOfContents);
+
+      // Serialize the TOC element and confirm the cached entry titles made it
+      // into the body XML — without this, Word renders "right-click to update".
+      const serialized = JSON.stringify(toc);
+      expect(serialized).toContain('Introduction');
+      expect(serialized).toContain('Background');
+    });
+
+    it('should respect beginDirty=true alongside cachedEntries', () => {
+      const component: TocComponentDefinition = {
+        name: 'toc',
+        props: {
+          cachedEntries: [{ title: 'Only Entry', level: 1 }],
+          beginDirty: true,
+        },
+      };
+
+      const result = renderTocComponent(
+        component,
+        createMockTheme(),
+        mockContext
+      );
+
+      expect(result[0]).toBeInstanceOf(TableOfContents);
+      expect(JSON.stringify(result[0])).toContain('Only Entry');
+    });
+
     it('should handle multiple TOCs in same section', async () => {
       const sectionWithMultipleTocs: SectionComponentDefinition = {
         name: 'section',

--- a/packages/core-docx/src/components/paragraph.ts
+++ b/packages/core-docx/src/components/paragraph.ts
@@ -201,6 +201,8 @@ export function renderParagraphComponent(
     keepLines: resolvedConfig.keepLines,
     // Pass bookmark ID for internal linking
     bookmarkId: resolvedConfig.id,
+    // Pass paragraph indent (twips, plus CJK firstLineChars)
+    indent: resolvedConfig.indent,
   });
 
   return [text];

--- a/packages/core-docx/src/components/table.ts
+++ b/packages/core-docx/src/components/table.ts
@@ -61,6 +61,15 @@ type CellDefaults = {
   height?: number;
 };
 
+type TableLook = {
+  firstRow?: boolean;
+  lastRow?: boolean;
+  firstColumn?: boolean;
+  lastColumn?: boolean;
+  bandedRows?: boolean;
+  bandedColumns?: boolean;
+};
+
 type TableConfig = {
   borderColor?: BorderColor;
   borderSize?: BorderSize;
@@ -81,6 +90,7 @@ type TableConfig = {
   keepInOnePage?: boolean;
   keepNext?: boolean;
   repeatHeaderOnPageBreak?: boolean;
+  tableLook?: TableLook;
 };
 
 /**

--- a/packages/core-docx/src/components/table.ts
+++ b/packages/core-docx/src/components/table.ts
@@ -145,6 +145,8 @@ export async function renderTableComponent(
           content: row[colIndex] || '',
         })),
       })),
+      // Preserve tableLook through legacy-shape conversion
+      ...(rawConfig.tableLook && { tableLook: rawConfig.tableLook }),
     };
 
     result.push(await createTable(config.columns, config, theme, themeName));

--- a/packages/core-docx/src/components/toc/index.ts
+++ b/packages/core-docx/src/components/toc/index.ts
@@ -14,6 +14,10 @@ import type { ITableOfContentsOptions } from 'docx';
 import type { TocProps } from '@json-to-office/shared-docx';
 import type { ThemeConfig } from '../../styles';
 import type { RenderContext } from '../../types';
+import {
+  RESOLVED_TOC_ENTRIES_FIELD,
+  type ResolvedTocEntry,
+} from '../../utils/tocCachedEntries';
 
 export interface TocComponentDefinition {
   name: 'toc';
@@ -269,16 +273,25 @@ export function renderTocComponent(
       : { entryAndPageNumberSeparator: '\t' }), // default to tab
   };
 
-  // Pre-rendered entries make Word display the TOC immediately on open.
-  // Without them, Word shows the "right-click to update field" placeholder.
-  const cachedEntries = componentProps.cachedEntries?.length
-    ? componentProps.cachedEntries.map((entry) => ({
-        title: entry.title,
-        level: entry.level,
-        ...(entry.page !== undefined && { page: entry.page }),
-        ...(entry.href !== undefined && { href: entry.href }),
-      }))
-    : undefined;
+  // Pre-rendered entries are auto-populated by injectTocCachedEntries
+  // during the structure pass. They live on a private field so they
+  // never round-trip through the user-facing schema.
+  const resolvedEntries = (component as unknown as Record<string, unknown>)[
+    RESOLVED_TOC_ENTRIES_FIELD
+  ] as ResolvedTocEntry[] | undefined;
+
+  const cachedEntries =
+    resolvedEntries && resolvedEntries.length > 0
+      ? resolvedEntries.map((entry) => ({
+          title: entry.title,
+          level: entry.level,
+        }))
+      : undefined;
+
+  // Default beginDirty to false when we have a fresh cache. That kills
+  // the macOS Word "update fields?" popup. Users can opt back in by
+  // setting `beginDirty: true` explicitly.
+  const beginDirty = componentProps.beginDirty ?? false;
 
   // Insert TOC as a top-level block (not wrapped in a Paragraph).
   // Wrapping TableOfContents inside a Paragraph produces an empty SDT above
@@ -287,9 +300,7 @@ export function renderTocComponent(
     new TableOfContents(componentProps.title ?? 'Table of Contents', {
       ...tocOptions,
       ...(cachedEntries && { cachedEntries }),
-      ...(componentProps.beginDirty !== undefined && {
-        beginDirty: componentProps.beginDirty,
-      }),
+      beginDirty,
     })
   );
 

--- a/packages/core-docx/src/components/toc/index.ts
+++ b/packages/core-docx/src/components/toc/index.ts
@@ -186,10 +186,10 @@ export function renderTocComponent(
         Object.prototype.hasOwnProperty.call(theme.styles, styleId);
       const styleDisplayName = isCustomStyle
         ? styleId
-          .replace(/([A-Z])/g, ' $1')
-          .replace(/[-_]+/g, ' ')
-          .replace(/\s+/g, ' ')
-          .trim()
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/[-_]+/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim()
         : styleId; // If it's not a custom style key, assume it's already a display name
 
       stylesWithLevels.push(
@@ -262,18 +262,35 @@ export function renderTocComponent(
     // Boolean: true = "\t" (tab, default), false = " " (space)
     ...(componentProps.numberSeparator !== undefined
       ? {
-        entryAndPageNumberSeparator: componentProps.numberSeparator
-          ? '\t'
-          : ' ',
-      }
+          entryAndPageNumberSeparator: componentProps.numberSeparator
+            ? '\t'
+            : ' ',
+        }
       : { entryAndPageNumberSeparator: '\t' }), // default to tab
   };
+
+  // Pre-rendered entries make Word display the TOC immediately on open.
+  // Without them, Word shows the "right-click to update field" placeholder.
+  const cachedEntries = componentProps.cachedEntries?.length
+    ? componentProps.cachedEntries.map((entry) => ({
+        title: entry.title,
+        level: entry.level,
+        ...(entry.page !== undefined && { page: entry.page }),
+        ...(entry.href !== undefined && { href: entry.href }),
+      }))
+    : undefined;
 
   // Insert TOC as a top-level block (not wrapped in a Paragraph).
   // Wrapping TableOfContents inside a Paragraph produces an empty SDT above
   // the actual entries in Word. Adding directly avoids that artifact.
   paragraphs.push(
-    new TableOfContents(componentProps.title ?? 'Table of Contents', tocOptions)
+    new TableOfContents(componentProps.title ?? 'Table of Contents', {
+      ...tocOptions,
+      ...(cachedEntries && { cachedEntries }),
+      ...(componentProps.beginDirty !== undefined && {
+        beginDirty: componentProps.beginDirty,
+      }),
+    })
   );
 
   // Do not append an extra empty paragraph after TOC to avoid

--- a/packages/core-docx/src/core/content.ts
+++ b/packages/core-docx/src/core/content.ts
@@ -144,6 +144,15 @@ export interface TextOptions {
   keepNext?: boolean;
   // Keep all lines of paragraph together
   keepLines?: boolean;
+  // Paragraph indent. left/right/firstLine/hanging in twips (1/20 pt);
+  // firstLineChars in hundredths of a character (CJK-friendly).
+  indent?: {
+    left?: number;
+    right?: number;
+    firstLine?: number;
+    hanging?: number;
+    firstLineChars?: number;
+  };
 }
 
 export interface ImageOptions {
@@ -340,6 +349,7 @@ export function createText(
     ...(frameOptions && { frame: frameOptions }),
     ...(options.keepNext !== undefined && { keepNext: options.keepNext }),
     ...(options.keepLines !== undefined && { keepLines: options.keepLines }),
+    ...(options.indent && { indent: options.indent }),
   });
 }
 
@@ -929,6 +939,15 @@ type HideBorders =
       insideVertical?: boolean;
     };
 
+type TableLook = {
+  firstRow?: boolean;
+  lastRow?: boolean;
+  firstColumn?: boolean;
+  lastColumn?: boolean;
+  bandedRows?: boolean;
+  bandedColumns?: boolean;
+};
+
 type TableConfig = {
   borderColor?: BorderColor;
   borderSize?: BorderSize;
@@ -950,6 +969,7 @@ type TableConfig = {
   keepInOnePage?: boolean;
   keepNext?: boolean;
   repeatHeaderOnPageBreak?: boolean;
+  tableLook?: TableLook;
 };
 
 export async function createTable(
@@ -2022,7 +2042,26 @@ export async function createTable(
     layout: TableLayoutType.FIXED,
     columnWidths: columnWidths,
     rows: [headerRow, ...dataRows],
+    ...(tableConfig.tableLook && {
+      tableLook: toDocxTableLook(tableConfig.tableLook),
+    }),
   });
+}
+
+/**
+ * Map our user-facing tableLook config to docx's ITableLookOptions.
+ * Note the inversion: docx expects `noHBand` / `noVBand` (negated banding),
+ * we expose the positive `bandedRows` / `bandedColumns` for clarity.
+ */
+function toDocxTableLook(look: TableLook) {
+  return {
+    ...(look.firstRow !== undefined && { firstRow: look.firstRow }),
+    ...(look.lastRow !== undefined && { lastRow: look.lastRow }),
+    ...(look.firstColumn !== undefined && { firstColumn: look.firstColumn }),
+    ...(look.lastColumn !== undefined && { lastColumn: look.lastColumn }),
+    ...(look.bandedRows !== undefined && { noHBand: !look.bandedRows }),
+    ...(look.bandedColumns !== undefined && { noVBand: !look.bandedColumns }),
+  };
 }
 
 /**

--- a/packages/core-docx/src/core/structure.ts
+++ b/packages/core-docx/src/core/structure.ts
@@ -18,6 +18,7 @@ import {
   resolveComponentDefaults,
 } from '../styles/utils/resolveComponentTree';
 import { mergeWithDefaults } from '../styles/utils/componentDefaults';
+import { injectTocCachedEntries } from '../utils/tocCachedEntries';
 
 export interface ProcessedDocument {
   metadata: DocumentMetadata;
@@ -104,6 +105,11 @@ export async function processDocument(
 
   // Extract sections from components
   const sections = await extractSections(resolvedChildren, context);
+
+  // Auto-populate TOC cached entries from the headings in scope. Doing
+  // this before render means Word displays the TOC body immediately on
+  // open and skips the "update fields?" popup.
+  injectTocCachedEntries(sections, effectiveTheme);
 
   return {
     metadata,

--- a/packages/core-docx/src/utils/__tests__/tocCachedEntries.test.ts
+++ b/packages/core-docx/src/utils/__tests__/tocCachedEntries.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the auto-injecting TOC cached-entries pre-pass.
+ * Exercises injectTocCachedEntries through processDocument so we cover
+ * the same path the generator runs in production.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { processDocument } from '../../core/structure';
+import {
+  createMockTheme,
+  TEST_THEME_NAME,
+} from '../../components/__tests__/helpers';
+import type { ReportComponentDefinition } from '../../types';
+import {
+  RESOLVED_TOC_ENTRIES_FIELD,
+  type ResolvedTocEntry,
+} from '../tocCachedEntries';
+
+function readEntries(component: unknown): ResolvedTocEntry[] | undefined {
+  return (component as Record<string, unknown>)[RESOLVED_TOC_ENTRIES_FIELD] as
+    | ResolvedTocEntry[]
+    | undefined;
+}
+
+describe('utils/tocCachedEntries', () => {
+  it('auto-collects all headings for a document-scoped TOC', async () => {
+    const doc: ReportComponentDefinition = {
+      name: 'docx',
+      props: { theme: TEST_THEME_NAME as never },
+      children: [
+        { name: 'toc', props: { title: 'Contents', scope: 'document' } },
+        { name: 'heading', props: { text: 'Intro', level: 1 } },
+        { name: 'heading', props: { text: 'Method', level: 2 } },
+        { name: 'heading', props: { text: 'Results', level: 1 } },
+      ],
+    } as unknown as ReportComponentDefinition;
+
+    const { sections } = await processDocument(
+      doc,
+      createMockTheme(),
+      TEST_THEME_NAME
+    );
+
+    // Find the TOC component in the flattened sections.
+    const toc = sections
+      .flatMap((s) => s.components)
+      .find((c) => c.name === 'toc');
+    expect(toc).toBeDefined();
+
+    const entries = readEntries(toc);
+    expect(entries).toEqual([
+      { title: 'Intro', level: 1 },
+      { title: 'Method', level: 2 },
+      { title: 'Results', level: 1 },
+    ]);
+  });
+
+  it('filters out headings outside the depth window', async () => {
+    const doc: ReportComponentDefinition = {
+      name: 'docx',
+      props: { theme: TEST_THEME_NAME as never },
+      children: [
+        {
+          name: 'toc',
+          props: { scope: 'document', depth: { from: 1, to: 1 } },
+        },
+        { name: 'heading', props: { text: 'In', level: 1 } },
+        { name: 'heading', props: { text: 'Out', level: 2 } },
+      ],
+    } as unknown as ReportComponentDefinition;
+
+    const { sections } = await processDocument(
+      doc,
+      createMockTheme(),
+      TEST_THEME_NAME
+    );
+    const toc = sections
+      .flatMap((s) => s.components)
+      .find((c) => c.name === 'toc');
+    const entries = readEntries(toc);
+    expect(entries).toEqual([{ title: 'In', level: 1 }]);
+  });
+
+  it('section-scoped TOC only picks up headings in its own section, excluding the section title', async () => {
+    const doc: ReportComponentDefinition = {
+      name: 'docx',
+      props: { theme: TEST_THEME_NAME as never },
+      children: [
+        {
+          name: 'section',
+          props: { title: 'Section A', level: 1 },
+          children: [
+            { name: 'toc', props: { scope: 'section' } },
+            { name: 'heading', props: { text: 'A-Sub', level: 2 } },
+          ],
+        },
+        {
+          name: 'section',
+          props: { title: 'Section B', level: 1 },
+          children: [{ name: 'heading', props: { text: 'B-Sub', level: 2 } }],
+        },
+      ],
+    } as unknown as ReportComponentDefinition;
+
+    const { sections } = await processDocument(
+      doc,
+      createMockTheme(),
+      TEST_THEME_NAME
+    );
+
+    // First section owns the TOC; it should see only "A-Sub" (section title
+    // "Section A" is at the title level and must be skipped).
+    const sectionAToc = sections[0].components.find((c) => c.name === 'toc');
+    const entries = readEntries(sectionAToc);
+    expect(entries).toEqual([{ title: 'A-Sub', level: 2 }]);
+  });
+
+  it('skips headings with empty text', async () => {
+    const doc: ReportComponentDefinition = {
+      name: 'docx',
+      props: { theme: TEST_THEME_NAME as never },
+      children: [
+        { name: 'toc', props: { scope: 'document' } },
+        { name: 'heading', props: { text: 'Keep', level: 1 } },
+        { name: 'heading', props: { text: '   ', level: 1 } },
+      ],
+    } as unknown as ReportComponentDefinition;
+
+    const { sections } = await processDocument(
+      doc,
+      createMockTheme(),
+      TEST_THEME_NAME
+    );
+    const toc = sections
+      .flatMap((s) => s.components)
+      .find((c) => c.name === 'toc');
+    const entries = readEntries(toc);
+    expect(entries).toEqual([{ title: 'Keep', level: 1 }]);
+  });
+});

--- a/packages/core-docx/src/utils/tocCachedEntries.ts
+++ b/packages/core-docx/src/utils/tocCachedEntries.ts
@@ -1,0 +1,188 @@
+/**
+ * TOC cached-entries pre-pass.
+ *
+ * Walks the flattened ProcessedSection[] tree, and for every TOC component
+ * found, computes the list of heading entries that would appear in that TOC
+ * under its scope/depth/styles configuration, then attaches the result as a
+ * private `__resolvedCachedEntries` field on the component for the renderer
+ * to consume.
+ *
+ * Why: docx's `TableOfContents` accepts a `cachedEntries` body that Word
+ * displays immediately on open. Without it, Word shows either a
+ * "right-click to update field" placeholder or pops up the "update fields?"
+ * dialog. Computing the entries up-front sidesteps both UX failures
+ * without asking the JSON author to maintain a TOC index by hand.
+ *
+ * Limitations:
+ * - Page numbers are not estimated (Word fills them on field update).
+ * - Hyperlink targets (`href`) are not populated yet — that would require
+ *   coordinating bookmark IDs across the pre-pass and the heading renderer.
+ */
+
+import type { ProcessedSection } from '../core/structure';
+import type {
+  ComponentDefinition,
+  HeadingComponentDefinition,
+  TocComponentDefinition,
+} from '../types';
+import {
+  isHeadingComponent,
+  isTocComponent,
+  isColumnsComponent,
+  isTextBoxComponent,
+} from '../types';
+import type { ThemeConfig } from '../styles';
+
+export interface ResolvedTocEntry {
+  title: string;
+  level: number;
+}
+
+/**
+ * Internal field name used to carry resolved cached entries from this
+ * pre-pass to the TOC renderer. Private — not part of the public schema.
+ */
+export const RESOLVED_TOC_ENTRIES_FIELD = '__resolvedCachedEntries';
+
+/**
+ * Mutate the section list in place: every TOC component gets its computed
+ * cached entries attached. Safe to call after extractSections.
+ */
+export function injectTocCachedEntries(
+  sections: ProcessedSection[],
+  theme: ThemeConfig
+): void {
+  for (const section of sections) {
+    walkAttachTocEntries(section, sections, theme);
+  }
+}
+
+function walkAttachTocEntries(
+  section: ProcessedSection,
+  allSections: ProcessedSection[],
+  theme: ThemeConfig
+): void {
+  visitComponents(section.components, (comp) => {
+    if (!isTocComponent(comp)) return;
+    const toc = comp as TocComponentDefinition;
+    const scope = resolveEffectiveScope(toc, section);
+
+    const sourceComponents =
+      scope === 'section'
+        ? section.components
+        : allSections.flatMap((s) => s.components);
+
+    const headings = collectHeadings(sourceComponents);
+    const entries = filterAndMap(headings, toc, theme, section, scope);
+
+    (toc as unknown as Record<string, unknown>)[RESOLVED_TOC_ENTRIES_FIELD] =
+      entries;
+  });
+}
+
+/**
+ * Recursively visit every component in a flat list, descending into
+ * container components (columns, text-box) that may host headings inline.
+ * Section components don't appear here — extractSections already flattened
+ * them into headings.
+ */
+function visitComponents(
+  components: ComponentDefinition[],
+  visitor: (component: ComponentDefinition) => void
+): void {
+  for (const component of components) {
+    visitor(component);
+    if (isColumnsComponent(component) && component.children) {
+      visitComponents(component.children, visitor);
+    } else if (isTextBoxComponent(component) && component.children) {
+      visitComponents(component.children, visitor);
+    }
+  }
+}
+
+/**
+ * Flat list of every heading reachable from `components`, in document
+ * order. Walks into columns/text-boxes the same way the renderer does.
+ */
+function collectHeadings(
+  components: ComponentDefinition[]
+): HeadingComponentDefinition[] {
+  const headings: HeadingComponentDefinition[] = [];
+  visitComponents(components, (comp) => {
+    if (isHeadingComponent(comp)) {
+      headings.push(comp as HeadingComponentDefinition);
+    }
+  });
+  return headings;
+}
+
+function resolveEffectiveScope(
+  toc: TocComponentDefinition,
+  section: ProcessedSection
+): 'document' | 'section' {
+  const requested = toc.props.scope ?? 'auto';
+  if (requested === 'document') return 'document';
+  if (requested === 'section') return 'section';
+  // auto: section if inside an explicit Section, else document. Matches the
+  // runtime detection in renderTocComponent.
+  return section.isExplicitSection ? 'section' : 'document';
+}
+
+function filterAndMap(
+  headings: HeadingComponentDefinition[],
+  toc: TocComponentDefinition,
+  theme: ThemeConfig,
+  section: ProcessedSection,
+  scope: 'document' | 'section'
+): ResolvedTocEntry[] {
+  // Depth window — mirrors parseDepthRange defaults in renderTocComponent.
+  const fromLevel = toc.props.depth?.from ?? 1;
+  const toLevel = toc.props.depth?.to ?? 3;
+
+  // For section-scoped TOCs, skip headings at or above the section title
+  // level. The section title is itself a synthetic heading inserted by
+  // extractSections and would self-include otherwise.
+  const sectionTitleLevel = scope === 'section' ? section.level : undefined;
+  const effectiveFrom =
+    sectionTitleLevel !== undefined
+      ? Math.max(fromLevel, sectionTitleLevel + 1)
+      : fromLevel;
+
+  // Custom-style mappings (theme styles → TOC level). When set, headings
+  // matching a custom themeStyle also count, at the mapped level. The
+  // built-in `level` field always wins for heading components.
+  const customStyleLevels = new Map<string, number>();
+  if (toc.props.styles) {
+    for (const mapping of toc.props.styles) {
+      customStyleLevels.set(mapping.styleId, mapping.level);
+    }
+  }
+
+  const entries: ResolvedTocEntry[] = [];
+  for (const heading of headings) {
+    const builtinLevel = heading.props.level ?? 1;
+    // If this heading uses a custom theme style mapped in styles[], honor
+    // that mapping; otherwise use the explicit heading level.
+    const themeStyle = (heading.props as Record<string, unknown>).themeStyle as
+      | string
+      | undefined;
+    const customLevel =
+      themeStyle && customStyleLevels.has(themeStyle)
+        ? customStyleLevels.get(themeStyle)!
+        : undefined;
+    const level = customLevel ?? builtinLevel;
+
+    if (level < effectiveFrom || level > toLevel) continue;
+
+    const title = (heading.props.text ?? '').trim();
+    if (!title) continue;
+
+    entries.push({ title, level });
+  }
+
+  // Mark theme as touched — silences lint warning while leaving the
+  // parameter wired for future custom-style theme resolution.
+  void theme;
+
+  return entries;
+}

--- a/packages/json-to-docx/package.json
+++ b/packages/json-to-docx/package.json
@@ -42,7 +42,7 @@
     "@json-to-office/shared-docx": "workspace:^"
   },
   "peerDependencies": {
-    "docx": "9.5.1"
+    "docx": "9.7.0"
   },
   "devDependencies": {
     "@types/node": "20.11.0",

--- a/packages/shared-docx/package.json
+++ b/packages/shared-docx/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@json-to-office/shared": "workspace:^",
     "@sinclair/typebox": "0.34.38",
-    "docx": "9.5.1"
+    "docx": "9.7.0"
   },
   "devDependencies": {
     "@types/node": "20.11.0",

--- a/packages/shared-docx/src/__tests__/document-validator.test.ts
+++ b/packages/shared-docx/src/__tests__/document-validator.test.ts
@@ -122,6 +122,68 @@ describe('validateJsonDocument: docx root recognition', () => {
     );
   });
 
+  it('accepts paragraph indent with firstLine + firstLineChars', () => {
+    const json = JSON.stringify({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'paragraph',
+          props: {
+            text: 'Indented',
+            indent: { left: 720, firstLine: 360, firstLineChars: 200 },
+          },
+        },
+      ],
+    });
+
+    const result = validate.jsonDocument(json);
+    expect(result.errors ?? []).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts paragraph indent with hanging', () => {
+    const json = JSON.stringify({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'paragraph',
+          props: {
+            text: 'Hanging indent',
+            indent: { left: 720, hanging: 360 },
+          },
+        },
+      ],
+    });
+
+    const result = validate.jsonDocument(json);
+    expect(result.errors ?? []).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects paragraph indent that combines firstLine and hanging', () => {
+    // firstLine and hanging are mutually exclusive. The IndentSchema union
+    // should refuse documents that set both — neither variant accepts the
+    // forbidden field.
+    const json = JSON.stringify({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'paragraph',
+          props: {
+            text: 'Conflicting',
+            indent: { firstLine: 360, hanging: 360 },
+          },
+        },
+      ],
+    });
+
+    const result = validate.jsonDocument(json);
+    expect(result.valid).toBe(false);
+  });
+
   it('populates `data` whenever `valid` is true (isValidDocument contract)', () => {
     // Triggers TypeBox failure (heading is not in docx.allowedChildren) so the
     // deep validator is the one declaring the doc valid. Even on that path,

--- a/packages/shared-docx/src/schemas/components/paragraph.ts
+++ b/packages/shared-docx/src/schemas/components/paragraph.ts
@@ -144,26 +144,24 @@ const FloatingFramePropertiesSchema = Type.Object(
 // Paragraph indent schema. All values in twips (1/20 of a point) unless noted.
 // firstLineChars uses Word's char-grid model (hundredths of a character),
 // useful for CJK text where indents should align to character columns.
-const IndentSchema = Type.Object(
+// firstLine and hanging are mutually exclusive — encoded as a Union so
+// validators reject documents that set both.
+const LeftRightIndentFields = {
+  left: Type.Optional(
+    Type.Number({ description: 'Left indent in twips (1/20 of a point)' })
+  ),
+  right: Type.Optional(
+    Type.Number({ description: 'Right indent in twips (1/20 of a point)' })
+  ),
+};
+
+const IndentWithFirstLineSchema = Type.Object(
   {
-    left: Type.Optional(
-      Type.Number({ description: 'Left indent in twips (1/20 of a point)' })
-    ),
-    right: Type.Optional(
-      Type.Number({ description: 'Right indent in twips (1/20 of a point)' })
-    ),
+    ...LeftRightIndentFields,
     firstLine: Type.Optional(
       Type.Number({
         minimum: 0,
-        description:
-          'First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.',
-      })
-    ),
-    hanging: Type.Optional(
-      Type.Number({
-        minimum: 0,
-        description:
-          'Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.',
+        description: 'First-line indent in twips (1/20 of a point).',
       })
     ),
     firstLineChars: Type.Optional(
@@ -174,8 +172,33 @@ const IndentSchema = Type.Object(
     ),
   },
   {
-    description: 'Paragraph indent options',
+    description:
+      'Paragraph indent with first-line indent (twips and/or CJK char-grid).',
     additionalProperties: false,
+  }
+);
+
+const IndentWithHangingSchema = Type.Object(
+  {
+    ...LeftRightIndentFields,
+    hanging: Type.Optional(
+      Type.Number({
+        minimum: 0,
+        description: 'Hanging indent in twips (1/20 of a point).',
+      })
+    ),
+  },
+  {
+    description: 'Paragraph indent with hanging indent.',
+    additionalProperties: false,
+  }
+);
+
+const IndentSchema = Type.Union(
+  [IndentWithFirstLineSchema, IndentWithHangingSchema],
+  {
+    description:
+      'Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.',
   }
 );
 

--- a/packages/shared-docx/src/schemas/components/paragraph.ts
+++ b/packages/shared-docx/src/schemas/components/paragraph.ts
@@ -141,6 +141,44 @@ const FloatingFramePropertiesSchema = Type.Object(
   }
 );
 
+// Paragraph indent schema. All values in twips (1/20 of a point) unless noted.
+// firstLineChars uses Word's char-grid model (hundredths of a character),
+// useful for CJK text where indents should align to character columns.
+const IndentSchema = Type.Object(
+  {
+    left: Type.Optional(
+      Type.Number({ description: 'Left indent in twips (1/20 of a point)' })
+    ),
+    right: Type.Optional(
+      Type.Number({ description: 'Right indent in twips (1/20 of a point)' })
+    ),
+    firstLine: Type.Optional(
+      Type.Number({
+        minimum: 0,
+        description:
+          'First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.',
+      })
+    ),
+    hanging: Type.Optional(
+      Type.Number({
+        minimum: 0,
+        description:
+          'Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.',
+      })
+    ),
+    firstLineChars: Type.Optional(
+      Type.Number({
+        description:
+          'First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.',
+      })
+    ),
+  },
+  {
+    description: 'Paragraph indent options',
+    additionalProperties: false,
+  }
+);
+
 // Alignment type schema (paragraph-level, not font-level)
 const AlignmentSchema = Type.Union(
   [
@@ -170,6 +208,7 @@ export const ParagraphPropsSchema = Type.Object(
     spacing: Type.Optional(SpacingSchema),
     // Paragraph alignment (moved from font to config level)
     alignment: Type.Optional(AlignmentSchema),
+    indent: Type.Optional(IndentSchema),
     pageBreak: Type.Optional(
       Type.Boolean({
         description: 'Insert page break before paragraph',

--- a/packages/shared-docx/src/schemas/components/table.ts
+++ b/packages/shared-docx/src/schemas/components/table.ts
@@ -139,6 +139,37 @@ const PaddingSchema = Type.Union([
   }),
 ]);
 
+// Conditional formatting flags (Word "Table Look"). When the table style or
+// theme defines style variants for header rows, banded rows, etc., these
+// toggles tell Word which variants to apply. All optional, all default off.
+const TableLookSchema = Type.Object(
+  {
+    firstRow: Type.Optional(
+      Type.Boolean({ description: 'Emphasize the first (header) row' })
+    ),
+    lastRow: Type.Optional(
+      Type.Boolean({ description: 'Emphasize the last (total) row' })
+    ),
+    firstColumn: Type.Optional(
+      Type.Boolean({ description: 'Emphasize the first column' })
+    ),
+    lastColumn: Type.Optional(
+      Type.Boolean({ description: 'Emphasize the last column' })
+    ),
+    bandedRows: Type.Optional(
+      Type.Boolean({ description: 'Alternate row shading (zebra striping)' })
+    ),
+    bandedColumns: Type.Optional(
+      Type.Boolean({ description: 'Alternate column shading' })
+    ),
+  },
+  {
+    description:
+      'Word "Table Look" flags for conditional formatting (banded rows, header/total row emphasis, etc.). Requires a table style that defines the corresponding variants.',
+    additionalProperties: false,
+  }
+);
+
 // Cell defaults configuration
 const CellDefaultsSchema = Type.Object({
   color: Type.Optional(HexColorSchema),
@@ -243,6 +274,7 @@ export function createTablePropsSchema(componentRef: TSchema): TSchema {
           default: true,
         })
       ),
+      tableLook: Type.Optional(TableLookSchema),
     },
     {
       description: 'Table component props with column-based structure',

--- a/packages/shared-docx/src/schemas/components/toc.ts
+++ b/packages/shared-docx/src/schemas/components/toc.ts
@@ -31,6 +31,37 @@ export const TocStyleMappingSchema = Type.Object(
   }
 );
 
+export const TocCachedEntrySchema = Type.Object(
+  {
+    title: Type.String({
+      description: 'Entry title text as it should appear in the cached TOC',
+    }),
+    level: Type.Number({
+      minimum: 1,
+      maximum: 6,
+      description: 'Outline level (1-6) of the entry',
+    }),
+    page: Type.Optional(
+      Type.Number({
+        minimum: 1,
+        description:
+          'Page number to show for the entry. Omit to leave blank until Word updates the field.',
+      })
+    ),
+    href: Type.Optional(
+      Type.String({
+        description:
+          'Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.',
+      })
+    ),
+  },
+  {
+    description:
+      'Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the "right-click to update field" placeholder.',
+    additionalProperties: false,
+  }
+);
+
 export const TocDepthRangeSchema = Type.Object(
   {
     from: Type.Optional(
@@ -155,6 +186,18 @@ export const TocPropsSchema = Type.Object(
       Type.Array(TocStyleMappingSchema, {
         description:
           'Custom style mappings for TOC entries. Maps custom theme styles to TOC levels.',
+      })
+    ),
+    cachedEntries: Type.Optional(
+      Type.Array(TocCachedEntrySchema, {
+        description:
+          'Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the "right-click to update field" placeholder. Word still recomputes the real TOC when the user updates fields.',
+      })
+    ),
+    beginDirty: Type.Optional(
+      Type.Boolean({
+        description:
+          'Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).',
       })
     ),
   },

--- a/packages/shared-docx/src/schemas/components/toc.ts
+++ b/packages/shared-docx/src/schemas/components/toc.ts
@@ -31,37 +31,6 @@ export const TocStyleMappingSchema = Type.Object(
   }
 );
 
-export const TocCachedEntrySchema = Type.Object(
-  {
-    title: Type.String({
-      description: 'Entry title text as it should appear in the cached TOC',
-    }),
-    level: Type.Number({
-      minimum: 1,
-      maximum: 6,
-      description: 'Outline level (1-6) of the entry',
-    }),
-    page: Type.Optional(
-      Type.Number({
-        minimum: 1,
-        description:
-          'Page number to show for the entry. Omit to leave blank until Word updates the field.',
-      })
-    ),
-    href: Type.Optional(
-      Type.String({
-        description:
-          'Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.',
-      })
-    ),
-  },
-  {
-    description:
-      'Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the "right-click to update field" placeholder.',
-    additionalProperties: false,
-  }
-);
-
 export const TocDepthRangeSchema = Type.Object(
   {
     from: Type.Optional(
@@ -188,16 +157,11 @@ export const TocPropsSchema = Type.Object(
           'Custom style mappings for TOC entries. Maps custom theme styles to TOC levels.',
       })
     ),
-    cachedEntries: Type.Optional(
-      Type.Array(TocCachedEntrySchema, {
-        description:
-          'Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the "right-click to update field" placeholder. Word still recomputes the real TOC when the user updates fields.',
-      })
-    ),
     beginDirty: Type.Optional(
       Type.Boolean({
+        default: false,
         description:
-          'Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).',
+          'When true, Word marks the TOC field as dirty and shows the "update fields?" prompt on open. Default false: the auto-populated cached entries render immediately with no prompt. The cache is always recomputed from the document\'s headings; this flag only controls the Word-side refresh dialog.',
       })
     ),
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  docx: 9.5.1
+  docx: 9.7.0
   typescript: 5.3.3
   eslint: 8.56.0
   prettier: 3.2.4
@@ -93,8 +93,8 @@ importers:
         specifier: 3.6.0
         version: 3.6.0
       docx:
-        specifier: 9.5.1
-        version: 9.5.1
+        specifier: 9.7.0
+        version: 9.7.0
       probe-image-size:
         specifier: 7.2.3
         version: 7.2.3
@@ -164,8 +164,8 @@ importers:
         specifier: workspace:^
         version: link:../shared-docx
       docx:
-        specifier: 9.5.1
-        version: 9.5.1
+        specifier: 9.7.0
+        version: 9.7.0
     devDependencies:
       '@types/node':
         specifier: 20.11.0
@@ -550,8 +550,8 @@ importers:
         specifier: 0.34.38
         version: 0.34.38
       docx:
-        specifier: 9.5.1
-        version: 9.5.1
+        specifier: 9.7.0
+        version: 9.7.0
     devDependencies:
       '@types/node':
         specifier: 20.11.0
@@ -2377,8 +2377,8 @@ packages:
   '@types/node@20.11.0':
     resolution: {integrity: sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==}
 
-  '@types/node@24.12.0':
-    resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/probe-image-size@7.2.4':
     resolution: {integrity: sha512-HVqYj3L+D+S/6qpQRv5qMxrD/5pglzZuhP7ZIqgVSZ+Ck4z1TCFkNIRG8WesFueQTqWFTSgkkAl6f8lwxFPQSw==}
@@ -3027,8 +3027,8 @@ packages:
   docx-preview@0.3.3:
     resolution: {integrity: sha512-vg0bjmp5Q/hWYgalvVsnOOdqKlSBvgzdbrqX8pKw4KuTH8FkX2FIs21w10HZdx6ZhApmMbgfae+lOXjdCSsc8A==}
 
-  docx@9.5.1:
-    resolution: {integrity: sha512-ABDI7JEirFD2+bHhOBlsGZxaG1UgZb2M/QMKhLSDGgVNhxDesTCDcP+qoDnDGjZ4EOXTRfUjUgwHVuZ6VSTfWQ==}
+  docx@9.7.0:
+    resolution: {integrity: sha512-saDn+8rAtW9nPlWxDs31Kbb/hL+AhHQN2gktHkWwkj59u9htUXtpVMN1Z+cSoLGCAaeYpW7Qe9F5sU3aPdiy9w==}
     engines: {node: '>=10'}
 
   dom-helpers@5.2.1:
@@ -5030,8 +5030,8 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -7061,9 +7061,9 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@24.12.0':
+  '@types/node@25.9.1':
     dependencies:
-      undici-types: 7.16.0
+      undici-types: 7.24.6
 
   '@types/probe-image-size@7.2.4':
     dependencies:
@@ -7718,9 +7718,9 @@ snapshots:
     dependencies:
       jszip: 3.10.1
 
-  docx@9.5.1:
+  docx@9.7.0:
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 25.9.1
       hash.js: 1.1.7
       jszip: 3.10.1
       nanoid: 5.1.6
@@ -10125,7 +10125,7 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici-types@7.16.0: {}
+  undici-types@7.24.6: {}
 
   unified@11.0.5:
     dependencies:

--- a/skills/json-to-office/assets/schemas/document.schema.json
+++ b/skills/json-to-office/assets/schemas/document.schema.json
@@ -5076,39 +5076,9 @@
                               "required": ["styleId", "level"]
                             }
                           },
-                          "cachedEntries": {
-                            "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
-                            "type": "array",
-                            "items": {
-                              "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
-                              "additionalProperties": false,
-                              "type": "object",
-                              "properties": {
-                                "title": {
-                                  "description": "Entry title text as it should appear in the cached TOC",
-                                  "type": "string"
-                                },
-                                "level": {
-                                  "minimum": 1,
-                                  "maximum": 6,
-                                  "description": "Outline level (1-6) of the entry",
-                                  "type": "number"
-                                },
-                                "page": {
-                                  "minimum": 1,
-                                  "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
-                                  "type": "number"
-                                },
-                                "href": {
-                                  "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
-                                  "type": "string"
-                                }
-                              },
-                              "required": ["title", "level"]
-                            }
-                          },
                           "beginDirty": {
-                            "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                            "default": false,
+                            "description": "When true, Word marks the TOC field as dirty and shows the \"update fields?\" prompt on open. Default false: the auto-populated cached entries render immediately with no prompt. The cache is always recomputed from the document's headings; this flag only controls the Word-side refresh dialog.",
                             "type": "boolean"
                           }
                         }
@@ -10349,39 +10319,9 @@
                               "required": ["styleId", "level"]
                             }
                           },
-                          "cachedEntries": {
-                            "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
-                            "type": "array",
-                            "items": {
-                              "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
-                              "additionalProperties": false,
-                              "type": "object",
-                              "properties": {
-                                "title": {
-                                  "description": "Entry title text as it should appear in the cached TOC",
-                                  "type": "string"
-                                },
-                                "level": {
-                                  "minimum": 1,
-                                  "maximum": 6,
-                                  "description": "Outline level (1-6) of the entry",
-                                  "type": "number"
-                                },
-                                "page": {
-                                  "minimum": 1,
-                                  "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
-                                  "type": "number"
-                                },
-                                "href": {
-                                  "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
-                                  "type": "string"
-                                }
-                              },
-                              "required": ["title", "level"]
-                            }
-                          },
                           "beginDirty": {
-                            "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                            "default": false,
+                            "description": "When true, Word marks the TOC field as dirty and shows the \"update fields?\" prompt on open. Default false: the auto-populated cached entries render immediately with no prompt. The cache is always recomputed from the document's headings; this flag only controls the Word-side refresh dialog.",
                             "type": "boolean"
                           }
                         }
@@ -13845,39 +13785,9 @@
                                         "required": ["styleId", "level"]
                                       }
                                     },
-                                    "cachedEntries": {
-                                      "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
-                                      "type": "array",
-                                      "items": {
-                                        "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
-                                        "additionalProperties": false,
-                                        "type": "object",
-                                        "properties": {
-                                          "title": {
-                                            "description": "Entry title text as it should appear in the cached TOC",
-                                            "type": "string"
-                                          },
-                                          "level": {
-                                            "minimum": 1,
-                                            "maximum": 6,
-                                            "description": "Outline level (1-6) of the entry",
-                                            "type": "number"
-                                          },
-                                          "page": {
-                                            "minimum": 1,
-                                            "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
-                                            "type": "number"
-                                          },
-                                          "href": {
-                                            "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
-                                            "type": "string"
-                                          }
-                                        },
-                                        "required": ["title", "level"]
-                                      }
-                                    },
                                     "beginDirty": {
-                                      "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                                      "default": false,
+                                      "description": "When true, Word marks the TOC field as dirty and shows the \"update fields?\" prompt on open. Default false: the auto-populated cached entries render immediately with no prompt. The cache is always recomputed from the document's headings; this flag only controls the Word-side refresh dialog.",
                                       "type": "boolean"
                                     }
                                   }
@@ -24145,39 +24055,9 @@
                                     "required": ["styleId", "level"]
                                   }
                                 },
-                                "cachedEntries": {
-                                  "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
-                                  "type": "array",
-                                  "items": {
-                                    "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
-                                    "additionalProperties": false,
-                                    "type": "object",
-                                    "properties": {
-                                      "title": {
-                                        "description": "Entry title text as it should appear in the cached TOC",
-                                        "type": "string"
-                                      },
-                                      "level": {
-                                        "minimum": 1,
-                                        "maximum": 6,
-                                        "description": "Outline level (1-6) of the entry",
-                                        "type": "number"
-                                      },
-                                      "page": {
-                                        "minimum": 1,
-                                        "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
-                                        "type": "number"
-                                      },
-                                      "href": {
-                                        "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": ["title", "level"]
-                                  }
-                                },
                                 "beginDirty": {
-                                  "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                                  "default": false,
+                                  "description": "When true, Word marks the TOC field as dirty and shows the \"update fields?\" prompt on open. Default false: the auto-populated cached entries render immediately with no prompt. The cache is always recomputed from the document's headings; this flag only controls the Word-side refresh dialog.",
                                   "type": "boolean"
                                 }
                               }
@@ -27641,39 +27521,9 @@
                                               "required": ["styleId", "level"]
                                             }
                                           },
-                                          "cachedEntries": {
-                                            "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
-                                            "type": "array",
-                                            "items": {
-                                              "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
-                                              "additionalProperties": false,
-                                              "type": "object",
-                                              "properties": {
-                                                "title": {
-                                                  "description": "Entry title text as it should appear in the cached TOC",
-                                                  "type": "string"
-                                                },
-                                                "level": {
-                                                  "minimum": 1,
-                                                  "maximum": 6,
-                                                  "description": "Outline level (1-6) of the entry",
-                                                  "type": "number"
-                                                },
-                                                "page": {
-                                                  "minimum": 1,
-                                                  "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
-                                                  "type": "number"
-                                                },
-                                                "href": {
-                                                  "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
-                                                  "type": "string"
-                                                }
-                                              },
-                                              "required": ["title", "level"]
-                                            }
-                                          },
                                           "beginDirty": {
-                                            "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                                            "default": false,
+                                            "description": "When true, Word marks the TOC field as dirty and shows the \"update fields?\" prompt on open. Default false: the auto-populated cached entries render immediately with no prompt. The cache is always recomputed from the document's headings; this flag only controls the Word-side refresh dialog.",
                                             "type": "boolean"
                                           }
                                         }
@@ -34465,39 +34315,9 @@
                     "required": ["styleId", "level"]
                   }
                 },
-                "cachedEntries": {
-                  "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
-                  "type": "array",
-                  "items": {
-                    "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
-                    "additionalProperties": false,
-                    "type": "object",
-                    "properties": {
-                      "title": {
-                        "description": "Entry title text as it should appear in the cached TOC",
-                        "type": "string"
-                      },
-                      "level": {
-                        "minimum": 1,
-                        "maximum": 6,
-                        "description": "Outline level (1-6) of the entry",
-                        "type": "number"
-                      },
-                      "page": {
-                        "minimum": 1,
-                        "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
-                        "type": "number"
-                      },
-                      "href": {
-                        "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
-                        "type": "string"
-                      }
-                    },
-                    "required": ["title", "level"]
-                  }
-                },
                 "beginDirty": {
-                  "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                  "default": false,
+                  "description": "When true, Word marks the TOC field as dirty and shows the \"update fields?\" prompt on open. Default false: the auto-populated cached entries render immediately with no prompt. The cache is always recomputed from the document's headings; this flag only controls the Word-side refresh dialog.",
                   "type": "boolean"
                 }
               }
@@ -41370,39 +41190,9 @@
                             "required": ["styleId", "level"]
                           }
                         },
-                        "cachedEntries": {
-                          "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
-                          "type": "array",
-                          "items": {
-                            "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
-                            "additionalProperties": false,
-                            "type": "object",
-                            "properties": {
-                              "title": {
-                                "description": "Entry title text as it should appear in the cached TOC",
-                                "type": "string"
-                              },
-                              "level": {
-                                "minimum": 1,
-                                "maximum": 6,
-                                "description": "Outline level (1-6) of the entry",
-                                "type": "number"
-                              },
-                              "page": {
-                                "minimum": 1,
-                                "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
-                                "type": "number"
-                              },
-                              "href": {
-                                "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
-                                "type": "string"
-                              }
-                            },
-                            "required": ["title", "level"]
-                          }
-                        },
                         "beginDirty": {
-                          "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                          "default": false,
+                          "description": "When true, Word marks the TOC field as dirty and shows the \"update fields?\" prompt on open. Default false: the auto-populated cached entries render immediately with no prompt. The cache is always recomputed from the document's headings; this flag only controls the Word-side refresh dialog.",
                           "type": "boolean"
                         }
                       }
@@ -44866,39 +44656,9 @@
                                       "required": ["styleId", "level"]
                                     }
                                   },
-                                  "cachedEntries": {
-                                    "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
-                                    "type": "array",
-                                    "items": {
-                                      "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
-                                      "additionalProperties": false,
-                                      "type": "object",
-                                      "properties": {
-                                        "title": {
-                                          "description": "Entry title text as it should appear in the cached TOC",
-                                          "type": "string"
-                                        },
-                                        "level": {
-                                          "minimum": 1,
-                                          "maximum": 6,
-                                          "description": "Outline level (1-6) of the entry",
-                                          "type": "number"
-                                        },
-                                        "page": {
-                                          "minimum": 1,
-                                          "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
-                                          "type": "number"
-                                        },
-                                        "href": {
-                                          "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
-                                          "type": "string"
-                                        }
-                                      },
-                                      "required": ["title", "level"]
-                                    }
-                                  },
                                   "beginDirty": {
-                                    "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                                    "default": false,
+                                    "description": "When true, Word marks the TOC field as dirty and shows the \"update fields?\" prompt on open. Default false: the auto-populated cached entries render immediately with no prompt. The cache is always recomputed from the document's headings; this flag only controls the Word-side refresh dialog.",
                                     "type": "boolean"
                                   }
                                 }

--- a/skills/json-to-office/assets/schemas/document.schema.json
+++ b/skills/json-to-office/assets/schemas/document.schema.json
@@ -1012,33 +1012,53 @@
                             ]
                           },
                           "indent": {
-                            "description": "Paragraph indent options",
-                            "additionalProperties": false,
-                            "type": "object",
-                            "properties": {
-                              "left": {
-                                "description": "Left indent in twips (1/20 of a point)",
-                                "type": "number"
+                            "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                            "anyOf": [
+                              {
+                                "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                                "additionalProperties": false,
+                                "type": "object",
+                                "properties": {
+                                  "left": {
+                                    "description": "Left indent in twips (1/20 of a point)",
+                                    "type": "number"
+                                  },
+                                  "right": {
+                                    "description": "Right indent in twips (1/20 of a point)",
+                                    "type": "number"
+                                  },
+                                  "firstLine": {
+                                    "minimum": 0,
+                                    "description": "First-line indent in twips (1/20 of a point).",
+                                    "type": "number"
+                                  },
+                                  "firstLineChars": {
+                                    "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                    "type": "number"
+                                  }
+                                }
                               },
-                              "right": {
-                                "description": "Right indent in twips (1/20 of a point)",
-                                "type": "number"
-                              },
-                              "firstLine": {
-                                "minimum": 0,
-                                "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                                "type": "number"
-                              },
-                              "hanging": {
-                                "minimum": 0,
-                                "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                                "type": "number"
-                              },
-                              "firstLineChars": {
-                                "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                                "type": "number"
+                              {
+                                "description": "Paragraph indent with hanging indent.",
+                                "additionalProperties": false,
+                                "type": "object",
+                                "properties": {
+                                  "left": {
+                                    "description": "Left indent in twips (1/20 of a point)",
+                                    "type": "number"
+                                  },
+                                  "right": {
+                                    "description": "Right indent in twips (1/20 of a point)",
+                                    "type": "number"
+                                  },
+                                  "hanging": {
+                                    "minimum": 0,
+                                    "description": "Hanging indent in twips (1/20 of a point).",
+                                    "type": "number"
+                                  }
+                                }
                               }
-                            }
+                            ]
                           },
                           "pageBreak": {
                             "description": "Insert page break before paragraph",
@@ -2238,33 +2258,53 @@
                             ]
                           },
                           "indent": {
-                            "description": "Paragraph indent options",
-                            "additionalProperties": false,
-                            "type": "object",
-                            "properties": {
-                              "left": {
-                                "description": "Left indent in twips (1/20 of a point)",
-                                "type": "number"
+                            "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                            "anyOf": [
+                              {
+                                "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                                "additionalProperties": false,
+                                "type": "object",
+                                "properties": {
+                                  "left": {
+                                    "description": "Left indent in twips (1/20 of a point)",
+                                    "type": "number"
+                                  },
+                                  "right": {
+                                    "description": "Right indent in twips (1/20 of a point)",
+                                    "type": "number"
+                                  },
+                                  "firstLine": {
+                                    "minimum": 0,
+                                    "description": "First-line indent in twips (1/20 of a point).",
+                                    "type": "number"
+                                  },
+                                  "firstLineChars": {
+                                    "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                    "type": "number"
+                                  }
+                                }
                               },
-                              "right": {
-                                "description": "Right indent in twips (1/20 of a point)",
-                                "type": "number"
-                              },
-                              "firstLine": {
-                                "minimum": 0,
-                                "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                                "type": "number"
-                              },
-                              "hanging": {
-                                "minimum": 0,
-                                "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                                "type": "number"
-                              },
-                              "firstLineChars": {
-                                "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                                "type": "number"
+                              {
+                                "description": "Paragraph indent with hanging indent.",
+                                "additionalProperties": false,
+                                "type": "object",
+                                "properties": {
+                                  "left": {
+                                    "description": "Left indent in twips (1/20 of a point)",
+                                    "type": "number"
+                                  },
+                                  "right": {
+                                    "description": "Right indent in twips (1/20 of a point)",
+                                    "type": "number"
+                                  },
+                                  "hanging": {
+                                    "minimum": 0,
+                                    "description": "Hanging indent in twips (1/20 of a point).",
+                                    "type": "number"
+                                  }
+                                }
                               }
-                            }
+                            ]
                           },
                           "pageBreak": {
                             "description": "Insert page break before paragraph",
@@ -6167,33 +6207,53 @@
                                       ]
                                     },
                                     "indent": {
-                                      "description": "Paragraph indent options",
-                                      "additionalProperties": false,
-                                      "type": "object",
-                                      "properties": {
-                                        "left": {
-                                          "description": "Left indent in twips (1/20 of a point)",
-                                          "type": "number"
+                                      "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                                      "anyOf": [
+                                        {
+                                          "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "left": {
+                                              "description": "Left indent in twips (1/20 of a point)",
+                                              "type": "number"
+                                            },
+                                            "right": {
+                                              "description": "Right indent in twips (1/20 of a point)",
+                                              "type": "number"
+                                            },
+                                            "firstLine": {
+                                              "minimum": 0,
+                                              "description": "First-line indent in twips (1/20 of a point).",
+                                              "type": "number"
+                                            },
+                                            "firstLineChars": {
+                                              "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                              "type": "number"
+                                            }
+                                          }
                                         },
-                                        "right": {
-                                          "description": "Right indent in twips (1/20 of a point)",
-                                          "type": "number"
-                                        },
-                                        "firstLine": {
-                                          "minimum": 0,
-                                          "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                                          "type": "number"
-                                        },
-                                        "hanging": {
-                                          "minimum": 0,
-                                          "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                                          "type": "number"
-                                        },
-                                        "firstLineChars": {
-                                          "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                                          "type": "number"
+                                        {
+                                          "description": "Paragraph indent with hanging indent.",
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "left": {
+                                              "description": "Left indent in twips (1/20 of a point)",
+                                              "type": "number"
+                                            },
+                                            "right": {
+                                              "description": "Right indent in twips (1/20 of a point)",
+                                              "type": "number"
+                                            },
+                                            "hanging": {
+                                              "minimum": 0,
+                                              "description": "Hanging indent in twips (1/20 of a point).",
+                                              "type": "number"
+                                            }
+                                          }
                                         }
-                                      }
+                                      ]
                                     },
                                     "pageBreak": {
                                       "description": "Insert page break before paragraph",
@@ -7471,33 +7531,53 @@
                             ]
                           },
                           "indent": {
-                            "description": "Paragraph indent options",
-                            "additionalProperties": false,
-                            "type": "object",
-                            "properties": {
-                              "left": {
-                                "description": "Left indent in twips (1/20 of a point)",
-                                "type": "number"
+                            "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                            "anyOf": [
+                              {
+                                "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                                "additionalProperties": false,
+                                "type": "object",
+                                "properties": {
+                                  "left": {
+                                    "description": "Left indent in twips (1/20 of a point)",
+                                    "type": "number"
+                                  },
+                                  "right": {
+                                    "description": "Right indent in twips (1/20 of a point)",
+                                    "type": "number"
+                                  },
+                                  "firstLine": {
+                                    "minimum": 0,
+                                    "description": "First-line indent in twips (1/20 of a point).",
+                                    "type": "number"
+                                  },
+                                  "firstLineChars": {
+                                    "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                    "type": "number"
+                                  }
+                                }
                               },
-                              "right": {
-                                "description": "Right indent in twips (1/20 of a point)",
-                                "type": "number"
-                              },
-                              "firstLine": {
-                                "minimum": 0,
-                                "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                                "type": "number"
-                              },
-                              "hanging": {
-                                "minimum": 0,
-                                "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                                "type": "number"
-                              },
-                              "firstLineChars": {
-                                "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                                "type": "number"
+                              {
+                                "description": "Paragraph indent with hanging indent.",
+                                "additionalProperties": false,
+                                "type": "object",
+                                "properties": {
+                                  "left": {
+                                    "description": "Left indent in twips (1/20 of a point)",
+                                    "type": "number"
+                                  },
+                                  "right": {
+                                    "description": "Right indent in twips (1/20 of a point)",
+                                    "type": "number"
+                                  },
+                                  "hanging": {
+                                    "minimum": 0,
+                                    "description": "Hanging indent in twips (1/20 of a point).",
+                                    "type": "number"
+                                  }
+                                }
                               }
-                            }
+                            ]
                           },
                           "pageBreak": {
                             "description": "Insert page break before paragraph",
@@ -10947,33 +11027,53 @@
                                       ]
                                     },
                                     "indent": {
-                                      "description": "Paragraph indent options",
-                                      "additionalProperties": false,
-                                      "type": "object",
-                                      "properties": {
-                                        "left": {
-                                          "description": "Left indent in twips (1/20 of a point)",
-                                          "type": "number"
+                                      "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                                      "anyOf": [
+                                        {
+                                          "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "left": {
+                                              "description": "Left indent in twips (1/20 of a point)",
+                                              "type": "number"
+                                            },
+                                            "right": {
+                                              "description": "Right indent in twips (1/20 of a point)",
+                                              "type": "number"
+                                            },
+                                            "firstLine": {
+                                              "minimum": 0,
+                                              "description": "First-line indent in twips (1/20 of a point).",
+                                              "type": "number"
+                                            },
+                                            "firstLineChars": {
+                                              "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                              "type": "number"
+                                            }
+                                          }
                                         },
-                                        "right": {
-                                          "description": "Right indent in twips (1/20 of a point)",
-                                          "type": "number"
-                                        },
-                                        "firstLine": {
-                                          "minimum": 0,
-                                          "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                                          "type": "number"
-                                        },
-                                        "hanging": {
-                                          "minimum": 0,
-                                          "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                                          "type": "number"
-                                        },
-                                        "firstLineChars": {
-                                          "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                                          "type": "number"
+                                        {
+                                          "description": "Paragraph indent with hanging indent.",
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "left": {
+                                              "description": "Left indent in twips (1/20 of a point)",
+                                              "type": "number"
+                                            },
+                                            "right": {
+                                              "description": "Right indent in twips (1/20 of a point)",
+                                              "type": "number"
+                                            },
+                                            "hanging": {
+                                              "minimum": 0,
+                                              "description": "Hanging indent in twips (1/20 of a point).",
+                                              "type": "number"
+                                            }
+                                          }
                                         }
-                                      }
+                                      ]
                                     },
                                     "pageBreak": {
                                       "description": "Insert page break before paragraph",
@@ -14882,33 +14982,53 @@
                                                 ]
                                               },
                                               "indent": {
-                                                "description": "Paragraph indent options",
-                                                "additionalProperties": false,
-                                                "type": "object",
-                                                "properties": {
-                                                  "left": {
-                                                    "description": "Left indent in twips (1/20 of a point)",
-                                                    "type": "number"
+                                                "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                                                "anyOf": [
+                                                  {
+                                                    "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                                                    "additionalProperties": false,
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "left": {
+                                                        "description": "Left indent in twips (1/20 of a point)",
+                                                        "type": "number"
+                                                      },
+                                                      "right": {
+                                                        "description": "Right indent in twips (1/20 of a point)",
+                                                        "type": "number"
+                                                      },
+                                                      "firstLine": {
+                                                        "minimum": 0,
+                                                        "description": "First-line indent in twips (1/20 of a point).",
+                                                        "type": "number"
+                                                      },
+                                                      "firstLineChars": {
+                                                        "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                                        "type": "number"
+                                                      }
+                                                    }
                                                   },
-                                                  "right": {
-                                                    "description": "Right indent in twips (1/20 of a point)",
-                                                    "type": "number"
-                                                  },
-                                                  "firstLine": {
-                                                    "minimum": 0,
-                                                    "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                                                    "type": "number"
-                                                  },
-                                                  "hanging": {
-                                                    "minimum": 0,
-                                                    "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                                                    "type": "number"
-                                                  },
-                                                  "firstLineChars": {
-                                                    "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                                                    "type": "number"
+                                                  {
+                                                    "description": "Paragraph indent with hanging indent.",
+                                                    "additionalProperties": false,
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "left": {
+                                                        "description": "Left indent in twips (1/20 of a point)",
+                                                        "type": "number"
+                                                      },
+                                                      "right": {
+                                                        "description": "Right indent in twips (1/20 of a point)",
+                                                        "type": "number"
+                                                      },
+                                                      "hanging": {
+                                                        "minimum": 0,
+                                                        "description": "Hanging indent in twips (1/20 of a point).",
+                                                        "type": "number"
+                                                      }
+                                                    }
                                                   }
-                                                }
+                                                ]
                                               },
                                               "pageBreak": {
                                                 "description": "Insert page break before paragraph",
@@ -16567,33 +16687,53 @@
                                       ]
                                     },
                                     "indent": {
-                                      "description": "Paragraph indent options",
-                                      "additionalProperties": false,
-                                      "type": "object",
-                                      "properties": {
-                                        "left": {
-                                          "description": "Left indent in twips (1/20 of a point)",
-                                          "type": "number"
+                                      "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                                      "anyOf": [
+                                        {
+                                          "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "left": {
+                                              "description": "Left indent in twips (1/20 of a point)",
+                                              "type": "number"
+                                            },
+                                            "right": {
+                                              "description": "Right indent in twips (1/20 of a point)",
+                                              "type": "number"
+                                            },
+                                            "firstLine": {
+                                              "minimum": 0,
+                                              "description": "First-line indent in twips (1/20 of a point).",
+                                              "type": "number"
+                                            },
+                                            "firstLineChars": {
+                                              "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                              "type": "number"
+                                            }
+                                          }
                                         },
-                                        "right": {
-                                          "description": "Right indent in twips (1/20 of a point)",
-                                          "type": "number"
-                                        },
-                                        "firstLine": {
-                                          "minimum": 0,
-                                          "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                                          "type": "number"
-                                        },
-                                        "hanging": {
-                                          "minimum": 0,
-                                          "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                                          "type": "number"
-                                        },
-                                        "firstLineChars": {
-                                          "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                                          "type": "number"
+                                        {
+                                          "description": "Paragraph indent with hanging indent.",
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "left": {
+                                              "description": "Left indent in twips (1/20 of a point)",
+                                              "type": "number"
+                                            },
+                                            "right": {
+                                              "description": "Right indent in twips (1/20 of a point)",
+                                              "type": "number"
+                                            },
+                                            "hanging": {
+                                              "minimum": 0,
+                                              "description": "Hanging indent in twips (1/20 of a point).",
+                                              "type": "number"
+                                            }
+                                          }
                                         }
-                                      }
+                                      ]
                                     },
                                     "pageBreak": {
                                       "description": "Insert page break before paragraph",
@@ -17703,33 +17843,53 @@
                           ]
                         },
                         "indent": {
-                          "description": "Paragraph indent options",
-                          "additionalProperties": false,
-                          "type": "object",
-                          "properties": {
-                            "left": {
-                              "description": "Left indent in twips (1/20 of a point)",
-                              "type": "number"
+                          "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                          "anyOf": [
+                            {
+                              "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "left": {
+                                  "description": "Left indent in twips (1/20 of a point)",
+                                  "type": "number"
+                                },
+                                "right": {
+                                  "description": "Right indent in twips (1/20 of a point)",
+                                  "type": "number"
+                                },
+                                "firstLine": {
+                                  "minimum": 0,
+                                  "description": "First-line indent in twips (1/20 of a point).",
+                                  "type": "number"
+                                },
+                                "firstLineChars": {
+                                  "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                  "type": "number"
+                                }
+                              }
                             },
-                            "right": {
-                              "description": "Right indent in twips (1/20 of a point)",
-                              "type": "number"
-                            },
-                            "firstLine": {
-                              "minimum": 0,
-                              "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                              "type": "number"
-                            },
-                            "hanging": {
-                              "minimum": 0,
-                              "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                              "type": "number"
-                            },
-                            "firstLineChars": {
-                              "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                              "type": "number"
+                            {
+                              "description": "Paragraph indent with hanging indent.",
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "left": {
+                                  "description": "Left indent in twips (1/20 of a point)",
+                                  "type": "number"
+                                },
+                                "right": {
+                                  "description": "Right indent in twips (1/20 of a point)",
+                                  "type": "number"
+                                },
+                                "hanging": {
+                                  "minimum": 0,
+                                  "description": "Hanging indent in twips (1/20 of a point).",
+                                  "type": "number"
+                                }
+                              }
                             }
-                          }
+                          ]
                         },
                         "pageBreak": {
                           "description": "Insert page break before paragraph",
@@ -21167,33 +21327,53 @@
                                   ]
                                 },
                                 "indent": {
-                                  "description": "Paragraph indent options",
-                                  "additionalProperties": false,
-                                  "type": "object",
-                                  "properties": {
-                                    "left": {
-                                      "description": "Left indent in twips (1/20 of a point)",
-                                      "type": "number"
+                                  "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                                  "anyOf": [
+                                    {
+                                      "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "left": {
+                                          "description": "Left indent in twips (1/20 of a point)",
+                                          "type": "number"
+                                        },
+                                        "right": {
+                                          "description": "Right indent in twips (1/20 of a point)",
+                                          "type": "number"
+                                        },
+                                        "firstLine": {
+                                          "minimum": 0,
+                                          "description": "First-line indent in twips (1/20 of a point).",
+                                          "type": "number"
+                                        },
+                                        "firstLineChars": {
+                                          "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                          "type": "number"
+                                        }
+                                      }
                                     },
-                                    "right": {
-                                      "description": "Right indent in twips (1/20 of a point)",
-                                      "type": "number"
-                                    },
-                                    "firstLine": {
-                                      "minimum": 0,
-                                      "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                                      "type": "number"
-                                    },
-                                    "hanging": {
-                                      "minimum": 0,
-                                      "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                                      "type": "number"
-                                    },
-                                    "firstLineChars": {
-                                      "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                                      "type": "number"
+                                    {
+                                      "description": "Paragraph indent with hanging indent.",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "left": {
+                                          "description": "Left indent in twips (1/20 of a point)",
+                                          "type": "number"
+                                        },
+                                        "right": {
+                                          "description": "Right indent in twips (1/20 of a point)",
+                                          "type": "number"
+                                        },
+                                        "hanging": {
+                                          "minimum": 0,
+                                          "description": "Hanging indent in twips (1/20 of a point).",
+                                          "type": "number"
+                                        }
+                                      }
                                     }
-                                  }
+                                  ]
                                 },
                                 "pageBreak": {
                                   "description": "Insert page break before paragraph",
@@ -24643,33 +24823,53 @@
                                             ]
                                           },
                                           "indent": {
-                                            "description": "Paragraph indent options",
-                                            "additionalProperties": false,
-                                            "type": "object",
-                                            "properties": {
-                                              "left": {
-                                                "description": "Left indent in twips (1/20 of a point)",
-                                                "type": "number"
+                                            "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                                            "anyOf": [
+                                              {
+                                                "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                                                "additionalProperties": false,
+                                                "type": "object",
+                                                "properties": {
+                                                  "left": {
+                                                    "description": "Left indent in twips (1/20 of a point)",
+                                                    "type": "number"
+                                                  },
+                                                  "right": {
+                                                    "description": "Right indent in twips (1/20 of a point)",
+                                                    "type": "number"
+                                                  },
+                                                  "firstLine": {
+                                                    "minimum": 0,
+                                                    "description": "First-line indent in twips (1/20 of a point).",
+                                                    "type": "number"
+                                                  },
+                                                  "firstLineChars": {
+                                                    "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                                    "type": "number"
+                                                  }
+                                                }
                                               },
-                                              "right": {
-                                                "description": "Right indent in twips (1/20 of a point)",
-                                                "type": "number"
-                                              },
-                                              "firstLine": {
-                                                "minimum": 0,
-                                                "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                                                "type": "number"
-                                              },
-                                              "hanging": {
-                                                "minimum": 0,
-                                                "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                                                "type": "number"
-                                              },
-                                              "firstLineChars": {
-                                                "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                                                "type": "number"
+                                              {
+                                                "description": "Paragraph indent with hanging indent.",
+                                                "additionalProperties": false,
+                                                "type": "object",
+                                                "properties": {
+                                                  "left": {
+                                                    "description": "Left indent in twips (1/20 of a point)",
+                                                    "type": "number"
+                                                  },
+                                                  "right": {
+                                                    "description": "Right indent in twips (1/20 of a point)",
+                                                    "type": "number"
+                                                  },
+                                                  "hanging": {
+                                                    "minimum": 0,
+                                                    "description": "Hanging indent in twips (1/20 of a point).",
+                                                    "type": "number"
+                                                  }
+                                                }
                                               }
-                                            }
+                                            ]
                                           },
                                           "pageBreak": {
                                             "description": "Insert page break before paragraph",
@@ -28581,33 +28781,53 @@
                                                       ]
                                                     },
                                                     "indent": {
-                                                      "description": "Paragraph indent options",
-                                                      "additionalProperties": false,
-                                                      "type": "object",
-                                                      "properties": {
-                                                        "left": {
-                                                          "description": "Left indent in twips (1/20 of a point)",
-                                                          "type": "number"
+                                                      "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                                                      "anyOf": [
+                                                        {
+                                                          "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                                                          "additionalProperties": false,
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "left": {
+                                                              "description": "Left indent in twips (1/20 of a point)",
+                                                              "type": "number"
+                                                            },
+                                                            "right": {
+                                                              "description": "Right indent in twips (1/20 of a point)",
+                                                              "type": "number"
+                                                            },
+                                                            "firstLine": {
+                                                              "minimum": 0,
+                                                              "description": "First-line indent in twips (1/20 of a point).",
+                                                              "type": "number"
+                                                            },
+                                                            "firstLineChars": {
+                                                              "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                                              "type": "number"
+                                                            }
+                                                          }
                                                         },
-                                                        "right": {
-                                                          "description": "Right indent in twips (1/20 of a point)",
-                                                          "type": "number"
-                                                        },
-                                                        "firstLine": {
-                                                          "minimum": 0,
-                                                          "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                                                          "type": "number"
-                                                        },
-                                                        "hanging": {
-                                                          "minimum": 0,
-                                                          "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                                                          "type": "number"
-                                                        },
-                                                        "firstLineChars": {
-                                                          "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                                                          "type": "number"
+                                                        {
+                                                          "description": "Paragraph indent with hanging indent.",
+                                                          "additionalProperties": false,
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "left": {
+                                                              "description": "Left indent in twips (1/20 of a point)",
+                                                              "type": "number"
+                                                            },
+                                                            "right": {
+                                                              "description": "Right indent in twips (1/20 of a point)",
+                                                              "type": "number"
+                                                            },
+                                                            "hanging": {
+                                                              "minimum": 0,
+                                                              "description": "Hanging indent in twips (1/20 of a point).",
+                                                              "type": "number"
+                                                            }
+                                                          }
                                                         }
-                                                      }
+                                                      ]
                                                     },
                                                     "pageBreak": {
                                                       "description": "Insert page break before paragraph",
@@ -30266,33 +30486,53 @@
                                             ]
                                           },
                                           "indent": {
-                                            "description": "Paragraph indent options",
-                                            "additionalProperties": false,
-                                            "type": "object",
-                                            "properties": {
-                                              "left": {
-                                                "description": "Left indent in twips (1/20 of a point)",
-                                                "type": "number"
+                                            "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                                            "anyOf": [
+                                              {
+                                                "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                                                "additionalProperties": false,
+                                                "type": "object",
+                                                "properties": {
+                                                  "left": {
+                                                    "description": "Left indent in twips (1/20 of a point)",
+                                                    "type": "number"
+                                                  },
+                                                  "right": {
+                                                    "description": "Right indent in twips (1/20 of a point)",
+                                                    "type": "number"
+                                                  },
+                                                  "firstLine": {
+                                                    "minimum": 0,
+                                                    "description": "First-line indent in twips (1/20 of a point).",
+                                                    "type": "number"
+                                                  },
+                                                  "firstLineChars": {
+                                                    "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                                    "type": "number"
+                                                  }
+                                                }
                                               },
-                                              "right": {
-                                                "description": "Right indent in twips (1/20 of a point)",
-                                                "type": "number"
-                                              },
-                                              "firstLine": {
-                                                "minimum": 0,
-                                                "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                                                "type": "number"
-                                              },
-                                              "hanging": {
-                                                "minimum": 0,
-                                                "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                                                "type": "number"
-                                              },
-                                              "firstLineChars": {
-                                                "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                                                "type": "number"
+                                              {
+                                                "description": "Paragraph indent with hanging indent.",
+                                                "additionalProperties": false,
+                                                "type": "object",
+                                                "properties": {
+                                                  "left": {
+                                                    "description": "Left indent in twips (1/20 of a point)",
+                                                    "type": "number"
+                                                  },
+                                                  "right": {
+                                                    "description": "Right indent in twips (1/20 of a point)",
+                                                    "type": "number"
+                                                  },
+                                                  "hanging": {
+                                                    "minimum": 0,
+                                                    "description": "Hanging indent in twips (1/20 of a point).",
+                                                    "type": "number"
+                                                  }
+                                                }
                                               }
-                                            }
+                                            ]
                                           },
                                           "pageBreak": {
                                             "description": "Insert page break before paragraph",
@@ -31407,33 +31647,53 @@
                   ]
                 },
                 "indent": {
-                  "description": "Paragraph indent options",
-                  "additionalProperties": false,
-                  "type": "object",
-                  "properties": {
-                    "left": {
-                      "description": "Left indent in twips (1/20 of a point)",
-                      "type": "number"
+                  "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                  "anyOf": [
+                    {
+                      "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                      "additionalProperties": false,
+                      "type": "object",
+                      "properties": {
+                        "left": {
+                          "description": "Left indent in twips (1/20 of a point)",
+                          "type": "number"
+                        },
+                        "right": {
+                          "description": "Right indent in twips (1/20 of a point)",
+                          "type": "number"
+                        },
+                        "firstLine": {
+                          "minimum": 0,
+                          "description": "First-line indent in twips (1/20 of a point).",
+                          "type": "number"
+                        },
+                        "firstLineChars": {
+                          "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                          "type": "number"
+                        }
+                      }
                     },
-                    "right": {
-                      "description": "Right indent in twips (1/20 of a point)",
-                      "type": "number"
-                    },
-                    "firstLine": {
-                      "minimum": 0,
-                      "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                      "type": "number"
-                    },
-                    "hanging": {
-                      "minimum": 0,
-                      "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                      "type": "number"
-                    },
-                    "firstLineChars": {
-                      "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                      "type": "number"
+                    {
+                      "description": "Paragraph indent with hanging indent.",
+                      "additionalProperties": false,
+                      "type": "object",
+                      "properties": {
+                        "left": {
+                          "description": "Left indent in twips (1/20 of a point)",
+                          "type": "number"
+                        },
+                        "right": {
+                          "description": "Right indent in twips (1/20 of a point)",
+                          "type": "number"
+                        },
+                        "hanging": {
+                          "minimum": 0,
+                          "description": "Hanging indent in twips (1/20 of a point).",
+                          "type": "number"
+                        }
+                      }
                     }
-                  }
+                  ]
                 },
                 "pageBreak": {
                   "description": "Insert page break before paragraph",
@@ -34811,33 +35071,53 @@
                   ]
                 },
                 "indent": {
-                  "description": "Paragraph indent options",
-                  "additionalProperties": false,
-                  "type": "object",
-                  "properties": {
-                    "left": {
-                      "description": "Left indent in twips (1/20 of a point)",
-                      "type": "number"
+                  "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                  "anyOf": [
+                    {
+                      "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                      "additionalProperties": false,
+                      "type": "object",
+                      "properties": {
+                        "left": {
+                          "description": "Left indent in twips (1/20 of a point)",
+                          "type": "number"
+                        },
+                        "right": {
+                          "description": "Right indent in twips (1/20 of a point)",
+                          "type": "number"
+                        },
+                        "firstLine": {
+                          "minimum": 0,
+                          "description": "First-line indent in twips (1/20 of a point).",
+                          "type": "number"
+                        },
+                        "firstLineChars": {
+                          "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                          "type": "number"
+                        }
+                      }
                     },
-                    "right": {
-                      "description": "Right indent in twips (1/20 of a point)",
-                      "type": "number"
-                    },
-                    "firstLine": {
-                      "minimum": 0,
-                      "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                      "type": "number"
-                    },
-                    "hanging": {
-                      "minimum": 0,
-                      "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                      "type": "number"
-                    },
-                    "firstLineChars": {
-                      "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                      "type": "number"
+                    {
+                      "description": "Paragraph indent with hanging indent.",
+                      "additionalProperties": false,
+                      "type": "object",
+                      "properties": {
+                        "left": {
+                          "description": "Left indent in twips (1/20 of a point)",
+                          "type": "number"
+                        },
+                        "right": {
+                          "description": "Right indent in twips (1/20 of a point)",
+                          "type": "number"
+                        },
+                        "hanging": {
+                          "minimum": 0,
+                          "description": "Hanging indent in twips (1/20 of a point).",
+                          "type": "number"
+                        }
+                      }
                     }
-                  }
+                  ]
                 },
                 "pageBreak": {
                   "description": "Insert page break before paragraph",
@@ -38272,33 +38552,53 @@
                           ]
                         },
                         "indent": {
-                          "description": "Paragraph indent options",
-                          "additionalProperties": false,
-                          "type": "object",
-                          "properties": {
-                            "left": {
-                              "description": "Left indent in twips (1/20 of a point)",
-                              "type": "number"
+                          "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                          "anyOf": [
+                            {
+                              "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "left": {
+                                  "description": "Left indent in twips (1/20 of a point)",
+                                  "type": "number"
+                                },
+                                "right": {
+                                  "description": "Right indent in twips (1/20 of a point)",
+                                  "type": "number"
+                                },
+                                "firstLine": {
+                                  "minimum": 0,
+                                  "description": "First-line indent in twips (1/20 of a point).",
+                                  "type": "number"
+                                },
+                                "firstLineChars": {
+                                  "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                  "type": "number"
+                                }
+                              }
                             },
-                            "right": {
-                              "description": "Right indent in twips (1/20 of a point)",
-                              "type": "number"
-                            },
-                            "firstLine": {
-                              "minimum": 0,
-                              "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                              "type": "number"
-                            },
-                            "hanging": {
-                              "minimum": 0,
-                              "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                              "type": "number"
-                            },
-                            "firstLineChars": {
-                              "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                              "type": "number"
+                            {
+                              "description": "Paragraph indent with hanging indent.",
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "left": {
+                                  "description": "Left indent in twips (1/20 of a point)",
+                                  "type": "number"
+                                },
+                                "right": {
+                                  "description": "Right indent in twips (1/20 of a point)",
+                                  "type": "number"
+                                },
+                                "hanging": {
+                                  "minimum": 0,
+                                  "description": "Hanging indent in twips (1/20 of a point).",
+                                  "type": "number"
+                                }
+                              }
                             }
-                          }
+                          ]
                         },
                         "pageBreak": {
                           "description": "Insert page break before paragraph",
@@ -41748,33 +42048,53 @@
                                     ]
                                   },
                                   "indent": {
-                                    "description": "Paragraph indent options",
-                                    "additionalProperties": false,
-                                    "type": "object",
-                                    "properties": {
-                                      "left": {
-                                        "description": "Left indent in twips (1/20 of a point)",
-                                        "type": "number"
+                                    "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                                    "anyOf": [
+                                      {
+                                        "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "left": {
+                                            "description": "Left indent in twips (1/20 of a point)",
+                                            "type": "number"
+                                          },
+                                          "right": {
+                                            "description": "Right indent in twips (1/20 of a point)",
+                                            "type": "number"
+                                          },
+                                          "firstLine": {
+                                            "minimum": 0,
+                                            "description": "First-line indent in twips (1/20 of a point).",
+                                            "type": "number"
+                                          },
+                                          "firstLineChars": {
+                                            "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                            "type": "number"
+                                          }
+                                        }
                                       },
-                                      "right": {
-                                        "description": "Right indent in twips (1/20 of a point)",
-                                        "type": "number"
-                                      },
-                                      "firstLine": {
-                                        "minimum": 0,
-                                        "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                                        "type": "number"
-                                      },
-                                      "hanging": {
-                                        "minimum": 0,
-                                        "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                                        "type": "number"
-                                      },
-                                      "firstLineChars": {
-                                        "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                                        "type": "number"
+                                      {
+                                        "description": "Paragraph indent with hanging indent.",
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "left": {
+                                            "description": "Left indent in twips (1/20 of a point)",
+                                            "type": "number"
+                                          },
+                                          "right": {
+                                            "description": "Right indent in twips (1/20 of a point)",
+                                            "type": "number"
+                                          },
+                                          "hanging": {
+                                            "minimum": 0,
+                                            "description": "Hanging indent in twips (1/20 of a point).",
+                                            "type": "number"
+                                          }
+                                        }
                                       }
-                                    }
+                                    ]
                                   },
                                   "pageBreak": {
                                     "description": "Insert page break before paragraph",
@@ -45677,33 +45997,53 @@
                                               ]
                                             },
                                             "indent": {
-                                              "description": "Paragraph indent options",
-                                              "additionalProperties": false,
-                                              "type": "object",
-                                              "properties": {
-                                                "left": {
-                                                  "description": "Left indent in twips (1/20 of a point)",
-                                                  "type": "number"
+                                              "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                                              "anyOf": [
+                                                {
+                                                  "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                                                  "additionalProperties": false,
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "left": {
+                                                      "description": "Left indent in twips (1/20 of a point)",
+                                                      "type": "number"
+                                                    },
+                                                    "right": {
+                                                      "description": "Right indent in twips (1/20 of a point)",
+                                                      "type": "number"
+                                                    },
+                                                    "firstLine": {
+                                                      "minimum": 0,
+                                                      "description": "First-line indent in twips (1/20 of a point).",
+                                                      "type": "number"
+                                                    },
+                                                    "firstLineChars": {
+                                                      "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                                      "type": "number"
+                                                    }
+                                                  }
                                                 },
-                                                "right": {
-                                                  "description": "Right indent in twips (1/20 of a point)",
-                                                  "type": "number"
-                                                },
-                                                "firstLine": {
-                                                  "minimum": 0,
-                                                  "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                                                  "type": "number"
-                                                },
-                                                "hanging": {
-                                                  "minimum": 0,
-                                                  "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                                                  "type": "number"
-                                                },
-                                                "firstLineChars": {
-                                                  "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                                                  "type": "number"
+                                                {
+                                                  "description": "Paragraph indent with hanging indent.",
+                                                  "additionalProperties": false,
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "left": {
+                                                      "description": "Left indent in twips (1/20 of a point)",
+                                                      "type": "number"
+                                                    },
+                                                    "right": {
+                                                      "description": "Right indent in twips (1/20 of a point)",
+                                                      "type": "number"
+                                                    },
+                                                    "hanging": {
+                                                      "minimum": 0,
+                                                      "description": "Hanging indent in twips (1/20 of a point).",
+                                                      "type": "number"
+                                                    }
+                                                  }
                                                 }
-                                              }
+                                              ]
                                             },
                                             "pageBreak": {
                                               "description": "Insert page break before paragraph",
@@ -47362,33 +47702,53 @@
                                     ]
                                   },
                                   "indent": {
-                                    "description": "Paragraph indent options",
-                                    "additionalProperties": false,
-                                    "type": "object",
-                                    "properties": {
-                                      "left": {
-                                        "description": "Left indent in twips (1/20 of a point)",
-                                        "type": "number"
+                                    "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+                                    "anyOf": [
+                                      {
+                                        "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "left": {
+                                            "description": "Left indent in twips (1/20 of a point)",
+                                            "type": "number"
+                                          },
+                                          "right": {
+                                            "description": "Right indent in twips (1/20 of a point)",
+                                            "type": "number"
+                                          },
+                                          "firstLine": {
+                                            "minimum": 0,
+                                            "description": "First-line indent in twips (1/20 of a point).",
+                                            "type": "number"
+                                          },
+                                          "firstLineChars": {
+                                            "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                            "type": "number"
+                                          }
+                                        }
                                       },
-                                      "right": {
-                                        "description": "Right indent in twips (1/20 of a point)",
-                                        "type": "number"
-                                      },
-                                      "firstLine": {
-                                        "minimum": 0,
-                                        "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                                        "type": "number"
-                                      },
-                                      "hanging": {
-                                        "minimum": 0,
-                                        "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                                        "type": "number"
-                                      },
-                                      "firstLineChars": {
-                                        "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                                        "type": "number"
+                                      {
+                                        "description": "Paragraph indent with hanging indent.",
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "left": {
+                                            "description": "Left indent in twips (1/20 of a point)",
+                                            "type": "number"
+                                          },
+                                          "right": {
+                                            "description": "Right indent in twips (1/20 of a point)",
+                                            "type": "number"
+                                          },
+                                          "hanging": {
+                                            "minimum": 0,
+                                            "description": "Hanging indent in twips (1/20 of a point).",
+                                            "type": "number"
+                                          }
+                                        }
                                       }
-                                    }
+                                    ]
                                   },
                                   "pageBreak": {
                                     "description": "Insert page break before paragraph",

--- a/skills/json-to-office/assets/schemas/document.schema.json
+++ b/skills/json-to-office/assets/schemas/document.schema.json
@@ -1011,6 +1011,35 @@
                               }
                             ]
                           },
+                          "indent": {
+                            "description": "Paragraph indent options",
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "left": {
+                                "description": "Left indent in twips (1/20 of a point)",
+                                "type": "number"
+                              },
+                              "right": {
+                                "description": "Right indent in twips (1/20 of a point)",
+                                "type": "number"
+                              },
+                              "firstLine": {
+                                "minimum": 0,
+                                "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                                "type": "number"
+                              },
+                              "hanging": {
+                                "minimum": 0,
+                                "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                                "type": "number"
+                              },
+                              "firstLineChars": {
+                                "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                "type": "number"
+                              }
+                            }
+                          },
                           "pageBreak": {
                             "description": "Insert page break before paragraph",
                             "type": "boolean"
@@ -2207,6 +2236,35 @@
                                 "type": "string"
                               }
                             ]
+                          },
+                          "indent": {
+                            "description": "Paragraph indent options",
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "left": {
+                                "description": "Left indent in twips (1/20 of a point)",
+                                "type": "number"
+                              },
+                              "right": {
+                                "description": "Right indent in twips (1/20 of a point)",
+                                "type": "number"
+                              },
+                              "firstLine": {
+                                "minimum": 0,
+                                "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                                "type": "number"
+                              },
+                              "hanging": {
+                                "minimum": 0,
+                                "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                                "type": "number"
+                              },
+                              "firstLineChars": {
+                                "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                "type": "number"
+                              }
+                            }
                           },
                           "pageBreak": {
                             "description": "Insert page break before paragraph",
@@ -4092,6 +4150,37 @@
                             "description": "Repeat the header row on each page when the table spans multiple pages. Defaults to false.",
                             "default": true,
                             "type": "boolean"
+                          },
+                          "tableLook": {
+                            "description": "Word \"Table Look\" flags for conditional formatting (banded rows, header/total row emphasis, etc.). Requires a table style that defines the corresponding variants.",
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "firstRow": {
+                                "description": "Emphasize the first (header) row",
+                                "type": "boolean"
+                              },
+                              "lastRow": {
+                                "description": "Emphasize the last (total) row",
+                                "type": "boolean"
+                              },
+                              "firstColumn": {
+                                "description": "Emphasize the first column",
+                                "type": "boolean"
+                              },
+                              "lastColumn": {
+                                "description": "Emphasize the last column",
+                                "type": "boolean"
+                              },
+                              "bandedRows": {
+                                "description": "Alternate row shading (zebra striping)",
+                                "type": "boolean"
+                              },
+                              "bandedColumns": {
+                                "description": "Alternate column shading",
+                                "type": "boolean"
+                              }
+                            }
                           }
                         },
                         "required": ["columns"]
@@ -4946,6 +5035,41 @@
                               },
                               "required": ["styleId", "level"]
                             }
+                          },
+                          "cachedEntries": {
+                            "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
+                            "type": "array",
+                            "items": {
+                              "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "title": {
+                                  "description": "Entry title text as it should appear in the cached TOC",
+                                  "type": "string"
+                                },
+                                "level": {
+                                  "minimum": 1,
+                                  "maximum": 6,
+                                  "description": "Outline level (1-6) of the entry",
+                                  "type": "number"
+                                },
+                                "page": {
+                                  "minimum": 1,
+                                  "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
+                                  "type": "number"
+                                },
+                                "href": {
+                                  "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["title", "level"]
+                            }
+                          },
+                          "beginDirty": {
+                            "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                            "type": "boolean"
                           }
                         }
                       }
@@ -6041,6 +6165,35 @@
                                           "type": "string"
                                         }
                                       ]
+                                    },
+                                    "indent": {
+                                      "description": "Paragraph indent options",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "left": {
+                                          "description": "Left indent in twips (1/20 of a point)",
+                                          "type": "number"
+                                        },
+                                        "right": {
+                                          "description": "Right indent in twips (1/20 of a point)",
+                                          "type": "number"
+                                        },
+                                        "firstLine": {
+                                          "minimum": 0,
+                                          "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                                          "type": "number"
+                                        },
+                                        "hanging": {
+                                          "minimum": 0,
+                                          "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                                          "type": "number"
+                                        },
+                                        "firstLineChars": {
+                                          "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                          "type": "number"
+                                        }
+                                      }
                                     },
                                     "pageBreak": {
                                       "description": "Insert page break before paragraph",
@@ -7317,6 +7470,35 @@
                               }
                             ]
                           },
+                          "indent": {
+                            "description": "Paragraph indent options",
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "left": {
+                                "description": "Left indent in twips (1/20 of a point)",
+                                "type": "number"
+                              },
+                              "right": {
+                                "description": "Right indent in twips (1/20 of a point)",
+                                "type": "number"
+                              },
+                              "firstLine": {
+                                "minimum": 0,
+                                "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                                "type": "number"
+                              },
+                              "hanging": {
+                                "minimum": 0,
+                                "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                                "type": "number"
+                              },
+                              "firstLineChars": {
+                                "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                "type": "number"
+                              }
+                            }
+                          },
                           "pageBreak": {
                             "description": "Insert page break before paragraph",
                             "type": "boolean"
@@ -9201,6 +9383,37 @@
                             "description": "Repeat the header row on each page when the table spans multiple pages. Defaults to false.",
                             "default": true,
                             "type": "boolean"
+                          },
+                          "tableLook": {
+                            "description": "Word \"Table Look\" flags for conditional formatting (banded rows, header/total row emphasis, etc.). Requires a table style that defines the corresponding variants.",
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "firstRow": {
+                                "description": "Emphasize the first (header) row",
+                                "type": "boolean"
+                              },
+                              "lastRow": {
+                                "description": "Emphasize the last (total) row",
+                                "type": "boolean"
+                              },
+                              "firstColumn": {
+                                "description": "Emphasize the first column",
+                                "type": "boolean"
+                              },
+                              "lastColumn": {
+                                "description": "Emphasize the last column",
+                                "type": "boolean"
+                              },
+                              "bandedRows": {
+                                "description": "Alternate row shading (zebra striping)",
+                                "type": "boolean"
+                              },
+                              "bandedColumns": {
+                                "description": "Alternate column shading",
+                                "type": "boolean"
+                              }
+                            }
                           }
                         },
                         "required": ["columns"]
@@ -10055,6 +10268,41 @@
                               },
                               "required": ["styleId", "level"]
                             }
+                          },
+                          "cachedEntries": {
+                            "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
+                            "type": "array",
+                            "items": {
+                              "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "title": {
+                                  "description": "Entry title text as it should appear in the cached TOC",
+                                  "type": "string"
+                                },
+                                "level": {
+                                  "minimum": 1,
+                                  "maximum": 6,
+                                  "description": "Outline level (1-6) of the entry",
+                                  "type": "number"
+                                },
+                                "page": {
+                                  "minimum": 1,
+                                  "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
+                                  "type": "number"
+                                },
+                                "href": {
+                                  "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["title", "level"]
+                            }
+                          },
+                          "beginDirty": {
+                            "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                            "type": "boolean"
                           }
                         }
                       }
@@ -10697,6 +10945,35 @@
                                           "type": "string"
                                         }
                                       ]
+                                    },
+                                    "indent": {
+                                      "description": "Paragraph indent options",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "left": {
+                                          "description": "Left indent in twips (1/20 of a point)",
+                                          "type": "number"
+                                        },
+                                        "right": {
+                                          "description": "Right indent in twips (1/20 of a point)",
+                                          "type": "number"
+                                        },
+                                        "firstLine": {
+                                          "minimum": 0,
+                                          "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                                          "type": "number"
+                                        },
+                                        "hanging": {
+                                          "minimum": 0,
+                                          "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                                          "type": "number"
+                                        },
+                                        "firstLineChars": {
+                                          "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                          "type": "number"
+                                        }
+                                      }
                                     },
                                     "pageBreak": {
                                       "description": "Insert page break before paragraph",
@@ -12582,6 +12859,37 @@
                                       "description": "Repeat the header row on each page when the table spans multiple pages. Defaults to false.",
                                       "default": true,
                                       "type": "boolean"
+                                    },
+                                    "tableLook": {
+                                      "description": "Word \"Table Look\" flags for conditional formatting (banded rows, header/total row emphasis, etc.). Requires a table style that defines the corresponding variants.",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "firstRow": {
+                                          "description": "Emphasize the first (header) row",
+                                          "type": "boolean"
+                                        },
+                                        "lastRow": {
+                                          "description": "Emphasize the last (total) row",
+                                          "type": "boolean"
+                                        },
+                                        "firstColumn": {
+                                          "description": "Emphasize the first column",
+                                          "type": "boolean"
+                                        },
+                                        "lastColumn": {
+                                          "description": "Emphasize the last column",
+                                          "type": "boolean"
+                                        },
+                                        "bandedRows": {
+                                          "description": "Alternate row shading (zebra striping)",
+                                          "type": "boolean"
+                                        },
+                                        "bandedColumns": {
+                                          "description": "Alternate column shading",
+                                          "type": "boolean"
+                                        }
+                                      }
                                     }
                                   },
                                   "required": ["columns"]
@@ -13436,6 +13744,41 @@
                                         },
                                         "required": ["styleId", "level"]
                                       }
+                                    },
+                                    "cachedEntries": {
+                                      "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "title": {
+                                            "description": "Entry title text as it should appear in the cached TOC",
+                                            "type": "string"
+                                          },
+                                          "level": {
+                                            "minimum": 1,
+                                            "maximum": 6,
+                                            "description": "Outline level (1-6) of the entry",
+                                            "type": "number"
+                                          },
+                                          "page": {
+                                            "minimum": 1,
+                                            "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
+                                            "type": "number"
+                                          },
+                                          "href": {
+                                            "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["title", "level"]
+                                      }
+                                    },
+                                    "beginDirty": {
+                                      "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                                      "type": "boolean"
                                     }
                                   }
                                 }
@@ -14537,6 +14880,35 @@
                                                     "type": "string"
                                                   }
                                                 ]
+                                              },
+                                              "indent": {
+                                                "description": "Paragraph indent options",
+                                                "additionalProperties": false,
+                                                "type": "object",
+                                                "properties": {
+                                                  "left": {
+                                                    "description": "Left indent in twips (1/20 of a point)",
+                                                    "type": "number"
+                                                  },
+                                                  "right": {
+                                                    "description": "Right indent in twips (1/20 of a point)",
+                                                    "type": "number"
+                                                  },
+                                                  "firstLine": {
+                                                    "minimum": 0,
+                                                    "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                                                    "type": "number"
+                                                  },
+                                                  "hanging": {
+                                                    "minimum": 0,
+                                                    "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                                                    "type": "number"
+                                                  },
+                                                  "firstLineChars": {
+                                                    "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                                    "type": "number"
+                                                  }
+                                                }
                                               },
                                               "pageBreak": {
                                                 "description": "Insert page break before paragraph",
@@ -16194,6 +16566,35 @@
                                         }
                                       ]
                                     },
+                                    "indent": {
+                                      "description": "Paragraph indent options",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "left": {
+                                          "description": "Left indent in twips (1/20 of a point)",
+                                          "type": "number"
+                                        },
+                                        "right": {
+                                          "description": "Right indent in twips (1/20 of a point)",
+                                          "type": "number"
+                                        },
+                                        "firstLine": {
+                                          "minimum": 0,
+                                          "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                                          "type": "number"
+                                        },
+                                        "hanging": {
+                                          "minimum": 0,
+                                          "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                                          "type": "number"
+                                        },
+                                        "firstLineChars": {
+                                          "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                          "type": "number"
+                                        }
+                                      }
+                                    },
                                     "pageBreak": {
                                       "description": "Insert page break before paragraph",
                                       "type": "boolean"
@@ -17300,6 +17701,35 @@
                               "type": "string"
                             }
                           ]
+                        },
+                        "indent": {
+                          "description": "Paragraph indent options",
+                          "additionalProperties": false,
+                          "type": "object",
+                          "properties": {
+                            "left": {
+                              "description": "Left indent in twips (1/20 of a point)",
+                              "type": "number"
+                            },
+                            "right": {
+                              "description": "Right indent in twips (1/20 of a point)",
+                              "type": "number"
+                            },
+                            "firstLine": {
+                              "minimum": 0,
+                              "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                              "type": "number"
+                            },
+                            "hanging": {
+                              "minimum": 0,
+                              "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                              "type": "number"
+                            },
+                            "firstLineChars": {
+                              "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                              "type": "number"
+                            }
+                          }
                         },
                         "pageBreak": {
                           "description": "Insert page break before paragraph",
@@ -19126,6 +19556,37 @@
                           "description": "Repeat the header row on each page when the table spans multiple pages. Defaults to false.",
                           "default": true,
                           "type": "boolean"
+                        },
+                        "tableLook": {
+                          "description": "Word \"Table Look\" flags for conditional formatting (banded rows, header/total row emphasis, etc.). Requires a table style that defines the corresponding variants.",
+                          "additionalProperties": false,
+                          "type": "object",
+                          "properties": {
+                            "firstRow": {
+                              "description": "Emphasize the first (header) row",
+                              "type": "boolean"
+                            },
+                            "lastRow": {
+                              "description": "Emphasize the last (total) row",
+                              "type": "boolean"
+                            },
+                            "firstColumn": {
+                              "description": "Emphasize the first column",
+                              "type": "boolean"
+                            },
+                            "lastColumn": {
+                              "description": "Emphasize the last column",
+                              "type": "boolean"
+                            },
+                            "bandedRows": {
+                              "description": "Alternate row shading (zebra striping)",
+                              "type": "boolean"
+                            },
+                            "bandedColumns": {
+                              "description": "Alternate column shading",
+                              "type": "boolean"
+                            }
+                          }
                         }
                       }
                     },
@@ -20704,6 +21165,35 @@
                                       "type": "string"
                                     }
                                   ]
+                                },
+                                "indent": {
+                                  "description": "Paragraph indent options",
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "left": {
+                                      "description": "Left indent in twips (1/20 of a point)",
+                                      "type": "number"
+                                    },
+                                    "right": {
+                                      "description": "Right indent in twips (1/20 of a point)",
+                                      "type": "number"
+                                    },
+                                    "firstLine": {
+                                      "minimum": 0,
+                                      "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                                      "type": "number"
+                                    },
+                                    "hanging": {
+                                      "minimum": 0,
+                                      "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                                      "type": "number"
+                                    },
+                                    "firstLineChars": {
+                                      "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                      "type": "number"
+                                    }
+                                  }
                                 },
                                 "pageBreak": {
                                   "description": "Insert page break before paragraph",
@@ -22589,6 +23079,37 @@
                                   "description": "Repeat the header row on each page when the table spans multiple pages. Defaults to false.",
                                   "default": true,
                                   "type": "boolean"
+                                },
+                                "tableLook": {
+                                  "description": "Word \"Table Look\" flags for conditional formatting (banded rows, header/total row emphasis, etc.). Requires a table style that defines the corresponding variants.",
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "firstRow": {
+                                      "description": "Emphasize the first (header) row",
+                                      "type": "boolean"
+                                    },
+                                    "lastRow": {
+                                      "description": "Emphasize the last (total) row",
+                                      "type": "boolean"
+                                    },
+                                    "firstColumn": {
+                                      "description": "Emphasize the first column",
+                                      "type": "boolean"
+                                    },
+                                    "lastColumn": {
+                                      "description": "Emphasize the last column",
+                                      "type": "boolean"
+                                    },
+                                    "bandedRows": {
+                                      "description": "Alternate row shading (zebra striping)",
+                                      "type": "boolean"
+                                    },
+                                    "bandedColumns": {
+                                      "description": "Alternate column shading",
+                                      "type": "boolean"
+                                    }
+                                  }
                                 }
                               },
                               "required": ["columns"]
@@ -23443,6 +23964,41 @@
                                     },
                                     "required": ["styleId", "level"]
                                   }
+                                },
+                                "cachedEntries": {
+                                  "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "title": {
+                                        "description": "Entry title text as it should appear in the cached TOC",
+                                        "type": "string"
+                                      },
+                                      "level": {
+                                        "minimum": 1,
+                                        "maximum": 6,
+                                        "description": "Outline level (1-6) of the entry",
+                                        "type": "number"
+                                      },
+                                      "page": {
+                                        "minimum": 1,
+                                        "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
+                                        "type": "number"
+                                      },
+                                      "href": {
+                                        "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["title", "level"]
+                                  }
+                                },
+                                "beginDirty": {
+                                  "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                                  "type": "boolean"
                                 }
                               }
                             }
@@ -24085,6 +24641,35 @@
                                                 "type": "string"
                                               }
                                             ]
+                                          },
+                                          "indent": {
+                                            "description": "Paragraph indent options",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "left": {
+                                                "description": "Left indent in twips (1/20 of a point)",
+                                                "type": "number"
+                                              },
+                                              "right": {
+                                                "description": "Right indent in twips (1/20 of a point)",
+                                                "type": "number"
+                                              },
+                                              "firstLine": {
+                                                "minimum": 0,
+                                                "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                                                "type": "number"
+                                              },
+                                              "hanging": {
+                                                "minimum": 0,
+                                                "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                                                "type": "number"
+                                              },
+                                              "firstLineChars": {
+                                                "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                                "type": "number"
+                                              }
+                                            }
                                           },
                                           "pageBreak": {
                                             "description": "Insert page break before paragraph",
@@ -25970,6 +26555,37 @@
                                             "description": "Repeat the header row on each page when the table spans multiple pages. Defaults to false.",
                                             "default": true,
                                             "type": "boolean"
+                                          },
+                                          "tableLook": {
+                                            "description": "Word \"Table Look\" flags for conditional formatting (banded rows, header/total row emphasis, etc.). Requires a table style that defines the corresponding variants.",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "firstRow": {
+                                                "description": "Emphasize the first (header) row",
+                                                "type": "boolean"
+                                              },
+                                              "lastRow": {
+                                                "description": "Emphasize the last (total) row",
+                                                "type": "boolean"
+                                              },
+                                              "firstColumn": {
+                                                "description": "Emphasize the first column",
+                                                "type": "boolean"
+                                              },
+                                              "lastColumn": {
+                                                "description": "Emphasize the last column",
+                                                "type": "boolean"
+                                              },
+                                              "bandedRows": {
+                                                "description": "Alternate row shading (zebra striping)",
+                                                "type": "boolean"
+                                              },
+                                              "bandedColumns": {
+                                                "description": "Alternate column shading",
+                                                "type": "boolean"
+                                              }
+                                            }
                                           }
                                         },
                                         "required": ["columns"]
@@ -26824,6 +27440,41 @@
                                               },
                                               "required": ["styleId", "level"]
                                             }
+                                          },
+                                          "cachedEntries": {
+                                            "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
+                                            "type": "array",
+                                            "items": {
+                                              "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
+                                              "additionalProperties": false,
+                                              "type": "object",
+                                              "properties": {
+                                                "title": {
+                                                  "description": "Entry title text as it should appear in the cached TOC",
+                                                  "type": "string"
+                                                },
+                                                "level": {
+                                                  "minimum": 1,
+                                                  "maximum": 6,
+                                                  "description": "Outline level (1-6) of the entry",
+                                                  "type": "number"
+                                                },
+                                                "page": {
+                                                  "minimum": 1,
+                                                  "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
+                                                  "type": "number"
+                                                },
+                                                "href": {
+                                                  "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": ["title", "level"]
+                                            }
+                                          },
+                                          "beginDirty": {
+                                            "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                                            "type": "boolean"
                                           }
                                         }
                                       }
@@ -27928,6 +28579,35 @@
                                                           "type": "string"
                                                         }
                                                       ]
+                                                    },
+                                                    "indent": {
+                                                      "description": "Paragraph indent options",
+                                                      "additionalProperties": false,
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "left": {
+                                                          "description": "Left indent in twips (1/20 of a point)",
+                                                          "type": "number"
+                                                        },
+                                                        "right": {
+                                                          "description": "Right indent in twips (1/20 of a point)",
+                                                          "type": "number"
+                                                        },
+                                                        "firstLine": {
+                                                          "minimum": 0,
+                                                          "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                                                          "type": "number"
+                                                        },
+                                                        "hanging": {
+                                                          "minimum": 0,
+                                                          "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                                                          "type": "number"
+                                                        },
+                                                        "firstLineChars": {
+                                                          "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                                          "type": "number"
+                                                        }
+                                                      }
                                                     },
                                                     "pageBreak": {
                                                       "description": "Insert page break before paragraph",
@@ -29585,6 +30265,35 @@
                                               }
                                             ]
                                           },
+                                          "indent": {
+                                            "description": "Paragraph indent options",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "left": {
+                                                "description": "Left indent in twips (1/20 of a point)",
+                                                "type": "number"
+                                              },
+                                              "right": {
+                                                "description": "Right indent in twips (1/20 of a point)",
+                                                "type": "number"
+                                              },
+                                              "firstLine": {
+                                                "minimum": 0,
+                                                "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                                                "type": "number"
+                                              },
+                                              "hanging": {
+                                                "minimum": 0,
+                                                "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                                                "type": "number"
+                                              },
+                                              "firstLineChars": {
+                                                "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                                "type": "number"
+                                              }
+                                            }
+                                          },
                                           "pageBreak": {
                                             "description": "Insert page break before paragraph",
                                             "type": "boolean"
@@ -30696,6 +31405,35 @@
                       "type": "string"
                     }
                   ]
+                },
+                "indent": {
+                  "description": "Paragraph indent options",
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "left": {
+                      "description": "Left indent in twips (1/20 of a point)",
+                      "type": "number"
+                    },
+                    "right": {
+                      "description": "Right indent in twips (1/20 of a point)",
+                      "type": "number"
+                    },
+                    "firstLine": {
+                      "minimum": 0,
+                      "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                      "type": "number"
+                    },
+                    "hanging": {
+                      "minimum": 0,
+                      "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                      "type": "number"
+                    },
+                    "firstLineChars": {
+                      "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                      "type": "number"
+                    }
+                  }
                 },
                 "pageBreak": {
                   "description": "Insert page break before paragraph",
@@ -32581,6 +33319,37 @@
                   "description": "Repeat the header row on each page when the table spans multiple pages. Defaults to false.",
                   "default": true,
                   "type": "boolean"
+                },
+                "tableLook": {
+                  "description": "Word \"Table Look\" flags for conditional formatting (banded rows, header/total row emphasis, etc.). Requires a table style that defines the corresponding variants.",
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "firstRow": {
+                      "description": "Emphasize the first (header) row",
+                      "type": "boolean"
+                    },
+                    "lastRow": {
+                      "description": "Emphasize the last (total) row",
+                      "type": "boolean"
+                    },
+                    "firstColumn": {
+                      "description": "Emphasize the first column",
+                      "type": "boolean"
+                    },
+                    "lastColumn": {
+                      "description": "Emphasize the last column",
+                      "type": "boolean"
+                    },
+                    "bandedRows": {
+                      "description": "Alternate row shading (zebra striping)",
+                      "type": "boolean"
+                    },
+                    "bandedColumns": {
+                      "description": "Alternate column shading",
+                      "type": "boolean"
+                    }
+                  }
                 }
               },
               "required": ["columns"]
@@ -33435,6 +34204,41 @@
                     },
                     "required": ["styleId", "level"]
                   }
+                },
+                "cachedEntries": {
+                  "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
+                  "type": "array",
+                  "items": {
+                    "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
+                    "additionalProperties": false,
+                    "type": "object",
+                    "properties": {
+                      "title": {
+                        "description": "Entry title text as it should appear in the cached TOC",
+                        "type": "string"
+                      },
+                      "level": {
+                        "minimum": 1,
+                        "maximum": 6,
+                        "description": "Outline level (1-6) of the entry",
+                        "type": "number"
+                      },
+                      "page": {
+                        "minimum": 1,
+                        "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
+                        "type": "number"
+                      },
+                      "href": {
+                        "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
+                        "type": "string"
+                      }
+                    },
+                    "required": ["title", "level"]
+                  }
+                },
+                "beginDirty": {
+                  "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                  "type": "boolean"
                 }
               }
             }
@@ -34005,6 +34809,35 @@
                       "type": "string"
                     }
                   ]
+                },
+                "indent": {
+                  "description": "Paragraph indent options",
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "left": {
+                      "description": "Left indent in twips (1/20 of a point)",
+                      "type": "number"
+                    },
+                    "right": {
+                      "description": "Right indent in twips (1/20 of a point)",
+                      "type": "number"
+                    },
+                    "firstLine": {
+                      "minimum": 0,
+                      "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                      "type": "number"
+                    },
+                    "hanging": {
+                      "minimum": 0,
+                      "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                      "type": "number"
+                    },
+                    "firstLineChars": {
+                      "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                      "type": "number"
+                    }
+                  }
                 },
                 "pageBreak": {
                   "description": "Insert page break before paragraph",
@@ -35831,6 +36664,37 @@
                   "description": "Repeat the header row on each page when the table spans multiple pages. Defaults to false.",
                   "default": true,
                   "type": "boolean"
+                },
+                "tableLook": {
+                  "description": "Word \"Table Look\" flags for conditional formatting (banded rows, header/total row emphasis, etc.). Requires a table style that defines the corresponding variants.",
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "firstRow": {
+                      "description": "Emphasize the first (header) row",
+                      "type": "boolean"
+                    },
+                    "lastRow": {
+                      "description": "Emphasize the last (total) row",
+                      "type": "boolean"
+                    },
+                    "firstColumn": {
+                      "description": "Emphasize the first column",
+                      "type": "boolean"
+                    },
+                    "lastColumn": {
+                      "description": "Emphasize the last column",
+                      "type": "boolean"
+                    },
+                    "bandedRows": {
+                      "description": "Alternate row shading (zebra striping)",
+                      "type": "boolean"
+                    },
+                    "bandedColumns": {
+                      "description": "Alternate column shading",
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -37406,6 +38270,35 @@
                               "type": "string"
                             }
                           ]
+                        },
+                        "indent": {
+                          "description": "Paragraph indent options",
+                          "additionalProperties": false,
+                          "type": "object",
+                          "properties": {
+                            "left": {
+                              "description": "Left indent in twips (1/20 of a point)",
+                              "type": "number"
+                            },
+                            "right": {
+                              "description": "Right indent in twips (1/20 of a point)",
+                              "type": "number"
+                            },
+                            "firstLine": {
+                              "minimum": 0,
+                              "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                              "type": "number"
+                            },
+                            "hanging": {
+                              "minimum": 0,
+                              "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                              "type": "number"
+                            },
+                            "firstLineChars": {
+                              "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                              "type": "number"
+                            }
+                          }
                         },
                         "pageBreak": {
                           "description": "Insert page break before paragraph",
@@ -39291,6 +40184,37 @@
                           "description": "Repeat the header row on each page when the table spans multiple pages. Defaults to false.",
                           "default": true,
                           "type": "boolean"
+                        },
+                        "tableLook": {
+                          "description": "Word \"Table Look\" flags for conditional formatting (banded rows, header/total row emphasis, etc.). Requires a table style that defines the corresponding variants.",
+                          "additionalProperties": false,
+                          "type": "object",
+                          "properties": {
+                            "firstRow": {
+                              "description": "Emphasize the first (header) row",
+                              "type": "boolean"
+                            },
+                            "lastRow": {
+                              "description": "Emphasize the last (total) row",
+                              "type": "boolean"
+                            },
+                            "firstColumn": {
+                              "description": "Emphasize the first column",
+                              "type": "boolean"
+                            },
+                            "lastColumn": {
+                              "description": "Emphasize the last column",
+                              "type": "boolean"
+                            },
+                            "bandedRows": {
+                              "description": "Alternate row shading (zebra striping)",
+                              "type": "boolean"
+                            },
+                            "bandedColumns": {
+                              "description": "Alternate column shading",
+                              "type": "boolean"
+                            }
+                          }
                         }
                       },
                       "required": ["columns"]
@@ -40145,6 +41069,41 @@
                             },
                             "required": ["styleId", "level"]
                           }
+                        },
+                        "cachedEntries": {
+                          "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
+                          "type": "array",
+                          "items": {
+                            "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "description": "Entry title text as it should appear in the cached TOC",
+                                "type": "string"
+                              },
+                              "level": {
+                                "minimum": 1,
+                                "maximum": 6,
+                                "description": "Outline level (1-6) of the entry",
+                                "type": "number"
+                              },
+                              "page": {
+                                "minimum": 1,
+                                "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
+                                "type": "number"
+                              },
+                              "href": {
+                                "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
+                                "type": "string"
+                              }
+                            },
+                            "required": ["title", "level"]
+                          }
+                        },
+                        "beginDirty": {
+                          "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                          "type": "boolean"
                         }
                       }
                     }
@@ -40787,6 +41746,35 @@
                                         "type": "string"
                                       }
                                     ]
+                                  },
+                                  "indent": {
+                                    "description": "Paragraph indent options",
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "left": {
+                                        "description": "Left indent in twips (1/20 of a point)",
+                                        "type": "number"
+                                      },
+                                      "right": {
+                                        "description": "Right indent in twips (1/20 of a point)",
+                                        "type": "number"
+                                      },
+                                      "firstLine": {
+                                        "minimum": 0,
+                                        "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                                        "type": "number"
+                                      },
+                                      "hanging": {
+                                        "minimum": 0,
+                                        "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                                        "type": "number"
+                                      },
+                                      "firstLineChars": {
+                                        "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                        "type": "number"
+                                      }
+                                    }
                                   },
                                   "pageBreak": {
                                     "description": "Insert page break before paragraph",
@@ -42672,6 +43660,37 @@
                                     "description": "Repeat the header row on each page when the table spans multiple pages. Defaults to false.",
                                     "default": true,
                                     "type": "boolean"
+                                  },
+                                  "tableLook": {
+                                    "description": "Word \"Table Look\" flags for conditional formatting (banded rows, header/total row emphasis, etc.). Requires a table style that defines the corresponding variants.",
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "firstRow": {
+                                        "description": "Emphasize the first (header) row",
+                                        "type": "boolean"
+                                      },
+                                      "lastRow": {
+                                        "description": "Emphasize the last (total) row",
+                                        "type": "boolean"
+                                      },
+                                      "firstColumn": {
+                                        "description": "Emphasize the first column",
+                                        "type": "boolean"
+                                      },
+                                      "lastColumn": {
+                                        "description": "Emphasize the last column",
+                                        "type": "boolean"
+                                      },
+                                      "bandedRows": {
+                                        "description": "Alternate row shading (zebra striping)",
+                                        "type": "boolean"
+                                      },
+                                      "bandedColumns": {
+                                        "description": "Alternate column shading",
+                                        "type": "boolean"
+                                      }
+                                    }
                                   }
                                 },
                                 "required": ["columns"]
@@ -43526,6 +44545,41 @@
                                       },
                                       "required": ["styleId", "level"]
                                     }
+                                  },
+                                  "cachedEntries": {
+                                    "description": "Pre-rendered TOC entries. When supplied, Word displays the cached list immediately on first open instead of showing the \"right-click to update field\" placeholder. Word still recomputes the real TOC when the user updates fields.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Pre-rendered Table of Contents entry. Supplying cachedEntries makes Word display the TOC immediately on open instead of the \"right-click to update field\" placeholder.",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "title": {
+                                          "description": "Entry title text as it should appear in the cached TOC",
+                                          "type": "string"
+                                        },
+                                        "level": {
+                                          "minimum": 1,
+                                          "maximum": 6,
+                                          "description": "Outline level (1-6) of the entry",
+                                          "type": "number"
+                                        },
+                                        "page": {
+                                          "minimum": 1,
+                                          "description": "Page number to show for the entry. Omit to leave blank until Word updates the field.",
+                                          "type": "number"
+                                        },
+                                        "href": {
+                                          "description": "Optional bookmark or hyperlink target name (no leading #) used when the entry is clicked.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["title", "level"]
+                                    }
+                                  },
+                                  "beginDirty": {
+                                    "description": "Mark the TOC field as dirty so Word prompts to update it on open. Only meaningful when cachedEntries are supplied; defaults to false (silent display).",
+                                    "type": "boolean"
                                   }
                                 }
                               }
@@ -44621,6 +45675,35 @@
                                                   "type": "string"
                                                 }
                                               ]
+                                            },
+                                            "indent": {
+                                              "description": "Paragraph indent options",
+                                              "additionalProperties": false,
+                                              "type": "object",
+                                              "properties": {
+                                                "left": {
+                                                  "description": "Left indent in twips (1/20 of a point)",
+                                                  "type": "number"
+                                                },
+                                                "right": {
+                                                  "description": "Right indent in twips (1/20 of a point)",
+                                                  "type": "number"
+                                                },
+                                                "firstLine": {
+                                                  "minimum": 0,
+                                                  "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                                                  "type": "number"
+                                                },
+                                                "hanging": {
+                                                  "minimum": 0,
+                                                  "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                                                  "type": "number"
+                                                },
+                                                "firstLineChars": {
+                                                  "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                                  "type": "number"
+                                                }
+                                              }
                                             },
                                             "pageBreak": {
                                               "description": "Insert page break before paragraph",
@@ -46277,6 +47360,35 @@
                                         "type": "string"
                                       }
                                     ]
+                                  },
+                                  "indent": {
+                                    "description": "Paragraph indent options",
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "left": {
+                                        "description": "Left indent in twips (1/20 of a point)",
+                                        "type": "number"
+                                      },
+                                      "right": {
+                                        "description": "Right indent in twips (1/20 of a point)",
+                                        "type": "number"
+                                      },
+                                      "firstLine": {
+                                        "minimum": 0,
+                                        "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                                        "type": "number"
+                                      },
+                                      "hanging": {
+                                        "minimum": 0,
+                                        "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                                        "type": "number"
+                                      },
+                                      "firstLineChars": {
+                                        "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                                        "type": "number"
+                                      }
+                                    }
                                   },
                                   "pageBreak": {
                                     "description": "Insert page break before paragraph",

--- a/skills/json-to-office/assets/schemas/theme.schema.json
+++ b/skills/json-to-office/assets/schemas/theme.schema.json
@@ -13222,6 +13222,35 @@
                 }
               ]
             },
+            "indent": {
+              "description": "Paragraph indent options",
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "left": {
+                  "description": "Left indent in twips (1/20 of a point)",
+                  "type": "number"
+                },
+                "right": {
+                  "description": "Right indent in twips (1/20 of a point)",
+                  "type": "number"
+                },
+                "firstLine": {
+                  "minimum": 0,
+                  "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
+                  "type": "number"
+                },
+                "hanging": {
+                  "minimum": 0,
+                  "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
+                  "type": "number"
+                },
+                "firstLineChars": {
+                  "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                  "type": "number"
+                }
+              }
+            },
             "pageBreak": {
               "description": "Insert page break before paragraph",
               "type": "boolean"
@@ -15047,6 +15076,37 @@
               "description": "Repeat the header row on each page when the table spans multiple pages. Defaults to false.",
               "default": true,
               "type": "boolean"
+            },
+            "tableLook": {
+              "description": "Word \"Table Look\" flags for conditional formatting (banded rows, header/total row emphasis, etc.). Requires a table style that defines the corresponding variants.",
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "firstRow": {
+                  "description": "Emphasize the first (header) row",
+                  "type": "boolean"
+                },
+                "lastRow": {
+                  "description": "Emphasize the last (total) row",
+                  "type": "boolean"
+                },
+                "firstColumn": {
+                  "description": "Emphasize the first column",
+                  "type": "boolean"
+                },
+                "lastColumn": {
+                  "description": "Emphasize the last column",
+                  "type": "boolean"
+                },
+                "bandedRows": {
+                  "description": "Alternate row shading (zebra striping)",
+                  "type": "boolean"
+                },
+                "bandedColumns": {
+                  "description": "Alternate column shading",
+                  "type": "boolean"
+                }
+              }
             }
           }
         },

--- a/skills/json-to-office/assets/schemas/theme.schema.json
+++ b/skills/json-to-office/assets/schemas/theme.schema.json
@@ -13223,33 +13223,53 @@
               ]
             },
             "indent": {
-              "description": "Paragraph indent options",
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "left": {
-                  "description": "Left indent in twips (1/20 of a point)",
-                  "type": "number"
+              "description": "Paragraph indent options. firstLine and hanging are mutually exclusive — pick one variant.",
+              "anyOf": [
+                {
+                  "description": "Paragraph indent with first-line indent (twips and/or CJK char-grid).",
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "left": {
+                      "description": "Left indent in twips (1/20 of a point)",
+                      "type": "number"
+                    },
+                    "right": {
+                      "description": "Right indent in twips (1/20 of a point)",
+                      "type": "number"
+                    },
+                    "firstLine": {
+                      "minimum": 0,
+                      "description": "First-line indent in twips (1/20 of a point).",
+                      "type": "number"
+                    },
+                    "firstLineChars": {
+                      "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
+                      "type": "number"
+                    }
+                  }
                 },
-                "right": {
-                  "description": "Right indent in twips (1/20 of a point)",
-                  "type": "number"
-                },
-                "firstLine": {
-                  "minimum": 0,
-                  "description": "First-line indent in twips (1/20 of a point). Mutually exclusive with hanging.",
-                  "type": "number"
-                },
-                "hanging": {
-                  "minimum": 0,
-                  "description": "Hanging indent in twips (1/20 of a point). Mutually exclusive with firstLine.",
-                  "type": "number"
-                },
-                "firstLineChars": {
-                  "description": "First-line indent in hundredths of a character (e.g. 200 = 2 characters). CJK-friendly companion to firstLine; takes precedence when both are set.",
-                  "type": "number"
+                {
+                  "description": "Paragraph indent with hanging indent.",
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "left": {
+                      "description": "Left indent in twips (1/20 of a point)",
+                      "type": "number"
+                    },
+                    "right": {
+                      "description": "Right indent in twips (1/20 of a point)",
+                      "type": "number"
+                    },
+                    "hanging": {
+                      "minimum": 0,
+                      "description": "Hanging indent in twips (1/20 of a point).",
+                      "type": "number"
+                    }
+                  }
                 }
-              }
+              ]
             },
             "pageBreak": {
               "description": "Insert page break before paragraph",


### PR DESCRIPTION
## Summary

- Bumps `docx` peer/dep from **9.5.1 → 9.7.0** across `core-docx`, `shared-docx`, `json-to-docx` (plus the pnpm override).
- Surfaces three new optional fields that map directly to features added in docx 9.6.0 / 9.7.0:
  - **TOC `cachedEntries` + `beginDirty`** — pre-rendered TOC entries; Word displays the TOC immediately on first open instead of the "right-click to update field" placeholder. ([dolanmiu/docx#3319](https://github.com/dolanmiu/docx/pull/3319))
  - **Table `tableLook`** — Word conditional formatting (`firstRow`, `lastRow`, `firstColumn`, `lastColumn`, `bandedRows`, `bandedColumns`). Inverted internally to docx's `noHBand`/`noVBand` for a positive user-facing API. ([dolanmiu/docx#3317](https://github.com/dolanmiu/docx/pull/3317))
  - **Paragraph `indent`** — full block (`left`, `right`, `firstLine`, `hanging`, `firstLineChars`). Indent wasn't exposed at all before; `firstLineChars` is the new CJK char-grid companion to `firstLine`. ([dolanmiu/docx#3420](https://github.com/dolanmiu/docx/pull/3420))
- All additive — no breaking changes to existing `.docx.json` documents.
- Schema mirror under `skills/json-to-office/assets/schemas/` regenerated; large diff is mostly pre-existing drift from prior unrelated work, my new fields are clearly visible (`cachedEntries`, `beginDirty`, `tableLook`, `firstRow`, `bandedRows`, `firstLineChars`).
- Changeset included (minor bump for the three DOCX packages; linked rule will cascade to all `@json-to-office/*`).

### Out of scope (deferred to follow-ups)
- Endnotes ([#3354](https://github.com/dolanmiu/docx/pull/3354)), richer footnotes ([#3325](https://github.com/dolanmiu/docx/pull/3325)), comment threading ([#3424](https://github.com/dolanmiu/docx/pull/3424)), WPS text box ([#3369](https://github.com/dolanmiu/docx/pull/3369)) — these need new top-level components that don't exist in `core-docx/src/components` today.
- Header/footer tables don't get `tableLook` — banding/header-emphasis are meaningless on layout primitives.
- Auto-collecting TOC `cachedEntries` from the document tree (vs. requiring the JSON author to supply them). Possible as a layered enhancement on top of this PR.

## Test plan

- [x] `pnpm install` picks up docx 9.7.0
- [x] `pnpm check` — lint + typecheck + 396/396 tests pass (4 new structural tests verify the new fields actually serialize into the produced XML via `JSON.stringify` substring checks)
- [x] `pnpm generate:schemas` regenerates `/schemas` + skill mirror with the new fields
- [x] `pnpm cli docx generate skills/json-to-office/assets/templates/docx/report-long.docx.json --output /tmp/x.docx` renders cleanly on the bumped lib (template contains a TOC, so this exercises the new TOC constructor signature end-to-end)
- [ ] Manual: open the rendered TOC fixture in Word and confirm cached entries display on first open without the "right-click to update field" placeholder (requires authoring a TOC with `cachedEntries` set — none of the bundled templates do this yet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paragraph indent options extended (left, right, firstLine, hanging, plus CJK-friendly firstLineChars).
  * Table "tableLook" styling flags added (first/last row/column, banded rows/columns).
  * TOC can auto-populate cached entries from document headings; optional beginDirty toggles Word's update prompt behavior.

* **Chores**
  * Bumped docx dependency to 9.7.0.

* **Tests**
  * Added tests covering indent validation, tableLook flags, and TOC cached-entry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wiseair-srl/json-to-office/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->