### PR TITLE
fix(server): raise libreoffice-from-json body cap to 16 MB

### DIFF
--- a/packages/jto/src/server/routes/format.ts
+++ b/packages/jto/src/server/routes/format.ts
@@ -243,9 +243,10 @@ export function createFormatRouter(adapter: FormatAdapter) {
   router.post(
     '/preview/libreoffice-from-json',
     bodyLimit({
-      // Doc JSON + custom themes. 2 MB covers large report fixtures; anything
-      // bigger is almost certainly an attempt to OOM the worker.
-      maxSize: 2 * 1024 * 1024,
+      // Doc JSON + custom themes. 16 MB accommodates real-world docs that
+      // inline base64 image assets (logos, screenshots, chart images); the
+      // earlier 2 MB cap rejected legitimate payloads with 413.
+      maxSize: 16 * 1024 * 1024,
       onError: () => {
         throw new HTTPException(413, { message: 'Request body too large' });
       },


### PR DESCRIPTION
## Summary
- Root cause of repeated `413 Payload Too Large` on `/api/docx/preview/libreoffice-from-json` in prod: the route's hono `bodyLimit` middleware was set to **2 MB** ([format.ts:248](packages/jto/src/server/routes/format.ts:248)), but real-world docs that inline base64 image assets (logos, screenshots, chart images) routinely exceed that.
- Sibling `/api/docx/generate` has no `bodyLimit` and was succeeding on the same payloads — the asymmetry produced a flow where generation worked but preview always 413'd.
- Bumped cap to **16 MB**, in line with observed `/generate` response sizes (~7.2 MB) plus headroom.

## Test plan
- [ ] Deploy and reproduce the original Chrome-from-frontend flow: confirm `/preview/libreoffice-from-json` returns 200 + PDF for the previously-failing doc.
- [ ] Send a synthetic >16 MB payload and confirm 413 still fires (cap still enforced).
- [ ] Watch worker memory under sustained preview traffic — no OOM regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum file size limit for LibreOffice preview generation from 2 MB to 16 MB, enabling processing of larger documents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wiseair-srl/json-to-office/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->