### PR TITLE
feat(docx): tracked-change document diff (CLI, API, playground)

### DIFF
--- a/.changeset/docx-diff.md
+++ b/.changeset/docx-diff.md
@@ -1,0 +1,20 @@
+---
+'@json-to-office/shared-docx': minor
+'@json-to-office/core-docx': minor
+'@json-to-office/json-to-docx': minor
+'@json-to-office/jto-cli': minor
+'@json-to-office/jto': minor
+---
+
+feat(docx): tracked-change document diff
+
+Diff two docx JSON definitions into a redline rendered as native Word tracked
+changes (accept/reject, author, timestamp; opens in review mode).
+
+- New `revision` prop on `paragraph`/`heading`/`list` items and a
+  `trackRevisions` root prop, rendered as `w:ins`/`w:del`.
+- `diffDocuments(oldDoc, newDoc)` (word-level diff, block alignment, fidelity
+  summary), re-exported from `@json-to-office/json-to-docx`.
+- CLI: `jto docx diff <old> <new> -o redline.docx`.
+- Playground: `POST /api/docx/diff` endpoint and a Compare dialog that opens
+  the redline as a normal document with live preview.

--- a/README.md
+++ b/README.md
@@ -280,6 +280,16 @@ An artifact rendered once and emailed? Any tool works. An _output of your platfo
 | highcharts | Server-side chart rendering                                                       |
 | slide      | Grid-based positioning, backgrounds, templates                                    |
 
+### Document diff (DOCX)
+
+Because documents are data, two versions diff like data — and the result opens in Word as native tracked changes:
+
+```bash
+jto docx diff contract-v1.json contract-v2.json -o redline.docx
+```
+
+Every text edit becomes a real Word revision (accept/reject, author, timestamp) and the file opens in review mode. Word-level diff on paragraphs, headings, and list items; structural changes (tables, images, charts) are replaced and reported in the CLI summary. Programmatic API: `diffDocuments(oldDoc, newDoc)` from `@json-to-office/json-to-docx`; HTTP API: `POST /api/docx/diff`. In the visual playground (`jto docx dev`), use the **Compare** button in the sidebar to diff two documents and open the redline with live preview. Try it with [examples/contract-v1.docx.json](examples/contract-v1.docx.json) and [contract-v2.docx.json](examples/contract-v2.docx.json).
+
 ### Cross-format
 
 - **Theme system**: colors, fonts, spacing, component defaults. 3 built-in themes per format (minimal, corporate, vibrant/modern), or define your own.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,9 +2,11 @@
 
 Real-world JSON document definitions you can render with json-to-office.
 
-| File                                   | Format | Description                                                                        |
-| -------------------------------------- | ------ | ---------------------------------------------------------------------------------- |
-| [invoice.docx.json](invoice.docx.json) | DOCX   | Northvane Studio invoice with line items, payment instructions, and retainer terms |
+| File                                           | Format | Description                                                                        |
+| ---------------------------------------------- | ------ | ---------------------------------------------------------------------------------- |
+| [invoice.docx.json](invoice.docx.json)         | DOCX   | Northvane Studio invoice with line items, payment instructions, and retainer terms |
+| [contract-v1.docx.json](contract-v1.docx.json) | DOCX   | Service agreement (base version) — diff it against v2 for a tracked-change redline |
+| [contract-v2.docx.json](contract-v2.docx.json) | DOCX   | Service agreement (revised version) for `jto docx diff`                            |
 
 More templates are available in the visual playground — run `jto pptx dev` or `jto docx dev` to browse the full gallery.
 
@@ -14,6 +16,9 @@ More templates are available in the visual playground — run `jto pptx dev` or 
 # With the CLI
 npm install -g @json-to-office/jto
 jto docx generate ./invoice.docx.json -o ./invoice.docx
+
+# Diff two versions into a redline with native Word tracked changes
+jto docx diff ./contract-v1.docx.json ./contract-v2.docx.json -o ./redline.docx
 
 # Or open in the visual playground
 jto docx dev

--- a/examples/contract-v1.docx.json
+++ b/examples/contract-v1.docx.json
@@ -1,0 +1,47 @@
+{
+  "name": "docx",
+  "props": {
+    "theme": "minimal",
+    "metadata": { "title": "Service Agreement", "author": "Wiseair" }
+  },
+  "children": [
+    { "name": "heading", "props": { "text": "Service Agreement", "level": 1 } },
+    {
+      "name": "paragraph",
+      "props": {
+        "text": "This Service Agreement is entered into by Wiseair S.r.l. and the Client as of January 1, 2026."
+      }
+    },
+    { "name": "heading", "props": { "text": "1. Fees", "level": 2 } },
+    {
+      "name": "paragraph",
+      "props": {
+        "text": "The Client shall pay a fee equal to 10% of monthly revenue, invoiced quarterly with payment due within 60 days."
+      }
+    },
+    { "name": "heading", "props": { "text": "2. Deliverables", "level": 2 } },
+    {
+      "name": "list",
+      "props": {
+        "items": [
+          "Monthly air quality report",
+          "Quarterly executive summary",
+          "Annual sustainability audit"
+        ]
+      }
+    },
+    { "name": "heading", "props": { "text": "3. Termination", "level": 2 } },
+    {
+      "name": "paragraph",
+      "props": {
+        "text": "Either party may terminate this agreement with 30 days written notice."
+      }
+    },
+    {
+      "name": "paragraph",
+      "props": {
+        "text": "Upon termination, all outstanding fees become immediately payable."
+      }
+    }
+  ]
+}

--- a/examples/contract-v2.docx.json
+++ b/examples/contract-v2.docx.json
@@ -1,0 +1,48 @@
+{
+  "name": "docx",
+  "props": {
+    "theme": "minimal",
+    "metadata": { "title": "Service Agreement", "author": "Wiseair" }
+  },
+  "children": [
+    { "name": "heading", "props": { "text": "Service Agreement", "level": 1 } },
+    {
+      "name": "paragraph",
+      "props": {
+        "text": "This Service Agreement is entered into by Wiseair S.r.l. and the Client as of June 1, 2026."
+      }
+    },
+    { "name": "heading", "props": { "text": "1. Fees", "level": 2 } },
+    {
+      "name": "paragraph",
+      "props": {
+        "text": "The Client shall pay a fee equal to 12% of monthly revenue, invoiced monthly with payment due within 30 days."
+      }
+    },
+    { "name": "heading", "props": { "text": "2. Deliverables", "level": 2 } },
+    {
+      "name": "list",
+      "props": {
+        "items": [
+          "Monthly air quality report",
+          "Quarterly executive summary with KPI dashboard",
+          "Annual sustainability audit",
+          "Real-time alerting via API"
+        ]
+      }
+    },
+    { "name": "heading", "props": { "text": "3. Termination", "level": 2 } },
+    {
+      "name": "paragraph",
+      "props": {
+        "text": "Either party may terminate this agreement with 60 days written notice."
+      }
+    },
+    {
+      "name": "paragraph",
+      "props": {
+        "text": "A renewal proposal will be issued 90 days before expiry."
+      }
+    }
+  ]
+}

--- a/packages/core-docx/src/__tests__/revision-rendering.test.ts
+++ b/packages/core-docx/src/__tests__/revision-rendering.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Revision rendering: `revision` props must produce native OOXML tracked
+ * changes (w:ins / w:del) and `trackRevisions` must reach settings.xml.
+ */
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { generateBufferFromJson } from '../core/generator';
+
+async function readZipEntry(buf: Buffer, path: string): Promise<string> {
+  const zip = await JSZip.loadAsync(buf);
+  const entry = zip.file(path);
+  if (!entry) throw new Error(`${path} missing`);
+  return entry.async('string');
+}
+
+const REVISION = {
+  author: 'jto-agent',
+  date: '2026-06-09T10:00:00Z',
+  segments: [
+    { type: 'equal', text: 'The fee is ' },
+    { type: 'delete', text: '10%' },
+    { type: 'insert', text: '12%' },
+    { type: 'equal', text: ' of revenue.' },
+  ],
+};
+
+describe('tracked-change rendering', () => {
+  it('renders paragraph revision segments as w:ins and w:del', async () => {
+    const buf = await generateBufferFromJson({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'paragraph',
+          props: { text: 'The fee is 12% of revenue.', revision: REVISION },
+        },
+      ],
+    } as any);
+    const xml = await readZipEntry(buf, 'word/document.xml');
+    expect(xml).toMatch(/<w:ins [^>]*w:author="jto-agent"/);
+    expect(xml).toMatch(/<w:del [^>]*w:author="jto-agent"/);
+    expect(xml).toContain('12%');
+    expect(xml).toMatch(/<w:delText[^>]*>10%<\/w:delText>/);
+  });
+
+  it('renders heading revisions and keeps heading style', async () => {
+    const buf = await generateBufferFromJson({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'heading',
+          props: {
+            text: 'New Title',
+            level: 1,
+            revision: {
+              segments: [
+                { type: 'delete', text: 'Old Title' },
+                { type: 'insert', text: 'New Title' },
+              ],
+            },
+          },
+        },
+      ],
+    } as any);
+    const xml = await readZipEntry(buf, 'word/document.xml');
+    expect(xml).toContain('<w:ins ');
+    expect(xml).toContain('<w:del ');
+    expect(xml).toMatch(/<w:delText[^>]*>Old Title<\/w:delText>/);
+  });
+
+  it('renders list item revisions including fully deleted items', async () => {
+    const buf = await generateBufferFromJson({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'list',
+          props: {
+            items: [
+              { text: 'alpha', level: 0 },
+              {
+                text: '',
+                level: 0,
+                revision: { segments: [{ type: 'delete', text: 'beta' }] },
+              },
+              {
+                text: 'gamma',
+                level: 0,
+                revision: { segments: [{ type: 'insert', text: 'gamma' }] },
+              },
+            ],
+          },
+        },
+      ],
+    } as any);
+    const xml = await readZipEntry(buf, 'word/document.xml');
+    expect(xml).toMatch(/<w:delText[^>]*>beta<\/w:delText>/);
+    expect(xml).toContain('<w:ins ');
+    expect(xml).toContain('gamma');
+  });
+
+  it('emits w:trackRevisions in settings.xml when trackRevisions is set', async () => {
+    const buf = await generateBufferFromJson({
+      name: 'docx',
+      props: { theme: 'minimal', trackRevisions: true },
+      children: [{ name: 'paragraph', props: { text: 'x' } }],
+    } as any);
+    const settings = await readZipEntry(buf, 'word/settings.xml');
+    expect(settings).toContain('<w:trackRevisions/>');
+  });
+
+  it('does not emit w:trackRevisions by default', async () => {
+    const buf = await generateBufferFromJson({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [{ name: 'paragraph', props: { text: 'x' } }],
+    } as any);
+    const settings = await readZipEntry(buf, 'word/settings.xml');
+    expect(settings).not.toContain('<w:trackRevisions/>');
+  });
+
+  it('renders \\n in segments as line breaks (w:br), not literal newlines', async () => {
+    const buf = await generateBufferFromJson({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'paragraph',
+          props: {
+            text: 'line one\nline two',
+            revision: {
+              segments: [
+                { type: 'equal', text: 'line one\nline two' },
+                { type: 'insert', text: ' added' },
+              ],
+            },
+          },
+        },
+      ],
+    } as any);
+    const xml = await readZipEntry(buf, 'word/document.xml');
+    expect(xml).toContain('<w:br/>');
+    expect(xml).not.toMatch(/<w:t[^>]*>line one\nline two<\/w:t>/);
+  });
+
+  it('resolves placeholders in unchanged (equal) segments', async () => {
+    const buf = await generateBufferFromJson({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'paragraph',
+          props: {
+            text: 'Generated {YEAR} for final review',
+            revision: {
+              segments: [
+                { type: 'equal', text: 'Generated {YEAR} for ' },
+                { type: 'insert', text: 'final ' },
+                { type: 'equal', text: 'review' },
+              ],
+            },
+          },
+        },
+      ],
+    } as any);
+    const xml = await readZipEntry(buf, 'word/document.xml');
+    expect(xml).not.toContain('{YEAR}');
+    expect(xml).toContain(String(new Date().getFullYear()));
+  });
+
+  it('keeps the bookmark anchor on a revised paragraph with an id', async () => {
+    const buf = await generateBufferFromJson({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'paragraph',
+          props: { text: 'See [the target](#target) below.' },
+        },
+        {
+          name: 'paragraph',
+          props: {
+            text: 'Target paragraph revised',
+            id: 'target',
+            revision: {
+              segments: [
+                { type: 'equal', text: 'Target paragraph ' },
+                { type: 'insert', text: 'revised' },
+              ],
+            },
+          },
+        },
+      ],
+    } as any);
+    const xml = await readZipEntry(buf, 'word/document.xml');
+    expect(xml).toMatch(/<w:bookmarkStart[^>]*w:name="target"/);
+  });
+
+  it('bypasses the component cache for revisions nested in containers', async () => {
+    const textBox = {
+      name: 'text-box',
+      props: {},
+      children: [
+        {
+          name: 'paragraph',
+          props: {
+            text: 'inner',
+            revision: { segments: [{ type: 'insert', text: 'inner' }] },
+          },
+        },
+      ],
+    };
+    // Doc A primes the cache with the container's rendered (id-bearing) runs
+    await generateBufferFromJson({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [textBox],
+    } as any);
+    // Doc B renders another revision first, then the identical container:
+    // a stale cache hit would replay duplicate ids
+    const buf = await generateBufferFromJson({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'paragraph',
+          props: {
+            text: 'outer',
+            revision: { segments: [{ type: 'insert', text: 'outer' }] },
+          },
+        },
+        textBox,
+      ],
+    } as any);
+    const xml = await readZipEntry(buf, 'word/document.xml');
+    const ids = [...xml.matchAll(/<w:ins [^>]*w:id="(\d+)"/g)].map((m) => m[1]);
+    expect(ids.length).toBe(2);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it('assigns unique revision ids within a document', async () => {
+    const buf = await generateBufferFromJson({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'paragraph',
+          props: {
+            text: 'a',
+            revision: { segments: [{ type: 'insert', text: 'a' }] },
+          },
+        },
+        {
+          name: 'paragraph',
+          props: {
+            text: 'b',
+            revision: { segments: [{ type: 'insert', text: 'b' }] },
+          },
+        },
+      ],
+    } as any);
+    const xml = await readZipEntry(buf, 'word/document.xml');
+    const ids = [...xml.matchAll(/<w:ins [^>]*w:id="(\d+)"/g)].map((m) => m[1]);
+    expect(ids.length).toBe(2);
+    expect(new Set(ids).size).toBe(2);
+  });
+});

--- a/packages/core-docx/src/components/heading.ts
+++ b/packages/core-docx/src/components/heading.ts
@@ -53,6 +53,8 @@ export function renderHeadingComponent(
       keepLines: config.keepLines,
       // Bookmark ID for internal linking
       bookmarkId: bookmarkId,
+      // Tracked-change segments (rendered as native Word revisions)
+      revision: config.revision,
     }
   );
 

--- a/packages/core-docx/src/components/paragraph.ts
+++ b/packages/core-docx/src/components/paragraph.ts
@@ -79,8 +79,12 @@ export function renderParagraphComponent(
   // Props are pre-resolved by resolveComponentTree
   const resolvedConfig = component.props;
 
-  // Check if text contains markdown list syntax
-  const listData = parseMarkdownList(resolvedConfig.text);
+  // Check if text contains markdown list syntax.
+  // Revision paragraphs always render as plain text: their segments carry
+  // literal text and cannot be re-split into list items.
+  const listData = resolvedConfig.revision
+    ? null
+    : parseMarkdownList(resolvedConfig.text);
 
   if (listData) {
     // Text is a markdown list - render as proper docx list
@@ -201,6 +205,8 @@ export function renderParagraphComponent(
     keepLines: resolvedConfig.keepLines,
     // Pass bookmark ID for internal linking
     bookmarkId: resolvedConfig.id,
+    // Tracked-change segments (rendered as native Word revisions)
+    revision: resolvedConfig.revision,
   });
 
   return [text];

--- a/packages/core-docx/src/core/cached-render.ts
+++ b/packages/core-docx/src/core/cached-render.ts
@@ -13,6 +13,7 @@ import {
   CachedComponent,
 } from '../cache';
 import { renderComponent } from './render';
+import { componentHasRevision } from '../utils/revisionUtils';
 import { createHash } from 'crypto';
 
 // Global component cache instance
@@ -93,7 +94,12 @@ export async function renderComponentWithCache(
   //   can produce stale references to non-existent bookmarks on re-render.
   // - 'section' generates unique bookmarks internally; caching would duplicate
   //   bookmark IDs across sections/documents.
-  const forceBypassForType = component.name === 'toc' || component.name === 'section';
+  // - revision-bearing components embed document-scoped w:ins/w:del ids from
+  //   a per-render counter; caching would leak ids across documents.
+  const forceBypassForType =
+    component.name === 'toc' ||
+    component.name === 'section' ||
+    componentHasRevision(component);
 
   // Initialize cache if needed
   if (!componentCache) {
@@ -181,13 +187,22 @@ export async function warmComponentCache(
     context: RenderContext;
   }>
 ): Promise<void> {
-  if (!componentCache || !componentCache.getConfig().performance.enableWarming) {
+  if (
+    !componentCache ||
+    !componentCache.getConfig().performance.enableWarming
+  ) {
     return;
   }
 
   const warmingPromises = components.map(
     async ({ component, theme, themeName, context }) => {
-      await renderComponentWithCache(component, theme, themeName, context, false);
+      await renderComponentWithCache(
+        component,
+        theme,
+        themeName,
+        context,
+        false
+      );
     }
   );
 

--- a/packages/core-docx/src/core/content.ts
+++ b/packages/core-docx/src/core/content.ts
@@ -40,6 +40,8 @@ import { processTextWithPlaceholders } from '../utils/placeholderProcessor';
 import { normalizeUnicodeText } from '../utils/unicode';
 import { getStyleIdForLevel } from '../styles/themeToDocxAdapter';
 import { globalBookmarkRegistry } from '../utils/bookmarkRegistry';
+import { createRevisionRuns } from '../utils/revisionUtils';
+import type { Revision } from '@json-to-office/shared-docx';
 import { resolveFontFamily } from '../styles/utils/styleHelpers';
 import { synthesizeFamilyName } from '@json-to-office/shared';
 import {
@@ -144,6 +146,9 @@ export interface TextOptions {
   keepNext?: boolean;
   // Keep all lines of paragraph together
   keepLines?: boolean;
+  // Tracked-change segments: when present, text is rendered from these
+  // (as native Word revisions) instead of the plain content string
+  revision?: Revision;
 }
 
 export interface ImageOptions {
@@ -256,6 +261,7 @@ export function createText(
     | ExternalHyperlink
     | InternalHyperlink
     | Bookmark
+    | import('../utils/revisionUtils').RevisionRun
   )[] = [];
 
   // Add column break if requested
@@ -295,31 +301,53 @@ export function createText(
     }),
   };
 
-  // Add text content - parseTextWithDecorators handles both decorators and newlines
-  const textRuns = parseTextWithDecorators(normalizedContent, baseTextStyle, {
-    boldColor: options.boldColor,
-    enableHyperlinks: true,
-  });
-
-  // If bookmarkId is provided, wrap text runs in a bookmark
-  if (options.bookmarkId) {
-    // Register bookmark
-    globalBookmarkRegistry.register(
-      options.bookmarkId,
-      normalizedContent,
-      'paragraph'
-    );
-
-    // Wrap text runs in bookmark
-    children.push(
-      new Bookmark({
-        id: options.bookmarkId,
-        children: textRuns as TextRun[],
-      })
-    );
+  if (options.revision) {
+    // Tracked changes: render revision segments as native w:ins/w:del runs
+    // (literal text, no markdown parsing). Bookmarks are preserved so
+    // internal hyperlinks targeting this paragraph keep working.
+    const revisionRuns = createRevisionRuns(options.revision, baseTextStyle);
+    if (options.bookmarkId) {
+      globalBookmarkRegistry.register(
+        options.bookmarkId,
+        normalizedContent,
+        'paragraph'
+      );
+      children.push(
+        new Bookmark({
+          id: options.bookmarkId,
+          children: revisionRuns as TextRun[],
+        })
+      );
+    } else {
+      children.push(...revisionRuns);
+    }
   } else {
-    // No bookmark, add text runs directly
-    children.push(...textRuns);
+    // Add text content - parseTextWithDecorators handles both decorators and newlines
+    const textRuns = parseTextWithDecorators(normalizedContent, baseTextStyle, {
+      boldColor: options.boldColor,
+      enableHyperlinks: true,
+    });
+
+    // If bookmarkId is provided, wrap text runs in a bookmark
+    if (options.bookmarkId) {
+      // Register bookmark
+      globalBookmarkRegistry.register(
+        options.bookmarkId,
+        normalizedContent,
+        'paragraph'
+      );
+
+      // Wrap text runs in bookmark
+      children.push(
+        new Bookmark({
+          id: options.bookmarkId,
+          children: textRuns as TextRun[],
+        })
+      );
+    } else {
+      // No bookmark, add text runs directly
+      children.push(...textRuns);
+    }
   }
 
   // Build frame options for floating text
@@ -509,8 +537,26 @@ export function createHeading(
     }),
   };
 
-  // Create bookmark if bookmarkId is provided
-  if (options.bookmarkId) {
+  if (options.revision) {
+    // Tracked changes: revision segments replace text rendering. The TOC
+    // bookmark is preserved so TOC links and cross-references keep working.
+    const revisionRuns = createRevisionRuns(options.revision, baseTextStyle);
+    if (options.bookmarkId) {
+      globalBookmarkRegistry.register(
+        options.bookmarkId,
+        normalizedText,
+        'heading'
+      );
+      children.push(
+        new Bookmark({
+          id: options.bookmarkId,
+          children: revisionRuns as TextRun[],
+        })
+      );
+    } else {
+      children.push(...revisionRuns);
+    }
+  } else if (options.bookmarkId) {
     // Register bookmark
     globalBookmarkRegistry.register(
       options.bookmarkId,
@@ -789,7 +835,7 @@ export function createStatistic(
  * Create a list of items using proper docx numbering
  */
 export function createList(
-  items: (string | { text: string; level?: number })[],
+  items: (string | { text: string; level?: number; revision?: Revision })[],
   _theme: ThemeConfig,
   _themeName: string,
   options: ListOptions = {}
@@ -804,20 +850,25 @@ export function createList(
     // Handle both string and object items
     const itemText = typeof item === 'string' ? item : item.text;
     const itemLevel = typeof item === 'object' ? item.level || 0 : 0;
+    const itemRevision = typeof item === 'object' ? item.revision : undefined;
 
-    if (!itemText.trim()) {
-      return; // Skip empty items
+    // Skip empty items — unless they carry revision data (a fully deleted
+    // item has empty new text but must still render its w:del runs)
+    if (!itemText.trim() && !itemRevision) {
+      return;
     }
 
     // Parse rich text decorators for each item
     // Don't pass font/size/color - let list items inherit from Normal paragraph style
-    const textRuns = parseTextWithDecorators(
-      itemText,
-      {},
-      {
-        enableHyperlinks: true,
-      }
-    );
+    const textRuns = itemRevision
+      ? createRevisionRuns(itemRevision, {})
+      : parseTextWithDecorators(
+          itemText,
+          {},
+          {
+            enableHyperlinks: true,
+          }
+        );
 
     // Calculate spacing for this item (convert points to twips)
     const spacing: { before?: number; after?: number } = {};

--- a/packages/core-docx/src/core/render.ts
+++ b/packages/core-docx/src/core/render.ts
@@ -116,6 +116,10 @@ export async function renderDocument(
   const { globalNumberingRegistry } = await import('../utils/numberingConfig');
   globalNumberingRegistry.clear();
 
+  // Revision ids (w:ins/w:del) are deliberately NOT reset here: the counter
+  // is process-wide so concurrent renders draw from disjoint id sets
+  // (intra-document uniqueness is the OOXML invariant; see revisionUtils.ts)
+
   const sections: ISectionOptions[] = [];
 
   // Render all layout sections
@@ -238,6 +242,8 @@ export async function renderDocument(
     sections,
     features: {
       updateFields: true, // Required for TOC fields to update correctly
+      // Word opens the document in review mode (further edits are tracked)
+      ...(structure.trackRevisions && { trackRevisions: true }),
     },
     // Add numbering configurations if any lists were rendered
     ...(numberingConfigs.length > 0 && {

--- a/packages/core-docx/src/core/structure.ts
+++ b/packages/core-docx/src/core/structure.ts
@@ -24,6 +24,8 @@ export interface ProcessedDocument {
   sections: ProcessedSection[];
   theme: ThemeConfig;
   themeName: string;
+  /** Open the generated document in track-changes mode */
+  trackRevisions?: boolean;
 }
 
 export interface DocumentMetadata {
@@ -110,6 +112,7 @@ export async function processDocument(
     sections,
     theme: effectiveTheme,
     themeName,
+    trackRevisions: document.props.trackRevisions,
   };
 }
 

--- a/packages/core-docx/src/utils/revisionUtils.ts
+++ b/packages/core-docx/src/utils/revisionUtils.ts
@@ -1,0 +1,167 @@
+/**
+ * Revision (tracked-change) rendering utilities
+ *
+ * Turns `revision.segments` from the JSON definition into native Word
+ * revision runs (w:ins / w:del) via docx.js InsertedTextRun / DeletedTextRun.
+ */
+
+import { TextRun, InsertedTextRun, DeletedTextRun } from 'docx';
+import type { IRunOptions, ParagraphChild } from 'docx';
+import type { Revision } from '@json-to-office/shared-docx';
+import { normalizeUnicodeText } from './unicode';
+import { processTextWithPlaceholders } from './placeholderProcessor';
+import type { TextStyle } from './textParser';
+
+export const DEFAULT_REVISION_AUTHOR = 'json-to-office';
+// Deterministic fallback so identical inputs produce byte-identical XML
+export const DEFAULT_REVISION_DATE = '1970-01-01T00:00:00Z';
+
+/**
+ * OOXML requires a numeric id on every w:ins / w:del element, unique within
+ * one document. The counter is process-wide and never reset between renders:
+ * concurrent renderDocument calls then draw from disjoint id sets, so
+ * intra-document uniqueness holds even when renders interleave (a per-render
+ * reset would let one render clear the counter mid-flight for another).
+ */
+class RevisionIdRegistry {
+  private counter = 0;
+
+  next(): number {
+    this.counter += 1;
+    return this.counter;
+  }
+
+  /** Test-only: deterministic ids for snapshot assertions. */
+  clear(): void {
+    this.counter = 0;
+  }
+}
+
+export const globalRevisionIdRegistry = new RevisionIdRegistry();
+
+export type RevisionRun = TextRun | InsertedTextRun | DeletedTextRun;
+
+const PLACEHOLDER_PATTERN = /\{[^}]+\}/;
+
+type RevisionBaseStyle = Omit<IRunOptions, 'text' | 'children'>;
+
+/**
+ * Build the runs for one segment, splitting on '\n' so line breaks render
+ * as <w:br/> (mirroring createTextRunsWithNewlines on the normal path).
+ */
+function segmentRuns(
+  text: string,
+  makeRun: (options: IRunOptions) => RevisionRun
+): RevisionRun[] {
+  const lines = text.split('\n');
+  return lines.map((line, index) =>
+    makeRun(index === 0 ? { text: line } : { text: line, break: 1 })
+  );
+}
+
+/**
+ * Build paragraph children from revision segments.
+ *
+ * Segment text is rendered literally (no markdown parsing): a `**` opened in
+ * one segment could close in another, so decorator parsing cannot work
+ * per-segment. The diff engine strips markdown before diffing for this
+ * reason. Placeholders ({DATE}, {PAGE}, ...) are resolved for unchanged
+ * segments; inside inserted/deleted text they render literally (the diff
+ * summary reports those).
+ */
+export function createRevisionRuns(
+  revision: Revision,
+  baseStyle: RevisionBaseStyle
+): ParagraphChild[] {
+  const author = revision.author || DEFAULT_REVISION_AUTHOR;
+  const date = revision.date || DEFAULT_REVISION_DATE;
+
+  const runs: ParagraphChild[] = [];
+  for (const segment of revision.segments) {
+    if (!segment.text) continue;
+    const text = normalizeUnicodeText(segment.text);
+
+    if (segment.type === 'insert') {
+      runs.push(
+        ...segmentRuns(
+          text,
+          (options) =>
+            new InsertedTextRun({
+              ...options,
+              ...baseStyle,
+              id: globalRevisionIdRegistry.next(),
+              author,
+              date,
+            })
+        )
+      );
+    } else if (segment.type === 'delete') {
+      runs.push(
+        ...segmentRuns(
+          text,
+          (options) =>
+            new DeletedTextRun({
+              ...options,
+              ...baseStyle,
+              id: globalRevisionIdRegistry.next(),
+              author,
+              date,
+            })
+        )
+      );
+    } else if (PLACEHOLDER_PATTERN.test(text)) {
+      // Unchanged text keeps full placeholder fidelity ({DATE}, {PAGE}, ...)
+      runs.push(
+        ...processTextWithPlaceholders(text, baseStyle as TextStyle, {})
+      );
+    } else {
+      runs.push(
+        ...segmentRuns(
+          text,
+          (options) => new TextRun({ ...options, ...baseStyle })
+        )
+      );
+    }
+  }
+  return runs;
+}
+
+/**
+ * True when a component carries revision data anywhere in its subtree
+ * (own props, list items, or any descendant), meaning its render output
+ * embeds document-scoped revision ids and must not be served from the
+ * cross-document component cache.
+ */
+export function componentHasRevision(component: {
+  props?: unknown;
+  children?: unknown[];
+}): boolean {
+  const props = component.props as Record<string, unknown> | undefined;
+  if (props) {
+    if (props.revision) return true;
+    const items = props.items;
+    if (Array.isArray(items)) {
+      if (
+        items.some(
+          (item) =>
+            typeof item === 'object' &&
+            item !== null &&
+            'revision' in item &&
+            (item as { revision?: unknown }).revision
+        )
+      ) {
+        return true;
+      }
+    }
+  }
+  const children = component.children;
+  if (Array.isArray(children)) {
+    return children.some(
+      (child) =>
+        typeof child === 'object' &&
+        child !== null &&
+        componentHasRevision(child as { props?: unknown; children?: unknown[] })
+    );
+  }
+  return false;
+}

--- a/packages/jto-cli/src/cli-register.ts
+++ b/packages/jto-cli/src/cli-register.ts
@@ -5,6 +5,7 @@ import {
   type FormatAdapter,
 } from './format-adapter.js';
 import { createGenerateCommand } from './commands/generate.js';
+import { createDiffCommand } from './commands/diff.js';
 import { createValidateCommand } from './commands/validate.js';
 import { createSchemasCommand } from './commands/schemas.js';
 import { createDiscoverCommand } from './commands/discover.js';
@@ -26,6 +27,10 @@ function registerFormatCommands(
   extras?: (adapter: FormatAdapter) => Command[]
 ): void {
   parent.addCommand(createGenerateCommand(adapter));
+  // Tracked-change redlines are DOCX-only (no PPTX visual diff yet)
+  if (adapter.name === 'docx') {
+    parent.addCommand(createDiffCommand(adapter));
+  }
   parent.addCommand(createValidateCommand(adapter));
   parent.addCommand(createSchemasCommand(adapter));
   parent.addCommand(createDiscoverCommand(adapter));

--- a/packages/jto-cli/src/commands/__tests__/diff.test.ts
+++ b/packages/jto-cli/src/commands/__tests__/diff.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import { createDiffCommand } from '../diff';
+import { registerCoreCommands } from '../../cli-register';
+import { DocxFormatAdapter } from '../../format-adapter';
+
+describe('createDiffCommand', () => {
+  const cmd = createDiffCommand(new DocxFormatAdapter());
+
+  it('registers the expected arguments and options', () => {
+    expect(cmd.name()).toBe('diff');
+    const optionNames = cmd.options.map((o) => o.long);
+    expect(optionNames).toEqual(
+      expect.arrayContaining([
+        '--output',
+        '--author',
+        '--date',
+        '--json-out',
+        '--format',
+        '--dry-run',
+      ])
+    );
+  });
+
+  it('defaults output to redline.docx and author to json-to-office', () => {
+    const opts = cmd.opts();
+    expect(opts.output).toBe('redline.docx');
+    expect(opts.author).toBe('json-to-office');
+  });
+});
+
+describe('cli registration', () => {
+  it('mounts diff under docx but not under pptx', () => {
+    const program = registerCoreCommands(new Command());
+    const docx = program.commands.find((c) => c.name() === 'docx')!;
+    const pptx = program.commands.find((c) => c.name() === 'pptx')!;
+    expect(docx.commands.map((c) => c.name())).toContain('diff');
+    expect(pptx.commands.map((c) => c.name())).not.toContain('diff');
+  });
+});

--- a/packages/jto-cli/src/commands/diff.ts
+++ b/packages/jto-cli/src/commands/diff.ts
@@ -201,8 +201,6 @@ export function createDiffCommand(adapter: FormatAdapter): Command {
               );
             }
           }
-
-          process.exit(EXIT_CODES.OK);
         } catch (error: any) {
           if (spinner) spinner.fail('Diff failed');
           if (isJsonFormat) {
@@ -214,6 +212,7 @@ export function createDiffCommand(adapter: FormatAdapter): Command {
           }
           process.exit(EXIT_CODES.FAIL);
         }
+        process.exit(EXIT_CODES.OK);
       }
     )
     .addHelpText(

--- a/packages/jto-cli/src/commands/diff.ts
+++ b/packages/jto-cli/src/commands/diff.ts
@@ -1,0 +1,229 @@
+import { Command } from 'commander';
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+import ora from 'ora';
+import chalk from 'chalk';
+import type { FormatAdapter } from '../format-adapter.js';
+import { shortPath, formatTiming, formatError, EXIT_CODES } from './ui.js';
+
+interface DiffOptions {
+  output?: string;
+  author?: string;
+  date?: string;
+  jsonOut?: string;
+  format?: 'pretty' | 'json';
+  dryRun?: boolean;
+}
+
+function readDefinition(label: string, filePath: string): unknown {
+  let content: string;
+  try {
+    content = readFileSync(filePath, 'utf-8');
+  } catch {
+    throw new Error(`Cannot read ${label} document: ${filePath}`);
+  }
+  try {
+    return JSON.parse(content);
+  } catch (error: any) {
+    throw new Error(
+      `${label} document is not valid JSON (${filePath}): ${error.message}`
+    );
+  }
+}
+
+async function validateDefinition(
+  label: string,
+  filePath: string,
+  definition: unknown
+): Promise<void> {
+  const sharedDocx = await import('@json-to-office/shared-docx');
+  const result = sharedDocx.validate.jsonDocument(JSON.stringify(definition));
+  if (!result.valid) {
+    const details = (result.errors || [])
+      .slice(0, 5)
+      .map((e: any) => `  - ${e.path || ''} ${e.message || e}`)
+      .join('\n');
+    throw new Error(
+      `${label} document failed validation (${filePath}):\n${details}`
+    );
+  }
+}
+
+export function createDiffCommand(adapter: FormatAdapter): Command {
+  return new Command('diff')
+    .description(
+      'Diff two JSON documents into a redline .docx with native Word tracked changes'
+    )
+    .argument('<old>', 'Old (base) JSON document')
+    .argument('<new>', 'New (revised) JSON document')
+    .option('-o, --output <path>', 'Output redline file path', 'redline.docx')
+    .option(
+      '--author <name>',
+      'Revision author shown in Word',
+      'json-to-office'
+    )
+    .option('--date <iso>', 'Revision timestamp (ISO 8601, default: now)')
+    .option(
+      '--json-out <path>',
+      'Also write the redline JSON definition to this path'
+    )
+    .option(
+      '-f, --format <format>',
+      "Summary output format: 'pretty' or 'json'",
+      'pretty'
+    )
+    .option('--dry-run', 'Compute the diff and summary without writing files')
+    .action(
+      async (oldInput: string, newInput: string, options: DiffOptions) => {
+        const isJsonFormat = options.format === 'json';
+        const spinner = isJsonFormat
+          ? null
+          : ora('Diffing documents...').start();
+        const startTime = performance.now();
+
+        try {
+          if (adapter.name !== 'docx') {
+            throw new Error(
+              'diff is only supported for DOCX documents (PPTX visual diff is not available yet)'
+            );
+          }
+
+          const oldPath = resolve(process.cwd(), oldInput);
+          const newPath = resolve(process.cwd(), newInput);
+          const oldDoc = readDefinition('Old', oldPath);
+          const newDoc = readDefinition('New', newPath);
+
+          if (spinner) spinner.text = 'Validating inputs...';
+          await validateDefinition('Old', oldPath, oldDoc);
+          await validateDefinition('New', newPath, newDoc);
+
+          // Validate and canonicalize --date: an invalid value would produce
+          // revision dates that fail both RevisionSchema and OOXML ST_DateTime
+          const revisionDate = options.date
+            ? new Date(options.date)
+            : new Date();
+          if (isNaN(revisionDate.getTime())) {
+            throw new Error(
+              `Invalid --date: "${options.date}" (expected ISO 8601, e.g. 2026-06-09T10:00:00Z)`
+            );
+          }
+
+          if (spinner) spinner.text = 'Computing diff...';
+          const { diffDocuments } = await import('@json-to-office/shared-docx');
+          type JsonNode = import('@json-to-office/shared-docx').JsonNode;
+          const { document, summary } = diffDocuments(
+            oldDoc as JsonNode,
+            newDoc as JsonNode,
+            {
+              author: options.author,
+              date: revisionDate.toISOString(),
+            }
+          );
+
+          const outputPath = resolve(
+            process.cwd(),
+            options.output || 'redline.docx'
+          );
+          const jsonOutPath = options.jsonOut
+            ? resolve(process.cwd(), options.jsonOut)
+            : undefined;
+
+          if (!options.dryRun) {
+            if (jsonOutPath) {
+              writeFileSync(jsonOutPath, JSON.stringify(document, null, 2));
+            }
+            if (spinner) spinner.text = 'Rendering redline document...';
+            const buffer = await adapter.generateBuffer(document, {});
+            writeFileSync(outputPath, buffer);
+          }
+
+          const totalTracked =
+            summary.tracked.modified +
+            summary.tracked.inserted +
+            summary.tracked.deleted;
+
+          if (isJsonFormat) {
+            console.log(
+              JSON.stringify(
+                {
+                  output: options.dryRun ? null : outputPath,
+                  jsonOut: options.dryRun ? null : jsonOutPath ?? null,
+                  summary,
+                },
+                null,
+                2
+              )
+            );
+          } else if (spinner) {
+            if (options.dryRun) {
+              spinner.succeed(
+                `Diff computed (dry run) ${formatTiming(startTime)}`
+              );
+            } else {
+              spinner.succeed(
+                `Redline written to ${shortPath(outputPath)} ${formatTiming(startTime)}`
+              );
+            }
+            console.log('');
+            console.log(
+              `  Tracked changes: ${chalk.green(`${summary.tracked.inserted} inserted`)}, ` +
+                `${chalk.red(`${summary.tracked.deleted} deleted`)}, ` +
+                `${chalk.yellow(`${summary.tracked.modified} modified`)} ` +
+                chalk.dim(`(${summary.unchangedBlocks} blocks unchanged)`)
+            );
+            if (totalTracked === 0 && summary.untracked.length === 0) {
+              console.log(chalk.dim('  Documents are identical.'));
+            }
+            if (summary.untracked.length > 0) {
+              console.log('');
+              console.log(
+                chalk.yellow(
+                  `  ${summary.untracked.length} change(s) not expressible as tracked changes:`
+                )
+              );
+              for (const change of summary.untracked) {
+                console.log(
+                  chalk.yellow(`  ! ${change.path}`) +
+                    chalk.dim(` [${change.component}] ${change.detail}`)
+                );
+              }
+            }
+            if (summary.notes.length > 0) {
+              console.log('');
+              for (const note of summary.notes) {
+                console.log(chalk.dim(`  Note: ${note}`));
+              }
+            }
+            if (jsonOutPath && !options.dryRun) {
+              console.log('');
+              console.log(
+                chalk.dim(`  Redline JSON: ${shortPath(jsonOutPath)}`)
+              );
+            }
+          }
+
+          process.exit(EXIT_CODES.OK);
+        } catch (error: any) {
+          if (spinner) spinner.fail('Diff failed');
+          if (isJsonFormat) {
+            console.log(
+              JSON.stringify({ error: true, message: error.message }, null, 2)
+            );
+          } else {
+            formatError(error);
+          }
+          process.exit(EXIT_CODES.FAIL);
+        }
+      }
+    )
+    .addHelpText(
+      'after',
+      `
+${chalk.gray('Examples:')}
+  $ jto docx diff contract-v1.json contract-v2.json -o redline.docx
+  $ jto docx diff old.json new.json --author "jto-agent"
+  $ jto docx diff old.json new.json --json-out redline.json --format json
+  $ jto docx diff old.json new.json --dry-run                ${chalk.dim('# summary only')}
+`
+    );
+}

--- a/packages/jto/src/client/components/playground/compare-documents-dialog.tsx
+++ b/packages/jto/src/client/components/playground/compare-documents-dialog.tsx
@@ -1,0 +1,296 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { GitCompareArrows, FileDiff } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../ui/select';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { Badge } from '../ui/badge';
+import { Spinner } from '../ui/spinner';
+import { useToast } from '../ui/use-toast';
+import { useDocumentsStore } from '../../store/documents-store-provider';
+import { useShallow } from 'zustand/react/shallow';
+import { API_ENDPOINTS } from '../../config/api';
+
+interface DiffSummary {
+  tracked: { modified: number; inserted: number; deleted: number };
+  untracked: {
+    path: string;
+    kind: string;
+    component: string;
+    detail: string;
+  }[];
+  unchangedBlocks: number;
+  notes: string[];
+}
+
+interface DiffResponse {
+  success: boolean;
+  data: { document: unknown; summary: DiffSummary };
+}
+
+interface CompareDocumentsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Compare two documents into a tracked-change redline: picks base and
+ * revised versions from the saved documents, calls /api/docx/diff, and
+ * opens the resulting redline as a regular document — so the existing
+ * preview and download pipeline applies to it unchanged.
+ */
+export const CompareDocumentsDialog: React.FC<CompareDocumentsDialogProps> = ({
+  open,
+  onOpenChange,
+}) => {
+  const { documents, documentTypes, activeTab, createDocument, openDocument } =
+    useDocumentsStore(
+      useShallow((state) => ({
+        documents: state.documents,
+        documentTypes: state.documentTypes,
+        activeTab: state.activeTab,
+        createDocument: state.createDocument,
+        openDocument: state.openDocument,
+      }))
+    );
+  const { toast } = useToast();
+
+  const reportDocuments = useMemo(
+    () =>
+      documents.filter(
+        (doc) => documentTypes[doc.name] !== 'application/json+theme'
+      ),
+    [documents, documentTypes]
+  );
+
+  const [baseName, setBaseName] = useState<string>('');
+  const [revisedName, setRevisedName] = useState<string>('');
+  const [author, setAuthor] = useState<string>('playground');
+  const [isDiffing, setIsDiffing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [summary, setSummary] = useState<DiffSummary | null>(null);
+  const [redlineDocument, setRedlineDocument] = useState<unknown>(null);
+
+  // Sensible defaults each time the dialog opens: revised = active tab,
+  // base = the first other document. Deliberately keyed on `open` only —
+  // re-running on store changes would clobber the user's selection.
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    setSummary(null);
+    setRedlineDocument(null);
+    const names = reportDocuments.map((d) => d.name);
+    const revised = names.includes(activeTab) ? activeTab : names[0] ?? '';
+    setRevisedName(revised);
+    setBaseName(names.find((n) => n !== revised) ?? '');
+  }, [open]);
+
+  const runDiff = async () => {
+    const base = reportDocuments.find((d) => d.name === baseName);
+    const revised = reportDocuments.find((d) => d.name === revisedName);
+    if (!base || !revised) return;
+
+    setIsDiffing(true);
+    setError(null);
+    setSummary(null);
+    setRedlineDocument(null);
+    try {
+      const response = await fetch(API_ENDPOINTS.diff, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          oldDefinition: base.text,
+          newDefinition: revised.text,
+          options: { author: author || 'playground' },
+        }),
+      });
+      const body = (await response.json()) as DiffResponse & {
+        error?: string;
+        errors?: { message?: string }[];
+      };
+      if (!response.ok || !body.success) {
+        const details = Array.isArray(body.errors)
+          ? `: ${body.errors
+              .slice(0, 3)
+              .map((e) => e.message || String(e))
+              .join('; ')}`
+          : '';
+        throw new Error(
+          (body.error || `Diff failed (${response.status})`) + details
+        );
+      }
+      setSummary(body.data.summary);
+      setRedlineDocument(body.data.document);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Diff failed');
+    } finally {
+      setIsDiffing(false);
+    }
+  };
+
+  const openRedline = () => {
+    if (!redlineDocument) return;
+    const existing = new Set(documents.map((d) => d.name));
+    let name = `${revisedName}-redline`;
+    let counter = 2;
+    while (existing.has(name)) {
+      name = `${revisedName}-redline-${counter++}`;
+    }
+    createDocument(name, JSON.stringify(redlineDocument, null, 2));
+    openDocument(name);
+    toast({ title: `Redline created: ${name}` });
+    onOpenChange(false);
+  };
+
+  const totalTracked = summary
+    ? summary.tracked.modified +
+      summary.tracked.inserted +
+      summary.tracked.deleted
+    : 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <GitCompareArrows className="size-4" />
+            Compare documents
+          </DialogTitle>
+          <DialogDescription>
+            Diff two versions into a redline with native Word tracked changes
+            (accept/reject in Word).
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="grid gap-1.5">
+              <Label htmlFor="diff-base">Base (old)</Label>
+              <Select value={baseName} onValueChange={setBaseName}>
+                <SelectTrigger id="diff-base">
+                  <SelectValue placeholder="Select document" />
+                </SelectTrigger>
+                <SelectContent>
+                  {reportDocuments.map((doc) => (
+                    <SelectItem key={doc.name} value={doc.name}>
+                      {doc.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid gap-1.5">
+              <Label htmlFor="diff-revised">Revised (new)</Label>
+              <Select value={revisedName} onValueChange={setRevisedName}>
+                <SelectTrigger id="diff-revised">
+                  <SelectValue placeholder="Select document" />
+                </SelectTrigger>
+                <SelectContent>
+                  {reportDocuments.map((doc) => (
+                    <SelectItem key={doc.name} value={doc.name}>
+                      {doc.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="diff-author">Revision author</Label>
+            <Input
+              id="diff-author"
+              value={author}
+              onChange={(e) => setAuthor(e.target.value)}
+              placeholder="playground"
+            />
+          </div>
+
+          {error && (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          )}
+
+          {summary && (
+            <div className="rounded-md border p-3 text-sm grid gap-2">
+              <div className="flex items-center gap-2 flex-wrap">
+                <Badge variant="secondary">
+                  {summary.tracked.inserted} inserted
+                </Badge>
+                <Badge variant="secondary">
+                  {summary.tracked.deleted} deleted
+                </Badge>
+                <Badge variant="secondary">
+                  {summary.tracked.modified} modified
+                </Badge>
+                <span className="text-muted-foreground text-xs">
+                  {summary.unchangedBlocks} blocks unchanged
+                </span>
+              </div>
+              {totalTracked === 0 && summary.untracked.length === 0 && (
+                <p className="text-muted-foreground">
+                  The documents are identical.
+                </p>
+              )}
+              {summary.untracked.length > 0 && (
+                <div className="grid gap-1 max-h-32 overflow-y-auto">
+                  <p className="font-medium text-amber-600 dark:text-amber-500">
+                    {summary.untracked.length} change(s) not expressible as
+                    tracked changes:
+                  </p>
+                  {summary.untracked.map((change, index) => (
+                    <p key={index} className="text-xs text-muted-foreground">
+                      {change.path} [{change.component}] {change.detail}
+                    </p>
+                  ))}
+                </div>
+              )}
+              {summary.notes.map((note, index) => (
+                <p key={index} className="text-xs text-muted-foreground">
+                  Note: {note}
+                </p>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          {summary && totalTracked + summary.untracked.length > 0 ? (
+            <Button onClick={openRedline}>
+              <FileDiff className="size-4 mr-1" />
+              Open redline
+            </Button>
+          ) : (
+            <Button
+              onClick={runDiff}
+              disabled={
+                isDiffing ||
+                !baseName ||
+                !revisedName ||
+                baseName === revisedName
+              }
+            >
+              {isDiffing && <Spinner className="size-4 mr-1" />}
+              Compare
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/jto/src/client/components/playground/compare-documents-dialog.tsx
+++ b/packages/jto/src/client/components/playground/compare-documents-dialog.tsx
@@ -85,6 +85,14 @@ export const CompareDocumentsDialog: React.FC<CompareDocumentsDialogProps> = ({
   const [summary, setSummary] = useState<DiffSummary | null>(null);
   const [redlineDocument, setRedlineDocument] = useState<unknown>(null);
 
+  // A computed diff is only valid for the inputs it was run with: changing
+  // base/revised/author discards it (the footer falls back to Compare).
+  const resetResult = () => {
+    setError(null);
+    setSummary(null);
+    setRedlineDocument(null);
+  };
+
   // Sensible defaults each time the dialog opens: revised = active tab,
   // base = the first other document. Deliberately keyed on `open` only —
   // re-running on store changes would clobber the user's selection.
@@ -180,7 +188,13 @@ export const CompareDocumentsDialog: React.FC<CompareDocumentsDialogProps> = ({
           <div className="grid grid-cols-2 gap-3">
             <div className="grid gap-1.5">
               <Label htmlFor="diff-base">Base (old)</Label>
-              <Select value={baseName} onValueChange={setBaseName}>
+              <Select
+                value={baseName}
+                onValueChange={(value) => {
+                  setBaseName(value);
+                  resetResult();
+                }}
+              >
                 <SelectTrigger id="diff-base">
                   <SelectValue placeholder="Select document" />
                 </SelectTrigger>
@@ -195,7 +209,13 @@ export const CompareDocumentsDialog: React.FC<CompareDocumentsDialogProps> = ({
             </div>
             <div className="grid gap-1.5">
               <Label htmlFor="diff-revised">Revised (new)</Label>
-              <Select value={revisedName} onValueChange={setRevisedName}>
+              <Select
+                value={revisedName}
+                onValueChange={(value) => {
+                  setRevisedName(value);
+                  resetResult();
+                }}
+              >
                 <SelectTrigger id="diff-revised">
                   <SelectValue placeholder="Select document" />
                 </SelectTrigger>
@@ -215,7 +235,10 @@ export const CompareDocumentsDialog: React.FC<CompareDocumentsDialogProps> = ({
             <Input
               id="diff-author"
               value={author}
-              onChange={(e) => setAuthor(e.target.value)}
+              onChange={(e) => {
+                setAuthor(e.target.value);
+                resetResult();
+              }}
               placeholder="playground"
             />
           </div>

--- a/packages/jto/src/client/components/playground/document-sidebar.tsx
+++ b/packages/jto/src/client/components/playground/document-sidebar.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 import {
   FilePlusIcon,
+  GitCompareArrows,
   PaletteIcon,
   Plus,
   Sparkles,
@@ -17,6 +18,8 @@ import {
   PanelLeftOpen,
   Info,
 } from 'lucide-react';
+import { CompareDocumentsDialog } from './compare-documents-dialog';
+import { FORMAT } from '../../lib/env';
 import { DocumentFormDialogContentMemoized } from './document-form-dialog-content';
 import { DocumentMenuItemMemoized } from './document-menu-item';
 import { PluginSelector } from './plugin-selector';
@@ -95,6 +98,7 @@ function DocumentSidebarComponent({
   const selectedPlugins = usePluginsStore((state) => state.selectedPlugins);
   const isApplyingPlugins = usePluginsStore((state) => state.isApplyingPlugins);
   const [schemaDialogOpen, setSchemaDialogOpen] = useState(false);
+  const [compareDialogOpen, setCompareDialogOpen] = useState(false);
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
     new Set(['current-docs', 'current-themes'])
   );
@@ -334,37 +338,64 @@ function DocumentSidebarComponent({
                 {!isCollapsed && <FilePlusIcon className="size-3" />}
                 {!isCollapsed && <span>Active Documents</span>}
               </div>
-              <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <DialogTrigger asChild>
+              <div className="flex items-center gap-0.5">
+                {FORMAT === 'docx' && !isCollapsed && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
                       <Button
-                        className={cn(
-                          'p-0 flex-shrink-0',
-                          isCollapsed
-                            ? 'mx-auto h-8 w-8 rounded border border-dashed border-sidebar-foreground/20 hover:border-sidebar-foreground/40'
-                            : 'h-6 w-6'
-                        )}
+                        className="h-6 w-6 p-0 flex-shrink-0"
                         variant="ghost"
                         size="icon"
+                        aria-label="Compare documents"
+                        disabled={reportDocuments.length < 2}
+                        onClick={() => setCompareDialogOpen(true)}
                       >
-                        <Plus className={isCollapsed ? 'size-3.5' : 'size-4'} />
+                        <GitCompareArrows className="size-4" />
                       </Button>
-                    </DialogTrigger>
-                  </TooltipTrigger>
-                  <TooltipContent side={isCollapsed ? 'right' : 'bottom'}>
-                    <span className="text-xs">New Document</span>
-                  </TooltipContent>
-                </Tooltip>
-                <DialogContent className="sm:max-w-[525px]">
-                  <DocumentFormDialogContentMemoized
-                    mode="create"
-                    shouldReset={!dialogOpen}
-                    postSubmit={closeDialog}
-                    discoveredDocuments={discoveryData?.documents || []}
-                  />
-                </DialogContent>
-              </Dialog>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      <span className="text-xs">
+                        {reportDocuments.length < 2
+                          ? 'Compare needs two documents'
+                          : 'Compare documents (redline)'}
+                      </span>
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+                <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DialogTrigger asChild>
+                        <Button
+                          className={cn(
+                            'p-0 flex-shrink-0',
+                            isCollapsed
+                              ? 'mx-auto h-8 w-8 rounded border border-dashed border-sidebar-foreground/20 hover:border-sidebar-foreground/40'
+                              : 'h-6 w-6'
+                          )}
+                          variant="ghost"
+                          size="icon"
+                        >
+                          <Plus
+                            className={isCollapsed ? 'size-3.5' : 'size-4'}
+                          />
+                        </Button>
+                      </DialogTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent side={isCollapsed ? 'right' : 'bottom'}>
+                      <span className="text-xs">New Document</span>
+                    </TooltipContent>
+                  </Tooltip>
+                  <DialogContent className="sm:max-w-[525px]">
+                    <DocumentFormDialogContentMemoized
+                      mode="create"
+                      shouldReset={!dialogOpen}
+                      postSubmit={closeDialog}
+                      discoveredDocuments={discoveryData?.documents || []}
+                    />
+                  </DialogContent>
+                </Dialog>
+              </div>
             </SidebarGroupLabel>
             {isCollapsed ? (
               /* Collapsed: show icon badges for each doc */
@@ -803,6 +834,10 @@ function DocumentSidebarComponent({
         open={schemaDialogOpen}
         onOpenChange={setSchemaDialogOpen}
         defaultTab={activeDocumentType === 'theme' ? 'theme' : 'document'}
+      />
+      <CompareDocumentsDialog
+        open={compareDialogOpen}
+        onOpenChange={setCompareDialogOpen}
       />
     </>
   );

--- a/packages/jto/src/client/config/api.ts
+++ b/packages/jto/src/client/config/api.ts
@@ -18,6 +18,7 @@ export const API_ENDPOINTS = {
   },
   generate: `${FORMAT_API}/generate`,
   validate: `${FORMAT_API}/validate`,
+  diff: `${FORMAT_API}/diff`,
   preview: {
     libreoffice: `${FORMAT_API}/preview/libreoffice`,
     libreofficeFromJson: `${FORMAT_API}/preview/libreoffice-from-json`,

--- a/packages/jto/src/server/routes/__tests__/diff.test.ts
+++ b/packages/jto/src/server/routes/__tests__/diff.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Hono } from 'hono';
+import { createFormatRouter } from '../format';
+import { Container } from '../../container';
+import { DocxFormatAdapter, PptxFormatAdapter } from '@json-to-office/jto-cli';
+
+// Hono's body-limit middleware reads Content-Length; tests must set it.
+async function post(app: Hono, url: string, body: unknown) {
+  const bodyStr = JSON.stringify(body);
+  return app.request(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': String(Buffer.byteLength(bodyStr)),
+    },
+    body: bodyStr,
+  });
+}
+
+const docOf = (text: string) => ({
+  name: 'docx',
+  props: { theme: 'minimal' },
+  children: [{ name: 'paragraph', props: { text } }],
+});
+
+describe('/api/docx/diff', () => {
+  let app: Hono;
+
+  beforeAll(() => {
+    Container.initialize(new DocxFormatAdapter());
+    app = new Hono();
+    app.route('/', createFormatRouter(new DocxFormatAdapter()) as any);
+  });
+
+  it('returns redline document and summary', async () => {
+    const res = await post(app, '/diff', {
+      oldDefinition: docOf('The fee is 10%.'),
+      newDefinition: docOf('The fee is 12%.'),
+      options: { author: 'test-suite' },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.success).toBe(true);
+    expect(body.data.document.props.trackRevisions).toBe(true);
+    expect(body.data.summary.tracked.modified).toBe(1);
+    const revision = body.data.document.children[0].props.revision;
+    expect(revision.author).toBe('test-suite');
+    expect(revision.segments.some((s: any) => s.type === 'delete')).toBe(true);
+  });
+
+  it('accepts string definitions', async () => {
+    const res = await post(app, '/diff', {
+      oldDefinition: JSON.stringify(docOf('a')),
+      newDefinition: JSON.stringify(docOf('b')),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects invalid documents with 400 and validation errors', async () => {
+    const res = await post(app, '/diff', {
+      oldDefinition: { name: 'docx', props: {}, children: [{ name: 'nope' }] },
+      newDefinition: docOf('b'),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Old document');
+  });
+
+  it('rejects malformed JSON strings with 400', async () => {
+    const res = await post(app, '/diff', {
+      oldDefinition: '{not json',
+      newDefinition: docOf('b'),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an invalid date with 400', async () => {
+    const res = await post(app, '/diff', {
+      oldDefinition: docOf('a'),
+      newDefinition: docOf('b'),
+      options: { date: 'garbage' },
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('/api/pptx/diff', () => {
+  it('is not mounted for pptx', async () => {
+    Container.initialize(new PptxFormatAdapter());
+    const app = new Hono();
+    app.route('/', createFormatRouter(new PptxFormatAdapter()) as any);
+    const res = await post(app, '/diff', {
+      oldDefinition: {},
+      newDefinition: {},
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/jto/src/server/routes/format.ts
+++ b/packages/jto/src/server/routes/format.ts
@@ -5,6 +5,7 @@ import { getContainer } from '../container/index.js';
 import {
   LooseDocumentGenerationRequestSchema,
   LooseDocumentValidationRequestSchema,
+  LooseDocumentDiffRequestSchema,
 } from '../schemas/loose.js';
 import { tbValidator, getValidated } from '../lib/typebox-validator.js';
 import { logger } from '../utils/logger.js';
@@ -160,6 +161,121 @@ export function createFormatRouter(adapter: FormatAdapter) {
       }
     }
   );
+
+  // POST /diff (DOCX only)
+  //
+  // Compare two document definitions into a tracked-change redline: returns
+  // the renderable redline JSON plus a summary. The client previews and
+  // downloads the redline through the normal generate/preview pipeline.
+  if (adapter.name === 'docx') {
+    router.post(
+      '/diff',
+      bodyLimit({
+        // Two full documents per request — same cap rationale as
+        // /preview/libreoffice-from-json, doubled.
+        maxSize: 32 * 1024 * 1024,
+        onError: () => {
+          throw new HTTPException(413, { message: 'Request body too large' });
+        },
+      }),
+      rateLimiter({
+        limit: process.env.NODE_ENV === 'production' ? 30 : 1000,
+        window: 15 * 60 * 1000,
+        keyGenerator: (c) =>
+          c.req.header('X-Real-IP') ||
+          c.req.header('X-Forwarded-For')?.split(',').pop()?.trim() ||
+          'anonymous',
+      }),
+      contentTypeMw,
+      tbValidator(LooseDocumentDiffRequestSchema),
+      async (c) => {
+        const { oldDefinition, newDefinition, options } = getValidated<{
+          oldDefinition: string | object;
+          newDefinition: string | object;
+          options?: { author?: string; date?: string };
+        }>(c, 'json');
+        const requestId = c.get('requestId');
+
+        const parseDef = (label: string, def: string | object): object => {
+          if (typeof def !== 'string') return def;
+          try {
+            return JSON.parse(def);
+          } catch {
+            throw new HTTPException(400, {
+              message: `${label} document is not valid JSON`,
+            });
+          }
+        };
+
+        try {
+          const oldDoc = parseDef('Old', oldDefinition);
+          const newDoc = parseDef('New', newDefinition);
+
+          // The adapter's validateDocument is a no-op stub; use the real
+          // TypeBox document validation from shared-docx (same as the CLI)
+          const sharedDocx = await import('@json-to-office/shared-docx');
+          for (const [label, doc] of [
+            ['Old', oldDoc],
+            ['New', newDoc],
+          ] as const) {
+            const result = sharedDocx.validate.jsonDocument(
+              JSON.stringify(doc)
+            );
+            if (!result.valid) {
+              return c.json(
+                {
+                  success: false,
+                  error: `${label} document failed validation`,
+                  errors: (result.errors || []).slice(0, 20),
+                  meta: { timestamp: new Date().toISOString(), requestId },
+                },
+                400
+              );
+            }
+          }
+
+          // Validate and canonicalize the revision date (invalid values
+          // would fail RevisionSchema and OOXML ST_DateTime downstream)
+          const revisionDate = options?.date
+            ? new Date(options.date)
+            : new Date();
+          if (isNaN(revisionDate.getTime())) {
+            throw new HTTPException(400, {
+              message: `Invalid date: "${options?.date}" (expected ISO 8601)`,
+            });
+          }
+
+          const { diffDocuments } = sharedDocx;
+          const { document, summary } = diffDocuments(
+            oldDoc as Parameters<typeof diffDocuments>[0],
+            newDoc as Parameters<typeof diffDocuments>[1],
+            {
+              author: options?.author || 'playground',
+              date: revisionDate.toISOString(),
+            }
+          );
+
+          return c.json({
+            success: true,
+            data: { document, summary },
+            meta: { timestamp: new Date().toISOString(), requestId },
+          });
+        } catch (error) {
+          if (error instanceof HTTPException) throw error;
+          logger.error('Document diff failed', { error, requestId });
+          if (
+            error instanceof Error &&
+            error.message.includes('top-level component')
+          ) {
+            throw new HTTPException(400, { message: error.message });
+          }
+          throw new HTTPException(500, {
+            message: 'Internal server error during document diff',
+          });
+        }
+      }
+    );
+  }
 
   // POST /preview/libreoffice
   router.post(

--- a/packages/jto/src/server/schemas/loose.ts
+++ b/packages/jto/src/server/schemas/loose.ts
@@ -63,3 +63,30 @@ export const LooseDocumentValidationRequestSchema = Type.Object(
   },
   { additionalProperties: true }
 );
+
+/**
+ * Diff request: two DOCX definitions to compare into a tracked-change
+ * redline. Strict validation of both documents happens in the handler.
+ */
+export const LooseDocumentDiffRequestSchema = Type.Object(
+  {
+    oldDefinition: Type.Union([
+      Type.String(),
+      Type.Object({}, { additionalProperties: true }),
+    ]),
+    newDefinition: Type.Union([
+      Type.String(),
+      Type.Object({}, { additionalProperties: true }),
+    ]),
+    options: Type.Optional(
+      Type.Object(
+        {
+          author: Type.Optional(Type.String({ maxLength: 128 })),
+          date: Type.Optional(Type.String({ maxLength: 64 })),
+        },
+        { additionalProperties: false }
+      )
+    ),
+  },
+  { additionalProperties: true }
+);

--- a/packages/shared-docx/src/__tests__/component-defaults-revision.test.ts
+++ b/packages/shared-docx/src/__tests__/component-defaults-revision.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression: `revision` is per-instance tracked-change data and must not be
+ * settable through componentDefaults — a shared default revision would
+ * silently replace every paragraph/heading text at render time.
+ */
+import { describe, it, expect } from 'vitest';
+import { validate } from '../validation/unified';
+
+const docWithDefaultRevision = JSON.stringify({
+  name: 'docx',
+  props: {
+    theme: 'minimal',
+    componentDefaults: {
+      paragraph: {
+        revision: { segments: [{ type: 'insert', text: 'INJECTED' }] },
+      },
+    },
+  },
+  children: [{ name: 'paragraph', props: { text: 'real text' } }],
+});
+
+describe('componentDefaults cannot carry revision', () => {
+  it('rejects revision inside componentDefaults.paragraph', () => {
+    const result = validate.jsonDocument(docWithDefaultRevision);
+    expect(result.valid).toBe(false);
+  });
+
+  it('still accepts revision on a component instance', () => {
+    const result = validate.jsonDocument(
+      JSON.stringify({
+        name: 'docx',
+        props: { theme: 'minimal' },
+        children: [
+          {
+            name: 'paragraph',
+            props: {
+              text: 'new',
+              revision: {
+                segments: [
+                  { type: 'delete', text: 'old' },
+                  { type: 'insert', text: 'new' },
+                ],
+              },
+            },
+          },
+        ],
+      })
+    );
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/shared-docx/src/diff/__tests__/document-diff.test.ts
+++ b/packages/shared-docx/src/diff/__tests__/document-diff.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect } from 'vitest';
+import { diffDocuments, type JsonNode } from '../document-diff';
+
+function doc(
+  children: JsonNode[],
+  props: Record<string, unknown> = {}
+): JsonNode {
+  return { name: 'docx', props: { theme: 'minimal', ...props }, children };
+}
+
+function para(text: string, extra: Record<string, unknown> = {}): JsonNode {
+  return { name: 'paragraph', props: { text, ...extra } };
+}
+
+describe('diffDocuments', () => {
+  it('rejects non-docx roots', () => {
+    expect(() => diffDocuments({ name: 'pptx' } as any, doc([]))).toThrow(
+      /top-level component must be "docx"/
+    );
+  });
+
+  it('sets trackRevisions on the output root', () => {
+    const { document } = diffDocuments(doc([]), doc([]));
+    expect(document.props?.trackRevisions).toBe(true);
+  });
+
+  it('identical documents produce no tracked changes', () => {
+    const a = doc([para('hello'), para('world')]);
+    const { document, summary } = diffDocuments(
+      a,
+      JSON.parse(JSON.stringify(a))
+    );
+    expect(summary.tracked).toEqual({ modified: 0, inserted: 0, deleted: 0 });
+    expect(summary.untracked).toEqual([]);
+    expect(summary.unchangedBlocks).toBe(2);
+    expect(document.children).toHaveLength(2);
+    expect(document.children?.[0].props?.revision).toBeUndefined();
+  });
+
+  it('modified paragraph gets word-level revision segments', () => {
+    const { document, summary } = diffDocuments(
+      doc([para('The fee is 10% of revenue.')]),
+      doc([para('The fee is 12% of revenue.')])
+    );
+    expect(summary.tracked.modified).toBe(1);
+    const revision = document.children?.[0].props?.revision as any;
+    expect(revision.segments).toEqual([
+      { type: 'equal', text: 'The fee is ' },
+      { type: 'delete', text: '10%' },
+      { type: 'insert', text: '12%' },
+      { type: 'equal', text: ' of revenue.' },
+    ]);
+    // text prop holds the new text
+    expect(document.children?.[0].props?.text).toBe(
+      'The fee is 12% of revenue.'
+    );
+  });
+
+  it('strips markdown before diffing (segments render literally)', () => {
+    const { document } = diffDocuments(
+      doc([para('grew **30%** fast')]),
+      doc([para('grew **32%** fast')])
+    );
+    const revision = document.children?.[0].props?.revision as any;
+    const allText = revision.segments.map((s: any) => s.text).join('');
+    expect(allText).not.toContain('**');
+  });
+
+  it('inserted paragraph becomes a fully tracked insertion', () => {
+    const { document, summary } = diffDocuments(
+      doc([para('one')]),
+      doc([para('one'), para('two')])
+    );
+    expect(summary.tracked.inserted).toBe(1);
+    const inserted = document.children?.[1].props?.revision as any;
+    expect(inserted.segments).toEqual([{ type: 'insert', text: 'two' }]);
+  });
+
+  it('deleted paragraph stays in the redline as a tracked deletion', () => {
+    const { document, summary } = diffDocuments(
+      doc([para('one'), para('two')]),
+      doc([para('one')])
+    );
+    expect(summary.tracked.deleted).toBe(1);
+    expect(document.children).toHaveLength(2);
+    const deleted = document.children?.[1].props as any;
+    expect(deleted.text).toBe('');
+    expect(deleted.revision.segments).toEqual([
+      { type: 'delete', text: 'two' },
+    ]);
+  });
+
+  it('pairs same-name neighbours; different components become delete+insert', () => {
+    const { document, summary } = diffDocuments(
+      doc([para('old text')]),
+      doc([{ name: 'heading', props: { text: 'New Title', level: 1 } }])
+    );
+    // paragraph deleted (tracked), heading inserted (tracked)
+    expect(summary.tracked.deleted).toBe(1);
+    expect(summary.tracked.inserted).toBe(1);
+    expect(document.children).toHaveLength(2);
+  });
+
+  it('propagates author and date into revisions', () => {
+    const { document } = diffDocuments(doc([para('a')]), doc([para('b')]), {
+      author: 'jto-agent',
+      date: '2026-06-09T10:00:00Z',
+    });
+    const revision = document.children?.[0].props?.revision as any;
+    expect(revision.author).toBe('jto-agent');
+    expect(revision.date).toBe('2026-06-09T10:00:00Z');
+  });
+
+  it('diffs list items at item level', () => {
+    const { document, summary } = diffDocuments(
+      doc([{ name: 'list', props: { items: ['alpha', 'beta', 'gamma'] } }]),
+      doc([
+        { name: 'list', props: { items: ['alpha', 'beta improved', 'delta'] } },
+      ])
+    );
+    expect(summary.tracked.modified).toBe(1);
+    const items = document.children?.[0].props?.items as any[];
+    // alpha unchanged, beta modified, gamma deleted+delta inserted (paired)
+    expect(items[0]).toEqual({ text: 'alpha', level: 0 });
+    expect(items[1].revision.segments).toEqual([
+      { type: 'equal', text: 'beta' },
+      { type: 'insert', text: ' improved' },
+    ]);
+    const reconstructed = items
+      .flatMap((i) => i.revision?.segments ?? [{ type: 'equal', text: i.text }])
+      .filter((s: any) => s.type !== 'delete')
+      .map((s: any) => s.text)
+      .join('|');
+    expect(reconstructed).toContain('delta');
+  });
+
+  it('table change is reported as untracked and renders the new version', () => {
+    const oldTable: JsonNode = {
+      name: 'table',
+      props: { headers: ['a'], rows: [['1']] },
+    };
+    const newTable: JsonNode = {
+      name: 'table',
+      props: { headers: ['a'], rows: [['2']] },
+    };
+    const { document, summary } = diffDocuments(
+      doc([oldTable]),
+      doc([newTable])
+    );
+    expect(summary.tracked.modified).toBe(0);
+    expect(summary.untracked).toHaveLength(1);
+    expect(summary.untracked[0].component).toBe('table');
+    expect(summary.untracked[0].kind).toBe('modified');
+    expect((document.children?.[0].props as any).rows).toEqual([['2']]);
+  });
+
+  it('deleted table is dropped and reported as untracked', () => {
+    const table: JsonNode = { name: 'table', props: { rows: [['x']] } };
+    const { document, summary } = diffDocuments(
+      doc([para('keep'), table]),
+      doc([para('keep')])
+    );
+    expect(document.children).toHaveLength(1);
+    expect(summary.untracked[0].kind).toBe('deleted');
+  });
+
+  it('recurses into containers', () => {
+    const oldSection: JsonNode = {
+      name: 'section',
+      props: { title: 'S' },
+      children: [para('inner old')],
+    };
+    const newSection: JsonNode = {
+      name: 'section',
+      props: { title: 'S' },
+      children: [para('inner new')],
+    };
+    const { document, summary } = diffDocuments(
+      doc([oldSection]),
+      doc([newSection])
+    );
+    expect(summary.tracked.modified).toBe(1);
+    const inner = document.children?.[0].children?.[0].props?.revision as any;
+    expect(inner).toBeDefined();
+  });
+
+  it('formatting-only change is untracked, no revision injected', () => {
+    const { document, summary } = diffDocuments(
+      doc([para('same text', { font: { bold: false } })]),
+      doc([para('same text', { font: { bold: true } })])
+    );
+    expect(summary.tracked.modified).toBe(0);
+    expect(summary.untracked).toHaveLength(1);
+    expect(document.children?.[0].props?.revision).toBeUndefined();
+  });
+
+  it('markdown-only change (e.g. hyperlink target) is surfaced as untracked', () => {
+    const { document, summary } = diffDocuments(
+      doc([para('see [terms](https://old.example.com)')]),
+      doc([para('see [terms](https://new.example.com)')])
+    );
+    expect(summary.tracked.modified).toBe(0);
+    expect(summary.untracked).toHaveLength(1);
+    expect(summary.untracked[0].detail).toContain('link target');
+    expect(document.children?.[0].props?.revision).toBeUndefined();
+  });
+
+  it('unchanged list items keep raw markdown when a sibling changes', () => {
+    const shared = ['**bold item** stays', 'see [docs](https://x.com)'];
+    const { document } = diffDocuments(
+      doc([{ name: 'list', props: { items: [...shared, 'third old'] } }]),
+      doc([{ name: 'list', props: { items: [...shared, 'third new'] } }])
+    );
+    const items = document.children?.[0].props?.items as any[];
+    expect(items[0].text).toBe('**bold item** stays');
+    expect(items[1].text).toBe('see [docs](https://x.com)');
+    expect(items[2].revision).toBeDefined();
+  });
+
+  it('NFD vs NFC text compares equal (no phantom changes)', () => {
+    const nfd = 'café menu';
+    const nfc = 'café menu';
+    const { summary } = diffDocuments(doc([para(nfd)]), doc([para(nfc)]));
+    expect(summary.tracked.modified).toBe(0);
+    expect(summary.untracked).toEqual([]);
+  });
+
+  it('enabled false->true is a tracked insertion, true->false a deletion', () => {
+    const off = { ...para('clause'), enabled: false };
+    const on = para('clause');
+    const enabledNow = diffDocuments(doc([off]), doc([on]));
+    expect(enabledNow.summary.tracked.inserted).toBe(1);
+    const disabledNow = diffDocuments(doc([on]), doc([{ ...off }]));
+    expect(disabledNow.summary.tracked.deleted).toBe(1);
+    // the emitted deletion node must actually render (not stay disabled)
+    expect(disabledNow.document.children?.[0].enabled).not.toBe(false);
+  });
+
+  it('deleting a disabled node is silent (it never rendered)', () => {
+    const off = { ...para('never shown'), enabled: false };
+    const { document, summary } = diffDocuments(
+      doc([para('keep'), off]),
+      doc([para('keep')])
+    );
+    expect(summary.tracked.deleted).toBe(0);
+    expect(document.children).toHaveLength(1);
+  });
+
+  it('placeholders inside changed text are flagged as untracked', () => {
+    const { summary } = diffDocuments(
+      doc([para('Generated for review')]),
+      doc([para('Generated {DATE} for review')])
+    );
+    expect(
+      summary.untracked.some((u) => u.detail.includes('placeholder'))
+    ).toBe(true);
+  });
+
+  it('summary.notes warns about empty paragraphs left by accept-all', () => {
+    const { summary } = diffDocuments(
+      doc([para('one'), para('two')]),
+      doc([para('one')])
+    );
+    expect(summary.notes.some((n) => n.includes('empty paragraph'))).toBe(true);
+  });
+
+  it('survives large nearly-identical documents (prefix/suffix trim)', () => {
+    const many = Array.from({ length: 30000 }, (_, i) => para(`block ${i}`));
+    const edited = [...many];
+    edited[15000] = para('block 15000 edited');
+    const start = Date.now();
+    const { summary } = diffDocuments(doc(many), doc(edited));
+    expect(Date.now() - start).toBeLessThan(5000);
+    expect(summary.tracked.modified).toBe(1);
+    expect(summary.unchangedBlocks).toBe(29999);
+  });
+
+  it('is deterministic for identical inputs', () => {
+    const oldD = doc([para('a b c'), para('x')]);
+    const newD = doc([para('a B c'), para('y'), para('z')]);
+    const run1 = diffDocuments(oldD, newD, { date: '2026-01-01T00:00:00Z' });
+    const run2 = diffDocuments(oldD, newD, { date: '2026-01-01T00:00:00Z' });
+    expect(JSON.stringify(run1)).toBe(JSON.stringify(run2));
+  });
+});

--- a/packages/shared-docx/src/diff/__tests__/document-diff.test.ts
+++ b/packages/shared-docx/src/diff/__tests__/document-diff.test.ts
@@ -66,6 +66,24 @@ describe('diffDocuments', () => {
     expect(allText).not.toContain('**');
   });
 
+  it('markdown in a modified block is reported as flattened', () => {
+    const { summary } = diffDocuments(
+      doc([para('grew **30%** fast')]),
+      doc([para('grew **32%** fast')])
+    );
+    expect(summary.untracked.some((u) => u.detail.includes('flattened'))).toBe(
+      true
+    );
+  });
+
+  it('plain-text modification reports no flattening', () => {
+    const { summary } = diffDocuments(
+      doc([para('grew 30% fast')]),
+      doc([para('grew 32% fast')])
+    );
+    expect(summary.untracked).toEqual([]);
+  });
+
   it('inserted paragraph becomes a fully tracked insertion', () => {
     const { document, summary } = diffDocuments(
       doc([para('one')]),

--- a/packages/shared-docx/src/diff/__tests__/word-diff.test.ts
+++ b/packages/shared-docx/src/diff/__tests__/word-diff.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { diffWords, stripMarkdown, tokenizeWords } from '../word-diff';
+
+describe('tokenizeWords', () => {
+  it('splits into alternating words and whitespace', () => {
+    expect(tokenizeWords('The  fee is')).toEqual([
+      'The',
+      '  ',
+      'fee',
+      ' ',
+      'is',
+    ]);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(tokenizeWords('')).toEqual([]);
+  });
+});
+
+describe('diffWords', () => {
+  it('returns a single equal segment for identical text', () => {
+    expect(diffWords('same text', 'same text')).toEqual([
+      { type: 'equal', text: 'same text' },
+    ]);
+  });
+
+  it('returns empty for two empty strings', () => {
+    expect(diffWords('', '')).toEqual([]);
+  });
+
+  it('marks everything inserted when old is empty', () => {
+    expect(diffWords('', 'brand new')).toEqual([
+      { type: 'insert', text: 'brand new' },
+    ]);
+  });
+
+  it('marks everything deleted when new is empty', () => {
+    expect(diffWords('all gone', '')).toEqual([
+      { type: 'delete', text: 'all gone' },
+    ]);
+  });
+
+  it('diffs a single word replacement', () => {
+    const segments = diffWords(
+      'The fee is 10% of revenue.',
+      'The fee is 12% of revenue.'
+    );
+    expect(segments).toEqual([
+      { type: 'equal', text: 'The fee is ' },
+      { type: 'delete', text: '10%' },
+      { type: 'insert', text: '12%' },
+      { type: 'equal', text: ' of revenue.' },
+    ]);
+  });
+
+  it('handles word insertion mid-sentence', () => {
+    const segments = diffWords('a b d', 'a b c d');
+    expect(segments).toEqual([
+      { type: 'equal', text: 'a b ' },
+      { type: 'insert', text: 'c ' },
+      { type: 'equal', text: 'd' },
+    ]);
+  });
+
+  it('handles word removal mid-sentence', () => {
+    const segments = diffWords('a b c d', 'a b d');
+    const reconstructedOld = segments
+      .filter((s) => s.type !== 'insert')
+      .map((s) => s.text)
+      .join('');
+    const reconstructedNew = segments
+      .filter((s) => s.type !== 'delete')
+      .map((s) => s.text)
+      .join('');
+    expect(reconstructedOld).toBe('a b c d');
+    expect(reconstructedNew).toBe('a b d');
+  });
+
+  it('reconstructs old and new text from any diff (invariant)', () => {
+    const cases: [string, string][] = [
+      ['the quick brown fox', 'the slow brown fox jumps'],
+      ['one two three', 'four five six'],
+      ['  leading space', 'leading space  '],
+      ['multi\nline\ntext', 'multi\nline edited\ntext'],
+    ];
+    for (const [oldText, newText] of cases) {
+      const segments = diffWords(oldText, newText);
+      const oldRecon = segments
+        .filter((s) => s.type !== 'insert')
+        .map((s) => s.text)
+        .join('');
+      const newRecon = segments
+        .filter((s) => s.type !== 'delete')
+        .map((s) => s.text)
+        .join('');
+      expect(oldRecon).toBe(oldText);
+      expect(newRecon).toBe(newText);
+    }
+  });
+
+  it('merges adjacent segments of the same type', () => {
+    const segments = diffWords('x y', 'a b');
+    expect(segments).toEqual([
+      { type: 'delete', text: 'x y' },
+      { type: 'insert', text: 'a b' },
+    ]);
+  });
+});
+
+describe('stripMarkdown', () => {
+  it('strips bold, italic and bold-italic markers', () => {
+    expect(stripMarkdown('grew **32%** this *quarter*')).toBe(
+      'grew 32% this quarter'
+    );
+    expect(stripMarkdown('***very*** important')).toBe('very important');
+    expect(stripMarkdown('__bold__ and _italic_')).toBe('bold and italic');
+  });
+
+  it('replaces links with their text', () => {
+    expect(stripMarkdown('see [the docs](https://example.com) here')).toBe(
+      'see the docs here'
+    );
+  });
+
+  it('leaves plain text untouched', () => {
+    expect(stripMarkdown('no markers at all')).toBe('no markers at all');
+  });
+
+  it('matches textParser semantics for content containing * or _', () => {
+    // Lazy [\s\S]*? content, exactly like the renderer's decorator regex
+    expect(stripMarkdown('**snake_case**')).toBe('snake_case');
+    expect(stripMarkdown('**a*b**')).toBe('a*b');
+    expect(stripMarkdown('**bold _inner_ text**')).toBe('bold _inner_ text');
+  });
+});

--- a/packages/shared-docx/src/diff/document-diff.ts
+++ b/packages/shared-docx/src/diff/document-diff.ts
@@ -78,6 +78,9 @@ interface DiffContext {
   summary: DiffSummary;
 }
 
+// Key-order sensitive: props objects with the same entries in a different
+// order compare unequal. Acceptable — inputs are machine-generated and a
+// false "changed" only adds a spurious untracked summary entry.
 function deepEqual(a: unknown, b: unknown): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
 }
@@ -356,6 +359,17 @@ function diffTextComponent(
   ctx.summary.tracked.modified++;
   const segments = diffWords(oldText, newText);
   notePlaceholdersInChanges(segments, path, newNode.name, ctx);
+  // Revision segments render literally, so markdown anywhere in a modified
+  // block — including its unchanged portions — is flattened to plain text
+  if (rawText(oldNode) !== oldText || rawText(newNode) !== newText) {
+    ctx.summary.untracked.push({
+      path,
+      kind: 'modified',
+      component: newNode.name,
+      detail:
+        'inline formatting or links flattened to plain text in the redline (revision segments render literally)',
+    });
+  }
   return {
     ...newNode,
     props: {

--- a/packages/shared-docx/src/diff/document-diff.ts
+++ b/packages/shared-docx/src/diff/document-diff.ts
@@ -1,0 +1,832 @@
+/**
+ * Document diff engine
+ *
+ * Compares two json-to-office DOCX definitions and produces a redline
+ * document: a third definition (based on the new one) where text changes
+ * are expressed as `revision` segments that the renderer turns into native
+ * Word tracked changes (w:ins / w:del).
+ *
+ * Scope (v1):
+ * - paragraph / heading: word-level tracked changes
+ * - list: item-level alignment, word-level tracked changes per item
+ * - containers (section, columns, text-box, ...): recursed into
+ * - everything else (table, image, chart, ...): block replace, reported
+ *   as an *untracked* change in the summary — Word has no native revision
+ *   for these at the fidelity docx.js supports.
+ */
+
+import { diffWords, stripMarkdown, type DiffSegment } from './word-diff';
+
+/** Structural view of any component node — schemas validate elsewhere. */
+export interface JsonNode {
+  name: string;
+  props?: Record<string, unknown>;
+  children?: JsonNode[];
+  [key: string]: unknown;
+}
+
+export interface DiffDocumentsOptions {
+  /** Revision author shown in Word (default: "json-to-office") */
+  author?: string;
+  /** Revision timestamp, ISO 8601 (default: deterministic epoch) */
+  date?: string;
+}
+
+export interface UntrackedChange {
+  /** JSON-pointer-ish location in the NEW document */
+  path: string;
+  kind: 'modified' | 'inserted' | 'deleted';
+  component: string;
+  detail: string;
+}
+
+export interface DiffSummary {
+  /** Blocks rendered with native tracked changes */
+  tracked: {
+    modified: number;
+    inserted: number;
+    deleted: number;
+  };
+  /** Changes the redline cannot express as native revisions */
+  untracked: UntrackedChange[];
+  unchangedBlocks: number;
+  /** Aggregate fidelity caveats about the redline */
+  notes: string[];
+}
+
+export interface DiffDocumentsResult {
+  /** Redline document definition (renderable as-is) */
+  document: JsonNode;
+  summary: DiffSummary;
+}
+
+const TEXT_COMPONENTS = new Set(['paragraph', 'heading']);
+
+type ListItem = string | { text: string; level?: number };
+
+interface NormalizedListItem {
+  /** Original item text (markdown intact) — emitted for unchanged items */
+  raw: string;
+  /** NFC-normalized, markdown-stripped text — used for alignment and diffing */
+  text: string;
+  level: number;
+}
+
+interface DiffContext {
+  author?: string;
+  date?: string;
+  summary: DiffSummary;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function makeRevision(ctx: DiffContext, segments: DiffSegment[]) {
+  return {
+    ...(ctx.author && { author: ctx.author }),
+    ...(ctx.date && { date: ctx.date }),
+    segments,
+  };
+}
+
+/** Raw text prop, NFC-normalized (matching the renderer's normalization). */
+function rawText(node: JsonNode): string {
+  const text = node.props?.text;
+  return typeof text === 'string' ? text.normalize('NFC') : '';
+}
+
+/** Text of a text component as it renders: NFC-normalized, markdown stripped. */
+function plainText(node: JsonNode): string {
+  return stripMarkdown(rawText(node));
+}
+
+const PLACEHOLDER_PATTERN = /\{[^}]+\}/;
+
+/** A node is rendered unless it explicitly opts out with enabled: false. */
+function isEnabled(node: JsonNode): boolean {
+  return node.enabled !== false;
+}
+
+function notePlaceholdersInChanges(
+  segments: DiffSegment[],
+  path: string,
+  component: string,
+  ctx: DiffContext
+): void {
+  if (
+    segments.some((s) => s.type !== 'equal' && PLACEHOLDER_PATTERN.test(s.text))
+  ) {
+    ctx.summary.untracked.push({
+      path,
+      kind: 'modified',
+      component,
+      detail:
+        'placeholder (e.g. {DATE}) inside inserted/deleted text renders literally in the redline',
+    });
+  }
+}
+
+function propsWithout(
+  props: Record<string, unknown> | undefined,
+  ...keys: string[]
+): Record<string, unknown> {
+  const copy = { ...(props || {}) };
+  for (const key of keys) delete copy[key];
+  return copy;
+}
+
+// ---------------------------------------------------------------------------
+// Generic LCS alignment over arrays
+// ---------------------------------------------------------------------------
+
+type AlignOp<T> =
+  | { op: 'equal'; oldItem: T; newItem: T }
+  | { op: 'delete'; oldItem: T }
+  | { op: 'insert'; newItem: T };
+
+/**
+ * Above this many DP cells the LCS table is not worth its memory (an
+ * Int32Array table lives off the V8 heap). Typical edits touch few blocks,
+ * so the prefix/suffix trim below makes the table tiny in practice.
+ */
+const MAX_ALIGN_CELLS = 4_000_000;
+
+/** LCS alignment of two arrays under a stable key function. */
+function alignByLcs<T>(
+  oldItems: T[],
+  newItems: T[],
+  key: (item: T) => string
+): AlignOp<T>[] {
+  const oldKeys = oldItems.map(key);
+  const newKeys = newItems.map(key);
+
+  // Trim the common prefix and suffix — emitted as equal ops directly
+  let start = 0;
+  while (
+    start < oldItems.length &&
+    start < newItems.length &&
+    oldKeys[start] === newKeys[start]
+  ) {
+    start++;
+  }
+  let oldEnd = oldItems.length;
+  let newEnd = newItems.length;
+  while (
+    oldEnd > start &&
+    newEnd > start &&
+    oldKeys[oldEnd - 1] === newKeys[newEnd - 1]
+  ) {
+    oldEnd--;
+    newEnd--;
+  }
+
+  const prefix: AlignOp<T>[] = [];
+  for (let k = 0; k < start; k++) {
+    prefix.push({ op: 'equal', oldItem: oldItems[k], newItem: newItems[k] });
+  }
+  const suffix: AlignOp<T>[] = [];
+  for (let k = 0; k < oldItems.length - oldEnd; k++) {
+    suffix.push({
+      op: 'equal',
+      oldItem: oldItems[oldEnd + k],
+      newItem: newItems[newEnd + k],
+    });
+  }
+
+  const n = oldEnd - start;
+  const m = newEnd - start;
+  const middle: AlignOp<T>[] = [];
+
+  if (n * m > MAX_ALIGN_CELLS) {
+    // Degenerate fallback: replace the whole middle
+    for (let k = 0; k < n; k++) {
+      middle.push({ op: 'delete', oldItem: oldItems[start + k] });
+    }
+    for (let k = 0; k < m; k++) {
+      middle.push({ op: 'insert', newItem: newItems[start + k] });
+    }
+    return [...prefix, ...middle, ...suffix];
+  }
+
+  const lcs: Int32Array[] = Array.from(
+    { length: n + 1 },
+    () => new Int32Array(m + 1)
+  );
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] =
+        oldKeys[start + i] === newKeys[start + j]
+          ? lcs[i + 1][j + 1] + 1
+          : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (oldKeys[start + i] === newKeys[start + j]) {
+      middle.push({
+        op: 'equal',
+        oldItem: oldItems[start + i],
+        newItem: newItems[start + j],
+      });
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      middle.push({ op: 'delete', oldItem: oldItems[start + i] });
+      i++;
+    } else {
+      middle.push({ op: 'insert', newItem: newItems[start + j] });
+      j++;
+    }
+  }
+  while (i < n) middle.push({ op: 'delete', oldItem: oldItems[start + i++] });
+  while (j < m) middle.push({ op: 'insert', newItem: newItems[start + j++] });
+
+  return [...prefix, ...middle, ...suffix];
+}
+
+/**
+ * Within a run of deletes+inserts between two equal anchors, pair removed
+ * and added nodes that share the same component name ("modified" instead of
+ * "deleted + inserted"). Pairing is greedy and order-preserving.
+ */
+interface GapPairing<T> {
+  pairs: { oldItem: T; newItem: T }[];
+  /** Emission plan preserving relative order */
+  plan: (
+    | { kind: 'deleted'; oldItem: T }
+    | { kind: 'inserted'; newItem: T }
+    | { kind: 'paired'; oldItem: T; newItem: T }
+  )[];
+}
+
+function pairGap<T>(
+  deleted: T[],
+  inserted: T[],
+  pairable: (oldItem: T, newItem: T) => boolean
+): GapPairing<T> {
+  const usedOld = new Array<boolean>(deleted.length).fill(false);
+  const pairing = new Array<number>(inserted.length).fill(-1);
+
+  let searchFrom = 0;
+  for (let j = 0; j < inserted.length; j++) {
+    for (let i = searchFrom; i < deleted.length; i++) {
+      if (!usedOld[i] && pairable(deleted[i], inserted[j])) {
+        usedOld[i] = true;
+        pairing[j] = i;
+        searchFrom = i + 1; // keep pairs order-preserving
+        break;
+      }
+    }
+  }
+
+  const plan: GapPairing<T>['plan'] = [];
+  const pairs: GapPairing<T>['pairs'] = [];
+  let emittedOld = 0;
+  for (let j = 0; j < inserted.length; j++) {
+    const i = pairing[j];
+    if (i >= 0) {
+      // Old nodes before this pair that were never matched: emit as deleted
+      while (emittedOld < i) {
+        if (!usedOld[emittedOld]) {
+          plan.push({ kind: 'deleted', oldItem: deleted[emittedOld] });
+        }
+        emittedOld++;
+      }
+      emittedOld = i + 1;
+      plan.push({ kind: 'paired', oldItem: deleted[i], newItem: inserted[j] });
+      pairs.push({ oldItem: deleted[i], newItem: inserted[j] });
+    } else {
+      plan.push({ kind: 'inserted', newItem: inserted[j] });
+    }
+  }
+  for (let i = emittedOld; i < deleted.length; i++) {
+    if (!usedOld[i]) plan.push({ kind: 'deleted', oldItem: deleted[i] });
+  }
+  return { pairs, plan };
+}
+
+// ---------------------------------------------------------------------------
+// Component-level diff
+// ---------------------------------------------------------------------------
+
+/** Modified text component → new node carrying revision segments. */
+function diffTextComponent(
+  oldNode: JsonNode,
+  newNode: JsonNode,
+  path: string,
+  ctx: DiffContext
+): JsonNode {
+  const oldText = plainText(oldNode);
+  const newText = plainText(newNode);
+
+  const propsChanged = !deepEqual(
+    propsWithout(oldNode.props, 'text', 'revision'),
+    propsWithout(newNode.props, 'text', 'revision')
+  );
+  if (propsChanged) {
+    ctx.summary.untracked.push({
+      path,
+      kind: 'modified',
+      component: newNode.name,
+      detail:
+        'formatting/props changed (not expressible as a tracked change); new version rendered',
+    });
+  }
+
+  if (oldText === newText) {
+    // Same rendered text, but markdown-only differences (bold markers,
+    // hyperlink targets) are invisible after stripping — surface them.
+    if (rawText(oldNode) !== rawText(newNode)) {
+      ctx.summary.untracked.push({
+        path,
+        kind: 'modified',
+        component: newNode.name,
+        detail:
+          'inline formatting or link target changed (markdown-only); new version rendered without a tracked change',
+      });
+    } else if (!propsChanged) {
+      ctx.summary.unchangedBlocks++;
+    }
+    return newNode;
+  }
+
+  ctx.summary.tracked.modified++;
+  const segments = diffWords(oldText, newText);
+  notePlaceholdersInChanges(segments, path, newNode.name, ctx);
+  return {
+    ...newNode,
+    props: {
+      ...newNode.props,
+      text: newText,
+      revision: makeRevision(ctx, segments),
+    },
+  };
+}
+
+/** Whole text component inserted/deleted → fully tracked block. */
+function insertedTextComponent(
+  node: JsonNode,
+  path: string,
+  ctx: DiffContext
+): JsonNode {
+  ctx.summary.tracked.inserted++;
+  const text = plainText(node);
+  const segments: DiffSegment[] = [{ type: 'insert', text }];
+  notePlaceholdersInChanges(segments, path, node.name, ctx);
+  return {
+    ...node,
+    props: {
+      ...node.props,
+      text,
+      revision: makeRevision(ctx, segments),
+    },
+  };
+}
+
+function deletedTextComponent(
+  node: JsonNode,
+  path: string,
+  ctx: DiffContext
+): JsonNode {
+  ctx.summary.tracked.deleted++;
+  const text = plainText(node);
+  const segments: DiffSegment[] = [{ type: 'delete', text }];
+  notePlaceholdersInChanges(segments, path, node.name, ctx);
+  return {
+    ...node,
+    props: {
+      ...node.props,
+      text: '',
+      revision: makeRevision(ctx, segments),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// List diff
+// ---------------------------------------------------------------------------
+
+function normalizeListItems(node: JsonNode): NormalizedListItem[] {
+  const items = (node.props?.items as ListItem[] | undefined) || [];
+  return items.map((item) => {
+    const raw = typeof item === 'string' ? item : item.text;
+    const level = typeof item === 'string' ? 0 : item.level || 0;
+    return { raw, text: stripMarkdown(raw.normalize('NFC')), level };
+  });
+}
+
+function diffListComponent(
+  oldNode: JsonNode,
+  newNode: JsonNode,
+  path: string,
+  ctx: DiffContext
+): JsonNode {
+  const propsChanged = !deepEqual(
+    propsWithout(oldNode.props, 'items'),
+    propsWithout(newNode.props, 'items')
+  );
+  if (propsChanged) {
+    ctx.summary.untracked.push({
+      path,
+      kind: 'modified',
+      component: 'list',
+      detail:
+        'list configuration changed (format/levels/spacing); new version rendered',
+    });
+  }
+
+  const oldItems = normalizeListItems(oldNode);
+  const newItems = normalizeListItems(newNode);
+
+  const stripped = (items: NormalizedListItem[]) =>
+    items.map((i) => ({ text: i.text, level: i.level }));
+  if (deepEqual(stripped(oldItems), stripped(newItems))) {
+    if (
+      !deepEqual(
+        oldItems.map((i) => i.raw),
+        newItems.map((i) => i.raw)
+      )
+    ) {
+      ctx.summary.untracked.push({
+        path,
+        kind: 'modified',
+        component: 'list',
+        detail:
+          'inline formatting or link target changed in list items (markdown-only); new version rendered without a tracked change',
+      });
+    } else if (!propsChanged) {
+      ctx.summary.unchangedBlocks++;
+    }
+    return newNode;
+  }
+
+  const ops = alignByLcs(
+    oldItems,
+    newItems,
+    (item) => `${item.level}:${item.text}`
+  );
+
+  // Collapse delete/insert runs into modified pairs (same level)
+  const outItems: Array<{
+    text: string;
+    level?: number;
+    revision?: ReturnType<typeof makeRevision>;
+  }> = [];
+  let changed = false;
+
+  let k = 0;
+  while (k < ops.length) {
+    const op = ops[k];
+    if (op.op === 'equal') {
+      // Unchanged item: keep the raw text so markdown/hyperlinks survive
+      outItems.push({ text: op.newItem.raw, level: op.newItem.level });
+      k++;
+      continue;
+    }
+    // Collect the full delete/insert run
+    const deleted: NormalizedListItem[] = [];
+    const inserted: NormalizedListItem[] = [];
+    while (k < ops.length && ops[k].op !== 'equal') {
+      const gapOp = ops[k];
+      if (gapOp.op === 'delete') deleted.push(gapOp.oldItem);
+      else if (gapOp.op === 'insert') inserted.push(gapOp.newItem);
+      k++;
+    }
+    const { plan } = pairGap(
+      deleted,
+      inserted,
+      (oldItem, newItem) => oldItem.level === newItem.level
+    );
+    for (const step of plan) {
+      changed = true;
+      if (step.kind === 'paired') {
+        const segments = diffWords(step.oldItem.text, step.newItem.text);
+        notePlaceholdersInChanges(segments, path, 'list', ctx);
+        outItems.push({
+          text: step.newItem.text,
+          level: step.newItem.level,
+          revision: makeRevision(ctx, segments),
+        });
+      } else if (step.kind === 'inserted') {
+        outItems.push({
+          text: step.newItem.text,
+          level: step.newItem.level,
+          revision: makeRevision(ctx, [
+            { type: 'insert', text: step.newItem.text },
+          ]),
+        });
+      } else {
+        outItems.push({
+          text: '',
+          level: step.oldItem.level,
+          revision: makeRevision(ctx, [
+            { type: 'delete', text: step.oldItem.text },
+          ]),
+        });
+      }
+    }
+  }
+
+  if (changed) ctx.summary.tracked.modified++;
+  return {
+    ...newNode,
+    props: { ...newNode.props, items: outItems },
+  };
+}
+
+function listWithAllItems(
+  node: JsonNode,
+  type: 'insert' | 'delete',
+  ctx: DiffContext
+): JsonNode {
+  if (type === 'insert') ctx.summary.tracked.inserted++;
+  else ctx.summary.tracked.deleted++;
+  const items = normalizeListItems(node).map((item) => ({
+    text: type === 'insert' ? item.text : '',
+    level: item.level,
+    revision: makeRevision(ctx, [{ type, text: item.text }]),
+  }));
+  return { ...node, props: { ...node.props, items } };
+}
+
+// ---------------------------------------------------------------------------
+// Tree diff
+// ---------------------------------------------------------------------------
+
+function isContainer(node: JsonNode): boolean {
+  return Array.isArray(node.children);
+}
+
+function nodesPairable(oldNode: JsonNode, newNode: JsonNode): boolean {
+  return oldNode.name === newNode.name;
+}
+
+function diffPairedNode(
+  oldNode: JsonNode,
+  newNode: JsonNode,
+  path: string,
+  ctx: DiffContext
+): JsonNode {
+  // `enabled` flips change what renders without touching props: treat them
+  // as content appearing (insertion) or disappearing (deletion).
+  const oldEnabled = isEnabled(oldNode);
+  const newEnabled = isEnabled(newNode);
+  if (!oldEnabled && !newEnabled) {
+    ctx.summary.unchangedBlocks++;
+    return newNode;
+  }
+  if (!oldEnabled && newEnabled) {
+    return emitInserted(newNode, path, ctx);
+  }
+  if (oldEnabled && !newEnabled) {
+    // The disabled new node would be filtered at render; emit the old
+    // content as a tracked deletion instead (where supported).
+    const deletedNode = emitDeleted(oldNode, path, ctx);
+    return deletedNode ?? newNode;
+  }
+
+  if (TEXT_COMPONENTS.has(newNode.name)) {
+    return diffTextComponent(oldNode, newNode, path, ctx);
+  }
+  if (newNode.name === 'list') {
+    return diffListComponent(oldNode, newNode, path, ctx);
+  }
+  if (isContainer(newNode) || isContainer(oldNode)) {
+    const propsChanged = !deepEqual(oldNode.props, newNode.props);
+    if (propsChanged) {
+      ctx.summary.untracked.push({
+        path,
+        kind: 'modified',
+        component: newNode.name,
+        detail: 'container props changed; new version rendered',
+      });
+    }
+    return {
+      ...newNode,
+      children: diffChildren(
+        oldNode.children || [],
+        newNode.children || [],
+        `${path}/children`,
+        ctx
+      ),
+    };
+  }
+  // Opaque component (table, image, chart, ...): block replace
+  ctx.summary.untracked.push({
+    path,
+    kind: 'modified',
+    component: newNode.name,
+    detail: `"${newNode.name}" changed (no native tracked-change support); new version rendered`,
+  });
+  return newNode;
+}
+
+function emitInserted(
+  node: JsonNode,
+  path: string,
+  ctx: DiffContext
+): JsonNode {
+  // A disabled node renders nothing — keep it, but track nothing
+  if (!isEnabled(node)) {
+    return node;
+  }
+  if (TEXT_COMPONENTS.has(node.name)) {
+    return insertedTextComponent(node, path, ctx);
+  }
+  if (node.name === 'list') {
+    return listWithAllItems(node, 'insert', ctx);
+  }
+  if (isContainer(node)) {
+    if (typeof node.props?.title === 'string') {
+      ctx.summary.untracked.push({
+        path,
+        kind: 'inserted',
+        component: node.name,
+        detail: `"${node.name}" title rendered without insertion mark (titles are props, not text blocks)`,
+      });
+    }
+    return {
+      ...node,
+      children: diffChildren([], node.children || [], `${path}/children`, ctx),
+    };
+  }
+  ctx.summary.untracked.push({
+    path,
+    kind: 'inserted',
+    component: node.name,
+    detail: `"${node.name}" added (rendered, but not marked as a tracked insertion)`,
+  });
+  return node;
+}
+
+/** Returns the redline node for a deleted block, or null if it must be dropped. */
+function emitDeleted(
+  node: JsonNode,
+  path: string,
+  ctx: DiffContext
+): JsonNode | null {
+  // A disabled node never rendered — drop it silently
+  if (!isEnabled(node)) {
+    return null;
+  }
+  if (TEXT_COMPONENTS.has(node.name)) {
+    return deletedTextComponent(node, path, ctx);
+  }
+  if (node.name === 'list') {
+    return listWithAllItems(node, 'delete', ctx);
+  }
+  if (isContainer(node)) {
+    if (typeof node.props?.title === 'string') {
+      ctx.summary.untracked.push({
+        path,
+        kind: 'deleted',
+        component: node.name,
+        detail: `"${node.name}" title still rendered without deletion mark (titles are props, not text blocks)`,
+      });
+    }
+    const children = diffChildren(
+      node.children || [],
+      [],
+      `${path}/children`,
+      ctx
+    );
+    return { ...node, children };
+  }
+  ctx.summary.untracked.push({
+    path,
+    kind: 'deleted',
+    component: node.name,
+    detail: `"${node.name}" removed (dropped from the redline; Word cannot mark it as a tracked deletion)`,
+  });
+  return null;
+}
+
+export function diffChildren(
+  oldChildren: JsonNode[],
+  newChildren: JsonNode[],
+  path: string,
+  ctx: DiffContext
+): JsonNode[] {
+  const ops = alignByLcs(oldChildren, newChildren, (node) =>
+    JSON.stringify(node)
+  );
+
+  const out: JsonNode[] = [];
+  let k = 0;
+  let newIndex = 0;
+  while (k < ops.length) {
+    const op = ops[k];
+    if (op.op === 'equal') {
+      ctx.summary.unchangedBlocks++;
+      out.push(op.newItem);
+      k++;
+      newIndex++;
+      continue;
+    }
+
+    // Collect the full delete/insert run between equal anchors
+    const deleted: JsonNode[] = [];
+    const inserted: JsonNode[] = [];
+    while (k < ops.length && ops[k].op !== 'equal') {
+      const gapOp = ops[k];
+      if (gapOp.op === 'delete') deleted.push(gapOp.oldItem);
+      else if (gapOp.op === 'insert') inserted.push(gapOp.newItem);
+      k++;
+    }
+
+    const { plan } = pairGap(deleted, inserted, nodesPairable);
+    for (const step of plan) {
+      if (step.kind === 'paired') {
+        out.push(
+          diffPairedNode(step.oldItem, step.newItem, `${path}/${newIndex}`, ctx)
+        );
+        newIndex++;
+      } else if (step.kind === 'inserted') {
+        out.push(emitInserted(step.newItem, `${path}/${newIndex}`, ctx));
+        newIndex++;
+      } else {
+        const deletedNode = emitDeleted(
+          step.oldItem,
+          `${path}/${newIndex}`,
+          ctx
+        );
+        if (deletedNode) out.push(deletedNode);
+      }
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Diff two DOCX definitions into a renderable redline document.
+ *
+ * Both inputs must be json-to-office DOCX definitions (root `name: "docx"`).
+ * The result is based on the NEW document; the root gains
+ * `trackRevisions: true` so Word opens it in review mode.
+ */
+export function diffDocuments(
+  oldDoc: JsonNode,
+  newDoc: JsonNode,
+  options: DiffDocumentsOptions = {}
+): DiffDocumentsResult {
+  if (!oldDoc || oldDoc.name !== 'docx') {
+    throw new Error('Old document: top-level component must be "docx"');
+  }
+  if (!newDoc || newDoc.name !== 'docx') {
+    throw new Error('New document: top-level component must be "docx"');
+  }
+
+  const summary: DiffSummary = {
+    tracked: { modified: 0, inserted: 0, deleted: 0 },
+    untracked: [],
+    unchangedBlocks: 0,
+    notes: [],
+  };
+  const ctx: DiffContext = {
+    author: options.author,
+    date: options.date,
+    summary,
+  };
+
+  const rootPropsChanged = !deepEqual(
+    propsWithout(oldDoc.props, 'trackRevisions'),
+    propsWithout(newDoc.props, 'trackRevisions')
+  );
+  if (rootPropsChanged) {
+    summary.untracked.push({
+      path: '/props',
+      kind: 'modified',
+      component: 'docx',
+      detail:
+        'document props changed (theme/metadata/defaults); new version used',
+    });
+  }
+
+  const children = diffChildren(
+    oldDoc.children || [],
+    newDoc.children || [],
+    '/children',
+    ctx
+  );
+
+  if (summary.tracked.deleted > 0) {
+    summary.notes.push(
+      `${summary.tracked.deleted} fully deleted block(s): accepting all changes leaves an empty paragraph behind (OOXML paragraph-mark deletion is not supported by the renderer)`
+    );
+  }
+
+  const document: JsonNode = {
+    ...newDoc,
+    props: { ...newDoc.props, trackRevisions: true },
+    children,
+  };
+
+  return { document, summary };
+}

--- a/packages/shared-docx/src/diff/index.ts
+++ b/packages/shared-docx/src/diff/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Document diff — "git diff for documents, reviewed in Word"
+ *
+ * Compares two DOCX JSON definitions and produces a renderable redline
+ * document with native Word tracked changes.
+ */
+
+export {
+  diffDocuments,
+  type JsonNode,
+  type DiffDocumentsOptions,
+  type DiffDocumentsResult,
+  type DiffSummary,
+  type UntrackedChange,
+} from './document-diff';
+
+export {
+  diffWords,
+  stripMarkdown,
+  tokenizeWords,
+  type DiffSegment,
+} from './word-diff';

--- a/packages/shared-docx/src/diff/word-diff.ts
+++ b/packages/shared-docx/src/diff/word-diff.ts
@@ -1,0 +1,178 @@
+/**
+ * Word-level text diff
+ *
+ * Tokenizes text into words and whitespace, runs an LCS diff over the
+ * tokens, and emits revision segments. Pure, dependency-free.
+ */
+
+import type { RevisionSegment } from '../schemas/components/revision';
+
+/**
+ * Anchored to the schema type so the diff engine can never emit segments
+ * the RevisionSchema would reject.
+ */
+export type DiffSegment = RevisionSegment;
+
+/**
+ * Above this many DP cells the LCS table is not worth building: fall back
+ * to a whole-text replace. ~1000x1000 tokens covers any realistic paragraph.
+ */
+const MAX_LCS_CELLS = 1_000_000;
+
+/** Split into alternating word / whitespace tokens (both preserved). */
+export function tokenizeWords(text: string): string[] {
+  if (!text) return [];
+  return text.split(/(\s+)/).filter((t) => t.length > 0);
+}
+
+function mergeSegments(segments: DiffSegment[]): DiffSegment[] {
+  const merged: DiffSegment[] = [];
+  for (const seg of segments) {
+    if (!seg.text) continue;
+    const last = merged[merged.length - 1];
+    if (last && last.type === seg.type) {
+      last.text += seg.text;
+    } else {
+      merged.push({ ...seg });
+    }
+  }
+  return merged;
+}
+
+/**
+ * Readability pass over the raw LCS output:
+ * 1. A whitespace-only equal segment flanked by changes joins the change
+ *    (the space is both deleted and re-inserted), so "x y" -> "a b" reads
+ *    as one replacement instead of three fragments.
+ * 2. Within each change run, deletions are emitted before insertions.
+ * The old/new reconstruction invariant is preserved.
+ */
+function normalizeSegments(segments: DiffSegment[]): DiffSegment[] {
+  const folded: DiffSegment[] = [];
+  for (let k = 0; k < segments.length; k++) {
+    const seg = segments[k];
+    if (seg.type === 'equal' && /^\s+$/.test(seg.text)) {
+      const prev = folded[folded.length - 1];
+      const next = segments[k + 1];
+      if (prev && prev.type !== 'equal' && next && next.type !== 'equal') {
+        folded.push(
+          { type: 'delete', text: seg.text },
+          { type: 'insert', text: seg.text }
+        );
+        continue;
+      }
+    }
+    folded.push({ ...seg });
+  }
+
+  const out: DiffSegment[] = [];
+  let k = 0;
+  while (k < folded.length) {
+    if (folded[k].type === 'equal') {
+      out.push(folded[k]);
+      k++;
+      continue;
+    }
+    let deleted = '';
+    let inserted = '';
+    while (k < folded.length && folded[k].type !== 'equal') {
+      if (folded[k].type === 'delete') deleted += folded[k].text;
+      else inserted += folded[k].text;
+      k++;
+    }
+    if (deleted) out.push({ type: 'delete', text: deleted });
+    if (inserted) out.push({ type: 'insert', text: inserted });
+  }
+  return mergeSegments(out);
+}
+
+/**
+ * Word-level diff between two strings.
+ *
+ * Returns merged segments in document order. Deleting everything and
+ * inserting everything (whole replace) is the degenerate output for
+ * completely different texts or oversized inputs.
+ */
+export function diffWords(oldText: string, newText: string): DiffSegment[] {
+  if (oldText === newText) {
+    return oldText ? [{ type: 'equal', text: oldText }] : [];
+  }
+
+  const oldTokens = tokenizeWords(oldText);
+  const newTokens = tokenizeWords(newText);
+
+  if (oldTokens.length === 0) {
+    return mergeSegments([{ type: 'insert', text: newText }]);
+  }
+  if (newTokens.length === 0) {
+    return mergeSegments([{ type: 'delete', text: oldText }]);
+  }
+
+  if (oldTokens.length * newTokens.length > MAX_LCS_CELLS) {
+    return mergeSegments([
+      { type: 'delete', text: oldText },
+      { type: 'insert', text: newText },
+    ]);
+  }
+
+  // Standard LCS dynamic programming table
+  const n = oldTokens.length;
+  const m = newTokens.length;
+  // lcs[i][j] = LCS length of oldTokens[i..] and newTokens[j..]
+  const lcs: Int32Array[] = Array.from(
+    { length: n + 1 },
+    () => new Int32Array(m + 1)
+  );
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] =
+        oldTokens[i] === newTokens[j]
+          ? lcs[i + 1][j + 1] + 1
+          : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+
+  // Backtrack
+  const segments: DiffSegment[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (oldTokens[i] === newTokens[j]) {
+      segments.push({ type: 'equal', text: oldTokens[i] });
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      segments.push({ type: 'delete', text: oldTokens[i] });
+      i++;
+    } else {
+      segments.push({ type: 'insert', text: newTokens[j] });
+      j++;
+    }
+  }
+  while (i < n) {
+    segments.push({ type: 'delete', text: oldTokens[i] });
+    i++;
+  }
+  while (j < m) {
+    segments.push({ type: 'insert', text: newTokens[j] });
+    j++;
+  }
+
+  return normalizeSegments(segments);
+}
+
+/**
+ * Strip the inline markdown the renderer understands (bold/italic markers,
+ * hyperlinks) so revision segments — which render literally — never expose
+ * raw markers. Uses the exact decorator regex of textParser.ts (lazy
+ * [\s\S]*? content), so what the parser would style, this strips — including
+ * content containing '*' or '_' (e.g. **snake_case**).
+ */
+export function stripMarkdown(text: string): string {
+  return text
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1') // [text](url) -> text
+    .replace(
+      /(\*\*\*|___)([\s\S]*?)\1|(\*\*|__)([\s\S]*?)\3|(\*|_)([\s\S]*?)\5/g,
+      (_match, _d1, bi, _d2, b, _d3, i) => bi ?? b ?? i ?? ''
+    );
+}

--- a/packages/shared-docx/src/index.ts
+++ b/packages/shared-docx/src/index.ts
@@ -2,6 +2,20 @@
 export const SHARED_DOCX_VERSION = '1.0.0';
 
 // ============================================================================
+// Document diff (tracked-change redlines)
+// ============================================================================
+
+export { diffDocuments, diffWords, stripMarkdown } from './diff';
+export type {
+  DiffDocumentsOptions,
+  DiffDocumentsResult,
+  DiffSummary,
+  UntrackedChange,
+  DiffSegment,
+  JsonNode,
+} from './diff';
+
+// ============================================================================
 // Format-agnostic re-exports from @json-to-office/shared
 // ============================================================================
 
@@ -211,6 +225,8 @@ export {
   TablePropsSchema,
   ListPropsSchema,
   TocPropsSchema,
+  RevisionSchema,
+  RevisionSegmentSchema,
   StandardComponentDefinitionSchema,
   ComponentDefinitionSchema,
 } from './schemas/components';
@@ -229,6 +245,8 @@ export type {
   TableProps,
   ListProps,
   TocProps,
+  Revision,
+  RevisionSegment,
   Alignment,
   JustifiedAlignment,
   HeadingLevel,

--- a/packages/shared-docx/src/schemas/component-defaults.ts
+++ b/packages/shared-docx/src/schemas/component-defaults.ts
@@ -18,10 +18,15 @@ import { SectionPropsSchema } from './components/section';
 import { ColumnsPropsSchema } from './components/columns';
 import { ListPropsSchema } from './components/list';
 
-// Create component defaults by making all fields optional (Type.Partial)
-export const HeadingComponentDefaultsSchema = Type.Partial(HeadingPropsSchema);
-export const ParagraphComponentDefaultsSchema =
-  Type.Partial(ParagraphPropsSchema);
+// Create component defaults by making all fields optional (Type.Partial).
+// `revision` (tracked-change segments) is per-instance data and must never
+// be a shared default — it would silently replace every component's text.
+export const HeadingComponentDefaultsSchema = Type.Partial(
+  Type.Omit(HeadingPropsSchema, ['revision'])
+);
+export const ParagraphComponentDefaultsSchema = Type.Partial(
+  Type.Omit(ParagraphPropsSchema, ['revision'])
+);
 export const ImageComponentDefaultsSchema = Type.Partial(ImagePropsSchema);
 export const StatisticComponentDefaultsSchema =
   Type.Partial(StatisticPropsSchema);

--- a/packages/shared-docx/src/schemas/components.ts
+++ b/packages/shared-docx/src/schemas/components.ts
@@ -16,6 +16,7 @@ import {
 
 // Re-export all schemas from individual component files
 export * from './components/common';
+export * from './components/revision';
 export * from './components/report';
 export * from './components/section';
 export * from './components/columns';

--- a/packages/shared-docx/src/schemas/components/heading.ts
+++ b/packages/shared-docx/src/schemas/components/heading.ts
@@ -10,6 +10,7 @@ import {
   SpacingSchema,
   LineSpacingSchema,
 } from './common';
+import { RevisionSchema } from './revision';
 
 export const HeadingPropsSchema = Type.Object(
   {
@@ -50,6 +51,7 @@ export const HeadingPropsSchema = Type.Object(
         description: 'Keep all lines of heading together on same page',
       })
     ),
+    revision: Type.Optional(RevisionSchema),
   },
   {
     description: 'Heading component props',

--- a/packages/shared-docx/src/schemas/components/index.ts
+++ b/packages/shared-docx/src/schemas/components/index.ts
@@ -8,6 +8,7 @@
 export * from './common';
 
 // Individual component schemas
+export * from './revision';
 export * from './report';
 export * from './section';
 export * from './columns';

--- a/packages/shared-docx/src/schemas/components/list.ts
+++ b/packages/shared-docx/src/schemas/components/list.ts
@@ -8,6 +8,7 @@ import {
   JustifiedAlignmentSchema,
   IndentSchema,
 } from './common';
+import { RevisionSchema } from './revision';
 
 /**
  * Level format options for docx numbering
@@ -139,6 +140,7 @@ export const ListPropsSchema = Type.Object(
               description: 'Nesting level for this item',
             })
           ),
+          revision: Type.Optional(RevisionSchema),
         }),
       ]),
       {

--- a/packages/shared-docx/src/schemas/components/paragraph.ts
+++ b/packages/shared-docx/src/schemas/components/paragraph.ts
@@ -5,6 +5,7 @@
 import { Type, Static } from '@sinclair/typebox';
 import { SpacingSchema } from './common';
 import { FontDefinitionSchema } from '../font';
+import { RevisionSchema } from './revision';
 
 // Frame wrapping type schema
 const FrameWrapTypeSchema = Type.Union(
@@ -196,6 +197,7 @@ export const ParagraphPropsSchema = Type.Object(
         description: 'Unique identifier for internal linking (bookmark anchor)',
       })
     ),
+    revision: Type.Optional(RevisionSchema),
   },
   {
     description:

--- a/packages/shared-docx/src/schemas/components/report.ts
+++ b/packages/shared-docx/src/schemas/components/report.ts
@@ -17,6 +17,12 @@ export const createReportPropsSchema = (_moduleRef?: TSchema) =>
         })
       ),
       componentDefaults: Type.Optional(ComponentDefaultsSchema),
+      trackRevisions: Type.Optional(
+        Type.Boolean({
+          description:
+            'Open the document in track-changes mode: Word marks any further edits as revisions. Set automatically on redline documents produced by the diff engine',
+        })
+      ),
       metadata: Type.Optional(
         Type.Object(
           {

--- a/packages/shared-docx/src/schemas/components/revision.ts
+++ b/packages/shared-docx/src/schemas/components/revision.ts
@@ -1,0 +1,62 @@
+/**
+ * Revision Schema
+ * Tracked-change (redline) metadata for text-bearing components.
+ *
+ * When a component carries a `revision`, its text is rendered from
+ * `revision.segments` as native Word tracked changes (w:ins / w:del)
+ * instead of the plain `text` prop. The `text` prop should hold the
+ * new (post-change) text so the document degrades gracefully when
+ * revisions are ignored.
+ */
+
+import { Type, Static } from '@sinclair/typebox';
+
+export const RevisionSegmentSchema = Type.Object(
+  {
+    type: Type.Union(
+      [Type.Literal('equal'), Type.Literal('insert'), Type.Literal('delete')],
+      {
+        description:
+          "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+      }
+    ),
+    text: Type.String({
+      description: 'Literal text of this segment (rendered without markdown)',
+    }),
+  },
+  {
+    description: 'A contiguous run of text sharing one revision state',
+    additionalProperties: false,
+  }
+);
+
+export const RevisionSchema = Type.Object(
+  {
+    author: Type.Optional(
+      Type.String({
+        description:
+          'Revision author shown in Word (default: "json-to-office")',
+      })
+    ),
+    date: Type.Optional(
+      Type.String({
+        format: 'date-time',
+        description:
+          'Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output',
+      })
+    ),
+    segments: Type.Array(RevisionSegmentSchema, {
+      minItems: 1,
+      description:
+        'Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text',
+    }),
+  },
+  {
+    description:
+      'Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)',
+    additionalProperties: false,
+  }
+);
+
+export type RevisionSegment = Static<typeof RevisionSegmentSchema>;
+export type Revision = Static<typeof RevisionSchema>;

--- a/skills/json-to-office/assets/schemas/document.schema.json
+++ b/skills/json-to-office/assets/schemas/document.schema.json
@@ -824,6 +824,57 @@
                           "keepLines": {
                             "description": "Keep all lines of heading together on same page",
                             "type": "boolean"
+                          },
+                          "revision": {
+                            "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "author": {
+                                "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                "type": "string"
+                              },
+                              "date": {
+                                "format": "date-time",
+                                "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                "type": "string"
+                              },
+                              "segments": {
+                                "minItems": 1,
+                                "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                "type": "array",
+                                "items": {
+                                  "description": "A contiguous run of text sharing one revision state",
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                      "anyOf": [
+                                        {
+                                          "const": "equal",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "insert",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "delete",
+                                          "type": "string"
+                                        }
+                                      ]
+                                    },
+                                    "text": {
+                                      "description": "Literal text of this segment (rendered without markdown)",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["type", "text"]
+                                }
+                              }
+                            },
+                            "required": ["segments"]
                           }
                         },
                         "required": ["text"]
@@ -1208,6 +1259,57 @@
                           "id": {
                             "description": "Unique identifier for internal linking (bookmark anchor)",
                             "type": "string"
+                          },
+                          "revision": {
+                            "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "author": {
+                                "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                "type": "string"
+                              },
+                              "date": {
+                                "format": "date-time",
+                                "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                "type": "string"
+                              },
+                              "segments": {
+                                "minItems": 1,
+                                "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                "type": "array",
+                                "items": {
+                                  "description": "A contiguous run of text sharing one revision state",
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                      "anyOf": [
+                                        {
+                                          "const": "equal",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "insert",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "delete",
+                                          "type": "string"
+                                        }
+                                      ]
+                                    },
+                                    "text": {
+                                      "description": "Literal text of this segment (rendered without markdown)",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["type", "text"]
+                                }
+                              }
+                            },
+                            "required": ["segments"]
                           }
                         },
                         "required": ["text"]
@@ -2021,6 +2123,57 @@
                           "keepLines": {
                             "description": "Keep all lines of heading together on same page",
                             "type": "boolean"
+                          },
+                          "revision": {
+                            "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "author": {
+                                "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                "type": "string"
+                              },
+                              "date": {
+                                "format": "date-time",
+                                "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                "type": "string"
+                              },
+                              "segments": {
+                                "minItems": 1,
+                                "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                "type": "array",
+                                "items": {
+                                  "description": "A contiguous run of text sharing one revision state",
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                      "anyOf": [
+                                        {
+                                          "const": "equal",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "insert",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "delete",
+                                          "type": "string"
+                                        }
+                                      ]
+                                    },
+                                    "text": {
+                                      "description": "Literal text of this segment (rendered without markdown)",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["type", "text"]
+                                }
+                              }
+                            },
+                            "required": ["segments"]
                           }
                         },
                         "required": ["text"]
@@ -2405,6 +2558,57 @@
                           "id": {
                             "description": "Unique identifier for internal linking (bookmark anchor)",
                             "type": "string"
+                          },
+                          "revision": {
+                            "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "author": {
+                                "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                "type": "string"
+                              },
+                              "date": {
+                                "format": "date-time",
+                                "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                "type": "string"
+                              },
+                              "segments": {
+                                "minItems": 1,
+                                "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                "type": "array",
+                                "items": {
+                                  "description": "A contiguous run of text sharing one revision state",
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                      "anyOf": [
+                                        {
+                                          "const": "equal",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "insert",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "delete",
+                                          "type": "string"
+                                        }
+                                      ]
+                                    },
+                                    "text": {
+                                      "description": "Literal text of this segment (rendered without markdown)",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["type", "text"]
+                                }
+                              }
+                            },
+                            "required": ["segments"]
                           }
                         },
                         "required": ["text"]
@@ -4140,6 +4344,57 @@
                                       "maximum": 8,
                                       "description": "Nesting level for this item",
                                       "type": "number"
+                                    },
+                                    "revision": {
+                                      "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "author": {
+                                          "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                          "type": "string"
+                                        },
+                                        "date": {
+                                          "format": "date-time",
+                                          "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                          "type": "string"
+                                        },
+                                        "segments": {
+                                          "minItems": 1,
+                                          "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A contiguous run of text sharing one revision state",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                "anyOf": [
+                                                  {
+                                                    "const": "equal",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "insert",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "delete",
+                                                    "type": "string"
+                                                  }
+                                                ]
+                                              },
+                                              "text": {
+                                                "description": "Literal text of this segment (rendered without markdown)",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": ["type", "text"]
+                                          }
+                                        }
+                                      },
+                                      "required": ["segments"]
                                     }
                                   },
                                   "required": ["text"]
@@ -5855,6 +6110,57 @@
                                     "keepLines": {
                                       "description": "Keep all lines of heading together on same page",
                                       "type": "boolean"
+                                    },
+                                    "revision": {
+                                      "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "author": {
+                                          "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                          "type": "string"
+                                        },
+                                        "date": {
+                                          "format": "date-time",
+                                          "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                          "type": "string"
+                                        },
+                                        "segments": {
+                                          "minItems": 1,
+                                          "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A contiguous run of text sharing one revision state",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                "anyOf": [
+                                                  {
+                                                    "const": "equal",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "insert",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "delete",
+                                                    "type": "string"
+                                                  }
+                                                ]
+                                              },
+                                              "text": {
+                                                "description": "Literal text of this segment (rendered without markdown)",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": ["type", "text"]
+                                          }
+                                        }
+                                      },
+                                      "required": ["segments"]
                                     }
                                   },
                                   "required": ["text"]
@@ -6239,6 +6545,57 @@
                                     "id": {
                                       "description": "Unique identifier for internal linking (bookmark anchor)",
                                       "type": "string"
+                                    },
+                                    "revision": {
+                                      "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "author": {
+                                          "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                          "type": "string"
+                                        },
+                                        "date": {
+                                          "format": "date-time",
+                                          "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                          "type": "string"
+                                        },
+                                        "segments": {
+                                          "minItems": 1,
+                                          "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A contiguous run of text sharing one revision state",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                "anyOf": [
+                                                  {
+                                                    "const": "equal",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "insert",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "delete",
+                                                    "type": "string"
+                                                  }
+                                                ]
+                                              },
+                                              "text": {
+                                                "description": "Literal text of this segment (rendered without markdown)",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": ["type", "text"]
+                                          }
+                                        }
+                                      },
+                                      "required": ["segments"]
                                     }
                                   },
                                   "required": ["text"]
@@ -7130,6 +7487,57 @@
                           "keepLines": {
                             "description": "Keep all lines of heading together on same page",
                             "type": "boolean"
+                          },
+                          "revision": {
+                            "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "author": {
+                                "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                "type": "string"
+                              },
+                              "date": {
+                                "format": "date-time",
+                                "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                "type": "string"
+                              },
+                              "segments": {
+                                "minItems": 1,
+                                "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                "type": "array",
+                                "items": {
+                                  "description": "A contiguous run of text sharing one revision state",
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                      "anyOf": [
+                                        {
+                                          "const": "equal",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "insert",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "delete",
+                                          "type": "string"
+                                        }
+                                      ]
+                                    },
+                                    "text": {
+                                      "description": "Literal text of this segment (rendered without markdown)",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["type", "text"]
+                                }
+                              }
+                            },
+                            "required": ["segments"]
                           }
                         },
                         "required": ["text"]
@@ -7514,6 +7922,57 @@
                           "id": {
                             "description": "Unique identifier for internal linking (bookmark anchor)",
                             "type": "string"
+                          },
+                          "revision": {
+                            "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "author": {
+                                "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                "type": "string"
+                              },
+                              "date": {
+                                "format": "date-time",
+                                "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                "type": "string"
+                              },
+                              "segments": {
+                                "minItems": 1,
+                                "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                "type": "array",
+                                "items": {
+                                  "description": "A contiguous run of text sharing one revision state",
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                      "anyOf": [
+                                        {
+                                          "const": "equal",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "insert",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "delete",
+                                          "type": "string"
+                                        }
+                                      ]
+                                    },
+                                    "text": {
+                                      "description": "Literal text of this segment (rendered without markdown)",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["type", "text"]
+                                }
+                              }
+                            },
+                            "required": ["segments"]
                           }
                         },
                         "required": ["text"]
@@ -9249,6 +9708,57 @@
                                       "maximum": 8,
                                       "description": "Nesting level for this item",
                                       "type": "number"
+                                    },
+                                    "revision": {
+                                      "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "author": {
+                                          "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                          "type": "string"
+                                        },
+                                        "date": {
+                                          "format": "date-time",
+                                          "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                          "type": "string"
+                                        },
+                                        "segments": {
+                                          "minItems": 1,
+                                          "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A contiguous run of text sharing one revision state",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                "anyOf": [
+                                                  {
+                                                    "const": "equal",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "insert",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "delete",
+                                                    "type": "string"
+                                                  }
+                                                ]
+                                              },
+                                              "text": {
+                                                "description": "Literal text of this segment (rendered without markdown)",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": ["type", "text"]
+                                          }
+                                        }
+                                      },
+                                      "required": ["segments"]
                                     }
                                   },
                                   "required": ["text"]
@@ -10511,6 +11021,57 @@
                                     "keepLines": {
                                       "description": "Keep all lines of heading together on same page",
                                       "type": "boolean"
+                                    },
+                                    "revision": {
+                                      "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "author": {
+                                          "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                          "type": "string"
+                                        },
+                                        "date": {
+                                          "format": "date-time",
+                                          "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                          "type": "string"
+                                        },
+                                        "segments": {
+                                          "minItems": 1,
+                                          "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A contiguous run of text sharing one revision state",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                "anyOf": [
+                                                  {
+                                                    "const": "equal",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "insert",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "delete",
+                                                    "type": "string"
+                                                  }
+                                                ]
+                                              },
+                                              "text": {
+                                                "description": "Literal text of this segment (rendered without markdown)",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": ["type", "text"]
+                                          }
+                                        }
+                                      },
+                                      "required": ["segments"]
                                     }
                                   },
                                   "required": ["text"]
@@ -10895,6 +11456,57 @@
                                     "id": {
                                       "description": "Unique identifier for internal linking (bookmark anchor)",
                                       "type": "string"
+                                    },
+                                    "revision": {
+                                      "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "author": {
+                                          "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                          "type": "string"
+                                        },
+                                        "date": {
+                                          "format": "date-time",
+                                          "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                          "type": "string"
+                                        },
+                                        "segments": {
+                                          "minItems": 1,
+                                          "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A contiguous run of text sharing one revision state",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                "anyOf": [
+                                                  {
+                                                    "const": "equal",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "insert",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "delete",
+                                                    "type": "string"
+                                                  }
+                                                ]
+                                              },
+                                              "text": {
+                                                "description": "Literal text of this segment (rendered without markdown)",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": ["type", "text"]
+                                          }
+                                        }
+                                      },
+                                      "required": ["segments"]
                                     }
                                   },
                                   "required": ["text"]
@@ -12630,6 +13242,60 @@
                                                 "maximum": 8,
                                                 "description": "Nesting level for this item",
                                                 "type": "number"
+                                              },
+                                              "revision": {
+                                                "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                                "additionalProperties": false,
+                                                "type": "object",
+                                                "properties": {
+                                                  "author": {
+                                                    "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                                    "type": "string"
+                                                  },
+                                                  "date": {
+                                                    "format": "date-time",
+                                                    "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                                    "type": "string"
+                                                  },
+                                                  "segments": {
+                                                    "minItems": 1,
+                                                    "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "description": "A contiguous run of text sharing one revision state",
+                                                      "additionalProperties": false,
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "type": {
+                                                          "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                          "anyOf": [
+                                                            {
+                                                              "const": "equal",
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "const": "insert",
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "const": "delete",
+                                                              "type": "string"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "text": {
+                                                          "description": "Literal text of this segment (rendered without markdown)",
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "type",
+                                                        "text"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["segments"]
                                               }
                                             },
                                             "required": ["text"]
@@ -14348,6 +15014,60 @@
                                               "keepLines": {
                                                 "description": "Keep all lines of heading together on same page",
                                                 "type": "boolean"
+                                              },
+                                              "revision": {
+                                                "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                                "additionalProperties": false,
+                                                "type": "object",
+                                                "properties": {
+                                                  "author": {
+                                                    "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                                    "type": "string"
+                                                  },
+                                                  "date": {
+                                                    "format": "date-time",
+                                                    "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                                    "type": "string"
+                                                  },
+                                                  "segments": {
+                                                    "minItems": 1,
+                                                    "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "description": "A contiguous run of text sharing one revision state",
+                                                      "additionalProperties": false,
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "type": {
+                                                          "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                          "anyOf": [
+                                                            {
+                                                              "const": "equal",
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "const": "insert",
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "const": "delete",
+                                                              "type": "string"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "text": {
+                                                          "description": "Literal text of this segment (rendered without markdown)",
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "type",
+                                                        "text"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["segments"]
                                               }
                                             },
                                             "required": ["text"]
@@ -14735,6 +15455,60 @@
                                               "id": {
                                                 "description": "Unique identifier for internal linking (bookmark anchor)",
                                                 "type": "string"
+                                              },
+                                              "revision": {
+                                                "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                                "additionalProperties": false,
+                                                "type": "object",
+                                                "properties": {
+                                                  "author": {
+                                                    "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                                    "type": "string"
+                                                  },
+                                                  "date": {
+                                                    "format": "date-time",
+                                                    "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                                    "type": "string"
+                                                  },
+                                                  "segments": {
+                                                    "minItems": 1,
+                                                    "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "description": "A contiguous run of text sharing one revision state",
+                                                      "additionalProperties": false,
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "type": {
+                                                          "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                          "anyOf": [
+                                                            {
+                                                              "const": "equal",
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "const": "insert",
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "const": "delete",
+                                                              "type": "string"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "text": {
+                                                          "description": "Literal text of this segment (rendered without markdown)",
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "type",
+                                                        "text"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "required": ["segments"]
                                               }
                                             },
                                             "required": ["text"]
@@ -16007,6 +16781,57 @@
                                     "keepLines": {
                                       "description": "Keep all lines of heading together on same page",
                                       "type": "boolean"
+                                    },
+                                    "revision": {
+                                      "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "author": {
+                                          "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                          "type": "string"
+                                        },
+                                        "date": {
+                                          "format": "date-time",
+                                          "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                          "type": "string"
+                                        },
+                                        "segments": {
+                                          "minItems": 1,
+                                          "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A contiguous run of text sharing one revision state",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                "anyOf": [
+                                                  {
+                                                    "const": "equal",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "insert",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "delete",
+                                                    "type": "string"
+                                                  }
+                                                ]
+                                              },
+                                              "text": {
+                                                "description": "Literal text of this segment (rendered without markdown)",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": ["type", "text"]
+                                          }
+                                        }
+                                      },
+                                      "required": ["segments"]
                                     }
                                   },
                                   "required": ["text"]
@@ -16391,6 +17216,57 @@
                                     "id": {
                                       "description": "Unique identifier for internal linking (bookmark anchor)",
                                       "type": "string"
+                                    },
+                                    "revision": {
+                                      "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "properties": {
+                                        "author": {
+                                          "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                          "type": "string"
+                                        },
+                                        "date": {
+                                          "format": "date-time",
+                                          "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                          "type": "string"
+                                        },
+                                        "segments": {
+                                          "minItems": 1,
+                                          "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A contiguous run of text sharing one revision state",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                "anyOf": [
+                                                  {
+                                                    "const": "equal",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "insert",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "const": "delete",
+                                                    "type": "string"
+                                                  }
+                                                ]
+                                              },
+                                              "text": {
+                                                "description": "Literal text of this segment (rendered without markdown)",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": ["type", "text"]
+                                          }
+                                        }
+                                      },
+                                      "required": ["segments"]
                                     }
                                   },
                                   "required": ["text"]
@@ -19375,6 +20251,57 @@
                                     "maximum": 8,
                                     "description": "Nesting level for this item",
                                     "type": "number"
+                                  },
+                                  "revision": {
+                                    "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "author": {
+                                        "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                        "type": "string"
+                                      },
+                                      "date": {
+                                        "format": "date-time",
+                                        "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                        "type": "string"
+                                      },
+                                      "segments": {
+                                        "minItems": 1,
+                                        "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A contiguous run of text sharing one revision state",
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                              "anyOf": [
+                                                {
+                                                  "const": "equal",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "const": "insert",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "const": "delete",
+                                                  "type": "string"
+                                                }
+                                              ]
+                                            },
+                                            "text": {
+                                              "description": "Literal text of this segment (rendered without markdown)",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": ["type", "text"]
+                                        }
+                                      }
+                                    },
+                                    "required": ["segments"]
                                   }
                                 },
                                 "required": ["text"]
@@ -20034,6 +20961,10 @@
                     }
                   }
                 },
+                "trackRevisions": {
+                  "description": "Open the document in track-changes mode: Word marks any further edits as revisions. Set automatically on redline documents produced by the diff engine",
+                  "type": "boolean"
+                },
                 "metadata": {
                   "description": "Document metadata (title, author, company, dates, etc.)",
                   "additionalProperties": false,
@@ -20518,6 +21449,57 @@
                                 "keepLines": {
                                   "description": "Keep all lines of heading together on same page",
                                   "type": "boolean"
+                                },
+                                "revision": {
+                                  "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "author": {
+                                      "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                      "type": "string"
+                                    },
+                                    "date": {
+                                      "format": "date-time",
+                                      "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                      "type": "string"
+                                    },
+                                    "segments": {
+                                      "minItems": 1,
+                                      "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "A contiguous run of text sharing one revision state",
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                            "anyOf": [
+                                              {
+                                                "const": "equal",
+                                                "type": "string"
+                                              },
+                                              {
+                                                "const": "insert",
+                                                "type": "string"
+                                              },
+                                              {
+                                                "const": "delete",
+                                                "type": "string"
+                                              }
+                                            ]
+                                          },
+                                          "text": {
+                                            "description": "Literal text of this segment (rendered without markdown)",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["type", "text"]
+                                      }
+                                    }
+                                  },
+                                  "required": ["segments"]
                                 }
                               },
                               "required": ["text"]
@@ -20902,6 +21884,57 @@
                                 "id": {
                                   "description": "Unique identifier for internal linking (bookmark anchor)",
                                   "type": "string"
+                                },
+                                "revision": {
+                                  "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "author": {
+                                      "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                      "type": "string"
+                                    },
+                                    "date": {
+                                      "format": "date-time",
+                                      "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                      "type": "string"
+                                    },
+                                    "segments": {
+                                      "minItems": 1,
+                                      "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "A contiguous run of text sharing one revision state",
+                                        "additionalProperties": false,
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                            "anyOf": [
+                                              {
+                                                "const": "equal",
+                                                "type": "string"
+                                              },
+                                              {
+                                                "const": "insert",
+                                                "type": "string"
+                                              },
+                                              {
+                                                "const": "delete",
+                                                "type": "string"
+                                              }
+                                            ]
+                                          },
+                                          "text": {
+                                            "description": "Literal text of this segment (rendered without markdown)",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["type", "text"]
+                                      }
+                                    }
+                                  },
+                                  "required": ["segments"]
                                 }
                               },
                               "required": ["text"]
@@ -22637,6 +23670,57 @@
                                             "maximum": 8,
                                             "description": "Nesting level for this item",
                                             "type": "number"
+                                          },
+                                          "revision": {
+                                            "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "author": {
+                                                "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                                "type": "string"
+                                              },
+                                              "date": {
+                                                "format": "date-time",
+                                                "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                                "type": "string"
+                                              },
+                                              "segments": {
+                                                "minItems": 1,
+                                                "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                                "type": "array",
+                                                "items": {
+                                                  "description": "A contiguous run of text sharing one revision state",
+                                                  "additionalProperties": false,
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                      "anyOf": [
+                                                        {
+                                                          "const": "equal",
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "const": "insert",
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "const": "delete",
+                                                          "type": "string"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "text": {
+                                                      "description": "Literal text of this segment (rendered without markdown)",
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["type", "text"]
+                                                }
+                                              }
+                                            },
+                                            "required": ["segments"]
                                           }
                                         },
                                         "required": ["text"]
@@ -23899,6 +24983,57 @@
                                           "keepLines": {
                                             "description": "Keep all lines of heading together on same page",
                                             "type": "boolean"
+                                          },
+                                          "revision": {
+                                            "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "author": {
+                                                "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                                "type": "string"
+                                              },
+                                              "date": {
+                                                "format": "date-time",
+                                                "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                                "type": "string"
+                                              },
+                                              "segments": {
+                                                "minItems": 1,
+                                                "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                                "type": "array",
+                                                "items": {
+                                                  "description": "A contiguous run of text sharing one revision state",
+                                                  "additionalProperties": false,
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                      "anyOf": [
+                                                        {
+                                                          "const": "equal",
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "const": "insert",
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "const": "delete",
+                                                          "type": "string"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "text": {
+                                                      "description": "Literal text of this segment (rendered without markdown)",
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["type", "text"]
+                                                }
+                                              }
+                                            },
+                                            "required": ["segments"]
                                           }
                                         },
                                         "required": ["text"]
@@ -24283,6 +25418,57 @@
                                           "id": {
                                             "description": "Unique identifier for internal linking (bookmark anchor)",
                                             "type": "string"
+                                          },
+                                          "revision": {
+                                            "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "author": {
+                                                "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                                "type": "string"
+                                              },
+                                              "date": {
+                                                "format": "date-time",
+                                                "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                                "type": "string"
+                                              },
+                                              "segments": {
+                                                "minItems": 1,
+                                                "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                                "type": "array",
+                                                "items": {
+                                                  "description": "A contiguous run of text sharing one revision state",
+                                                  "additionalProperties": false,
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                      "anyOf": [
+                                                        {
+                                                          "const": "equal",
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "const": "insert",
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "const": "delete",
+                                                          "type": "string"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "text": {
+                                                      "description": "Literal text of this segment (rendered without markdown)",
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["type", "text"]
+                                                }
+                                              }
+                                            },
+                                            "required": ["segments"]
                                           }
                                         },
                                         "required": ["text"]
@@ -26018,6 +27204,60 @@
                                                       "maximum": 8,
                                                       "description": "Nesting level for this item",
                                                       "type": "number"
+                                                    },
+                                                    "revision": {
+                                                      "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                                      "additionalProperties": false,
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "author": {
+                                                          "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                                          "type": "string"
+                                                        },
+                                                        "date": {
+                                                          "format": "date-time",
+                                                          "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                                          "type": "string"
+                                                        },
+                                                        "segments": {
+                                                          "minItems": 1,
+                                                          "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                                          "type": "array",
+                                                          "items": {
+                                                            "description": "A contiguous run of text sharing one revision state",
+                                                            "additionalProperties": false,
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                                "anyOf": [
+                                                                  {
+                                                                    "const": "equal",
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "const": "insert",
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "const": "delete",
+                                                                    "type": "string"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "text": {
+                                                                "description": "Literal text of this segment (rendered without markdown)",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "text"
+                                                            ]
+                                                          }
+                                                        }
+                                                      },
+                                                      "required": ["segments"]
                                                     }
                                                   },
                                                   "required": ["text"]
@@ -27739,6 +28979,60 @@
                                                     "keepLines": {
                                                       "description": "Keep all lines of heading together on same page",
                                                       "type": "boolean"
+                                                    },
+                                                    "revision": {
+                                                      "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                                      "additionalProperties": false,
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "author": {
+                                                          "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                                          "type": "string"
+                                                        },
+                                                        "date": {
+                                                          "format": "date-time",
+                                                          "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                                          "type": "string"
+                                                        },
+                                                        "segments": {
+                                                          "minItems": 1,
+                                                          "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                                          "type": "array",
+                                                          "items": {
+                                                            "description": "A contiguous run of text sharing one revision state",
+                                                            "additionalProperties": false,
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                                "anyOf": [
+                                                                  {
+                                                                    "const": "equal",
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "const": "insert",
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "const": "delete",
+                                                                    "type": "string"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "text": {
+                                                                "description": "Literal text of this segment (rendered without markdown)",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "text"
+                                                            ]
+                                                          }
+                                                        }
+                                                      },
+                                                      "required": ["segments"]
                                                     }
                                                   },
                                                   "required": ["text"]
@@ -28126,6 +29420,60 @@
                                                     "id": {
                                                       "description": "Unique identifier for internal linking (bookmark anchor)",
                                                       "type": "string"
+                                                    },
+                                                    "revision": {
+                                                      "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                                      "additionalProperties": false,
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "author": {
+                                                          "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                                          "type": "string"
+                                                        },
+                                                        "date": {
+                                                          "format": "date-time",
+                                                          "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                                          "type": "string"
+                                                        },
+                                                        "segments": {
+                                                          "minItems": 1,
+                                                          "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                                          "type": "array",
+                                                          "items": {
+                                                            "description": "A contiguous run of text sharing one revision state",
+                                                            "additionalProperties": false,
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                                "anyOf": [
+                                                                  {
+                                                                    "const": "equal",
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "const": "insert",
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "const": "delete",
+                                                                    "type": "string"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "text": {
+                                                                "description": "Literal text of this segment (rendered without markdown)",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "text"
+                                                            ]
+                                                          }
+                                                        }
+                                                      },
+                                                      "required": ["segments"]
                                                     }
                                                   },
                                                   "required": ["text"]
@@ -29398,6 +30746,57 @@
                                           "keepLines": {
                                             "description": "Keep all lines of heading together on same page",
                                             "type": "boolean"
+                                          },
+                                          "revision": {
+                                            "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "author": {
+                                                "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                                "type": "string"
+                                              },
+                                              "date": {
+                                                "format": "date-time",
+                                                "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                                "type": "string"
+                                              },
+                                              "segments": {
+                                                "minItems": 1,
+                                                "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                                "type": "array",
+                                                "items": {
+                                                  "description": "A contiguous run of text sharing one revision state",
+                                                  "additionalProperties": false,
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                      "anyOf": [
+                                                        {
+                                                          "const": "equal",
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "const": "insert",
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "const": "delete",
+                                                          "type": "string"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "text": {
+                                                      "description": "Literal text of this segment (rendered without markdown)",
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["type", "text"]
+                                                }
+                                              }
+                                            },
+                                            "required": ["segments"]
                                           }
                                         },
                                         "required": ["text"]
@@ -29782,6 +31181,57 @@
                                           "id": {
                                             "description": "Unique identifier for internal linking (bookmark anchor)",
                                             "type": "string"
+                                          },
+                                          "revision": {
+                                            "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                            "additionalProperties": false,
+                                            "type": "object",
+                                            "properties": {
+                                              "author": {
+                                                "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                                "type": "string"
+                                              },
+                                              "date": {
+                                                "format": "date-time",
+                                                "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                                "type": "string"
+                                              },
+                                              "segments": {
+                                                "minItems": 1,
+                                                "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                                "type": "array",
+                                                "items": {
+                                                  "description": "A contiguous run of text sharing one revision state",
+                                                  "additionalProperties": false,
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                      "anyOf": [
+                                                        {
+                                                          "const": "equal",
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "const": "insert",
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "const": "delete",
+                                                          "type": "string"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "text": {
+                                                      "description": "Literal text of this segment (rendered without markdown)",
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["type", "text"]
+                                                }
+                                              }
+                                            },
+                                            "required": ["segments"]
                                           }
                                         },
                                         "required": ["text"]
@@ -30510,6 +31960,57 @@
                 "keepLines": {
                   "description": "Keep all lines of heading together on same page",
                   "type": "boolean"
+                },
+                "revision": {
+                  "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "author": {
+                      "description": "Revision author shown in Word (default: \"json-to-office\")",
+                      "type": "string"
+                    },
+                    "date": {
+                      "format": "date-time",
+                      "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                      "type": "string"
+                    },
+                    "segments": {
+                      "minItems": 1,
+                      "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                      "type": "array",
+                      "items": {
+                        "description": "A contiguous run of text sharing one revision state",
+                        "additionalProperties": false,
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                            "anyOf": [
+                              {
+                                "const": "equal",
+                                "type": "string"
+                              },
+                              {
+                                "const": "insert",
+                                "type": "string"
+                              },
+                              {
+                                "const": "delete",
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "text": {
+                            "description": "Literal text of this segment (rendered without markdown)",
+                            "type": "string"
+                          }
+                        },
+                        "required": ["type", "text"]
+                      }
+                    }
+                  },
+                  "required": ["segments"]
                 }
               },
               "required": ["text"]
@@ -30894,6 +32395,57 @@
                 "id": {
                   "description": "Unique identifier for internal linking (bookmark anchor)",
                   "type": "string"
+                },
+                "revision": {
+                  "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "author": {
+                      "description": "Revision author shown in Word (default: \"json-to-office\")",
+                      "type": "string"
+                    },
+                    "date": {
+                      "format": "date-time",
+                      "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                      "type": "string"
+                    },
+                    "segments": {
+                      "minItems": 1,
+                      "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                      "type": "array",
+                      "items": {
+                        "description": "A contiguous run of text sharing one revision state",
+                        "additionalProperties": false,
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                            "anyOf": [
+                              {
+                                "const": "equal",
+                                "type": "string"
+                              },
+                              {
+                                "const": "insert",
+                                "type": "string"
+                              },
+                              {
+                                "const": "delete",
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "text": {
+                            "description": "Literal text of this segment (rendered without markdown)",
+                            "type": "string"
+                          }
+                        },
+                        "required": ["type", "text"]
+                      }
+                    }
+                  },
+                  "required": ["segments"]
                 }
               },
               "required": ["text"]
@@ -32629,6 +34181,57 @@
                             "maximum": 8,
                             "description": "Nesting level for this item",
                             "type": "number"
+                          },
+                          "revision": {
+                            "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "author": {
+                                "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                "type": "string"
+                              },
+                              "date": {
+                                "format": "date-time",
+                                "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                "type": "string"
+                              },
+                              "segments": {
+                                "minItems": 1,
+                                "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                "type": "array",
+                                "items": {
+                                  "description": "A contiguous run of text sharing one revision state",
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                      "anyOf": [
+                                        {
+                                          "const": "equal",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "insert",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "delete",
+                                          "type": "string"
+                                        }
+                                      ]
+                                    },
+                                    "text": {
+                                      "description": "Literal text of this segment (rendered without markdown)",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["type", "text"]
+                                }
+                              }
+                            },
+                            "required": ["segments"]
                           }
                         },
                         "required": ["text"]
@@ -36080,6 +37683,57 @@
                             "maximum": 8,
                             "description": "Nesting level for this item",
                             "type": "number"
+                          },
+                          "revision": {
+                            "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                            "additionalProperties": false,
+                            "type": "object",
+                            "properties": {
+                              "author": {
+                                "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                "type": "string"
+                              },
+                              "date": {
+                                "format": "date-time",
+                                "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                "type": "string"
+                              },
+                              "segments": {
+                                "minItems": 1,
+                                "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                "type": "array",
+                                "items": {
+                                  "description": "A contiguous run of text sharing one revision state",
+                                  "additionalProperties": false,
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                      "anyOf": [
+                                        {
+                                          "const": "equal",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "insert",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "const": "delete",
+                                          "type": "string"
+                                        }
+                                      ]
+                                    },
+                                    "text": {
+                                      "description": "Literal text of this segment (rendered without markdown)",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["type", "text"]
+                                }
+                              }
+                            },
+                            "required": ["segments"]
                           }
                         },
                         "required": ["text"]
@@ -36739,6 +38393,10 @@
             }
           }
         },
+        "trackRevisions": {
+          "description": "Open the document in track-changes mode: Word marks any further edits as revisions. Set automatically on redline documents produced by the diff engine",
+          "type": "boolean"
+        },
         "metadata": {
           "description": "Document metadata (title, author, company, dates, etc.)",
           "additionalProperties": false,
@@ -37220,6 +38878,57 @@
                         "keepLines": {
                           "description": "Keep all lines of heading together on same page",
                           "type": "boolean"
+                        },
+                        "revision": {
+                          "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                          "additionalProperties": false,
+                          "type": "object",
+                          "properties": {
+                            "author": {
+                              "description": "Revision author shown in Word (default: \"json-to-office\")",
+                              "type": "string"
+                            },
+                            "date": {
+                              "format": "date-time",
+                              "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                              "type": "string"
+                            },
+                            "segments": {
+                              "minItems": 1,
+                              "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                              "type": "array",
+                              "items": {
+                                "description": "A contiguous run of text sharing one revision state",
+                                "additionalProperties": false,
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                    "anyOf": [
+                                      {
+                                        "const": "equal",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "const": "insert",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "const": "delete",
+                                        "type": "string"
+                                      }
+                                    ]
+                                  },
+                                  "text": {
+                                    "description": "Literal text of this segment (rendered without markdown)",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["type", "text"]
+                              }
+                            }
+                          },
+                          "required": ["segments"]
                         }
                       },
                       "required": ["text"]
@@ -37604,6 +39313,57 @@
                         "id": {
                           "description": "Unique identifier for internal linking (bookmark anchor)",
                           "type": "string"
+                        },
+                        "revision": {
+                          "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                          "additionalProperties": false,
+                          "type": "object",
+                          "properties": {
+                            "author": {
+                              "description": "Revision author shown in Word (default: \"json-to-office\")",
+                              "type": "string"
+                            },
+                            "date": {
+                              "format": "date-time",
+                              "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                              "type": "string"
+                            },
+                            "segments": {
+                              "minItems": 1,
+                              "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                              "type": "array",
+                              "items": {
+                                "description": "A contiguous run of text sharing one revision state",
+                                "additionalProperties": false,
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                    "anyOf": [
+                                      {
+                                        "const": "equal",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "const": "insert",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "const": "delete",
+                                        "type": "string"
+                                      }
+                                    ]
+                                  },
+                                  "text": {
+                                    "description": "Literal text of this segment (rendered without markdown)",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["type", "text"]
+                              }
+                            }
+                          },
+                          "required": ["segments"]
                         }
                       },
                       "required": ["text"]
@@ -39339,6 +41099,57 @@
                                     "maximum": 8,
                                     "description": "Nesting level for this item",
                                     "type": "number"
+                                  },
+                                  "revision": {
+                                    "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "author": {
+                                        "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                        "type": "string"
+                                      },
+                                      "date": {
+                                        "format": "date-time",
+                                        "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                        "type": "string"
+                                      },
+                                      "segments": {
+                                        "minItems": 1,
+                                        "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A contiguous run of text sharing one revision state",
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                              "anyOf": [
+                                                {
+                                                  "const": "equal",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "const": "insert",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "const": "delete",
+                                                  "type": "string"
+                                                }
+                                              ]
+                                            },
+                                            "text": {
+                                              "description": "Literal text of this segment (rendered without markdown)",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": ["type", "text"]
+                                        }
+                                      }
+                                    },
+                                    "required": ["segments"]
                                   }
                                 },
                                 "required": ["text"]
@@ -40601,6 +42412,57 @@
                                   "keepLines": {
                                     "description": "Keep all lines of heading together on same page",
                                     "type": "boolean"
+                                  },
+                                  "revision": {
+                                    "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "author": {
+                                        "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                        "type": "string"
+                                      },
+                                      "date": {
+                                        "format": "date-time",
+                                        "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                        "type": "string"
+                                      },
+                                      "segments": {
+                                        "minItems": 1,
+                                        "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A contiguous run of text sharing one revision state",
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                              "anyOf": [
+                                                {
+                                                  "const": "equal",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "const": "insert",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "const": "delete",
+                                                  "type": "string"
+                                                }
+                                              ]
+                                            },
+                                            "text": {
+                                              "description": "Literal text of this segment (rendered without markdown)",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": ["type", "text"]
+                                        }
+                                      }
+                                    },
+                                    "required": ["segments"]
                                   }
                                 },
                                 "required": ["text"]
@@ -40985,6 +42847,57 @@
                                   "id": {
                                     "description": "Unique identifier for internal linking (bookmark anchor)",
                                     "type": "string"
+                                  },
+                                  "revision": {
+                                    "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "author": {
+                                        "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                        "type": "string"
+                                      },
+                                      "date": {
+                                        "format": "date-time",
+                                        "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                        "type": "string"
+                                      },
+                                      "segments": {
+                                        "minItems": 1,
+                                        "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A contiguous run of text sharing one revision state",
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                              "anyOf": [
+                                                {
+                                                  "const": "equal",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "const": "insert",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "const": "delete",
+                                                  "type": "string"
+                                                }
+                                              ]
+                                            },
+                                            "text": {
+                                              "description": "Literal text of this segment (rendered without markdown)",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": ["type", "text"]
+                                        }
+                                      }
+                                    },
+                                    "required": ["segments"]
                                   }
                                 },
                                 "required": ["text"]
@@ -42720,6 +44633,57 @@
                                               "maximum": 8,
                                               "description": "Nesting level for this item",
                                               "type": "number"
+                                            },
+                                            "revision": {
+                                              "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                              "additionalProperties": false,
+                                              "type": "object",
+                                              "properties": {
+                                                "author": {
+                                                  "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                                  "type": "string"
+                                                },
+                                                "date": {
+                                                  "format": "date-time",
+                                                  "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                                  "type": "string"
+                                                },
+                                                "segments": {
+                                                  "minItems": 1,
+                                                  "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "A contiguous run of text sharing one revision state",
+                                                    "additionalProperties": false,
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                        "anyOf": [
+                                                          {
+                                                            "const": "equal",
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "const": "insert",
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "const": "delete",
+                                                            "type": "string"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "text": {
+                                                        "description": "Literal text of this segment (rendered without markdown)",
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": ["type", "text"]
+                                                  }
+                                                }
+                                              },
+                                              "required": ["segments"]
                                             }
                                           },
                                           "required": ["text"]
@@ -44435,6 +46399,57 @@
                                             "keepLines": {
                                               "description": "Keep all lines of heading together on same page",
                                               "type": "boolean"
+                                            },
+                                            "revision": {
+                                              "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                              "additionalProperties": false,
+                                              "type": "object",
+                                              "properties": {
+                                                "author": {
+                                                  "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                                  "type": "string"
+                                                },
+                                                "date": {
+                                                  "format": "date-time",
+                                                  "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                                  "type": "string"
+                                                },
+                                                "segments": {
+                                                  "minItems": 1,
+                                                  "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "A contiguous run of text sharing one revision state",
+                                                    "additionalProperties": false,
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                        "anyOf": [
+                                                          {
+                                                            "const": "equal",
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "const": "insert",
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "const": "delete",
+                                                            "type": "string"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "text": {
+                                                        "description": "Literal text of this segment (rendered without markdown)",
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": ["type", "text"]
+                                                  }
+                                                }
+                                              },
+                                              "required": ["segments"]
                                             }
                                           },
                                           "required": ["text"]
@@ -44819,6 +46834,57 @@
                                             "id": {
                                               "description": "Unique identifier for internal linking (bookmark anchor)",
                                               "type": "string"
+                                            },
+                                            "revision": {
+                                              "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                              "additionalProperties": false,
+                                              "type": "object",
+                                              "properties": {
+                                                "author": {
+                                                  "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                                  "type": "string"
+                                                },
+                                                "date": {
+                                                  "format": "date-time",
+                                                  "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                                  "type": "string"
+                                                },
+                                                "segments": {
+                                                  "minItems": 1,
+                                                  "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "A contiguous run of text sharing one revision state",
+                                                    "additionalProperties": false,
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                                        "anyOf": [
+                                                          {
+                                                            "const": "equal",
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "const": "insert",
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "const": "delete",
+                                                            "type": "string"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "text": {
+                                                        "description": "Literal text of this segment (rendered without markdown)",
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": ["type", "text"]
+                                                  }
+                                                }
+                                              },
+                                              "required": ["segments"]
                                             }
                                           },
                                           "required": ["text"]
@@ -46091,6 +48157,57 @@
                                   "keepLines": {
                                     "description": "Keep all lines of heading together on same page",
                                     "type": "boolean"
+                                  },
+                                  "revision": {
+                                    "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "author": {
+                                        "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                        "type": "string"
+                                      },
+                                      "date": {
+                                        "format": "date-time",
+                                        "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                        "type": "string"
+                                      },
+                                      "segments": {
+                                        "minItems": 1,
+                                        "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A contiguous run of text sharing one revision state",
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                              "anyOf": [
+                                                {
+                                                  "const": "equal",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "const": "insert",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "const": "delete",
+                                                  "type": "string"
+                                                }
+                                              ]
+                                            },
+                                            "text": {
+                                              "description": "Literal text of this segment (rendered without markdown)",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": ["type", "text"]
+                                        }
+                                      }
+                                    },
+                                    "required": ["segments"]
                                   }
                                 },
                                 "required": ["text"]
@@ -46475,6 +48592,57 @@
                                   "id": {
                                     "description": "Unique identifier for internal linking (bookmark anchor)",
                                     "type": "string"
+                                  },
+                                  "revision": {
+                                    "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                                    "additionalProperties": false,
+                                    "type": "object",
+                                    "properties": {
+                                      "author": {
+                                        "description": "Revision author shown in Word (default: \"json-to-office\")",
+                                        "type": "string"
+                                      },
+                                      "date": {
+                                        "format": "date-time",
+                                        "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                                        "type": "string"
+                                      },
+                                      "segments": {
+                                        "minItems": 1,
+                                        "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A contiguous run of text sharing one revision state",
+                                          "additionalProperties": false,
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                              "anyOf": [
+                                                {
+                                                  "const": "equal",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "const": "insert",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "const": "delete",
+                                                  "type": "string"
+                                                }
+                                              ]
+                                            },
+                                            "text": {
+                                              "description": "Literal text of this segment (rendered without markdown)",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": ["type", "text"]
+                                        }
+                                      }
+                                    },
+                                    "required": ["segments"]
                                   }
                                 },
                                 "required": ["text"]


### PR DESCRIPTION
## What

Diff two **docx JSON definitions** into a redline rendered as **native Word tracked changes** — accept/reject in Word, with author + timestamp, opening in review mode. The killer proof of *documents as data*: you can't diff a `python-pptx` script or a `docx.js` call tree, but two JSON trees diff trivially, and the output lands in the reviewer's native tool.

```bash
jto docx diff contract-v1.json contract-v2.json -o redline.docx
```

Three surfaces, one engine:
- **CLI** — `jto docx diff` (`--author`, `--date`, `--json-out`, `--format json`, `--dry-run`)
- **HTTP** — `POST /api/docx/diff` (docx-only; returns redline JSON + summary)
- **Playground** — **Compare** button in the sidebar → pick base/revised → open the redline as a normal document with live preview

## How

| Layer | Change |
|---|---|
| `shared-docx` | `revision` schema on paragraph/heading/list-item + `trackRevisions` root prop; word-level LCS diff engine, block tree alignment with same-name pairing, fidelity `summary` (`tracked`/`untracked`/`notes`) |
| `core-docx` | `InsertedTextRun`/`DeletedTextRun` rendering, `w:trackRevisions` in settings.xml, placeholder + newline + bookmark fidelity, component-cache bypass for revisions |
| `jto-cli` | `jto docx diff` command |
| `jto` (playground) | `POST /api/docx/diff` route + `CompareDocumentsDialog` producing a redline document |

The redline is a **plain jto document** — so preview, download, validation, and the Monaco editor all apply to it unchanged. No dedicated pipeline.

## Design choices & scope (v1)

- **Closed-world**: both inputs must be jto JSON. Marketed as the agent-edit / version review step, not "redline any third-party .docx" (no importer yet).
- **Word-level** tracked changes on paragraphs, headings, list items. Structural changes (tables, images, charts) → block replace, reported in `summary.untracked`.
- Fully-deleted blocks leave an empty paragraph on accept-all (OOXML paragraph-mark deletion unsupported by `docx.js`) — surfaced in `summary.notes`.
- No PPTX visual diff.

## Verification

- Adversarial multi-agent review of the engine/renderer surfaced 15 real issues — all fixed with regression tests (placeholder/newline/bookmark fidelity, cache id leak in nested containers, NFC normalization, markdown-only & `enabled` change reporting, `--date` validation, `revision` blocked from `componentDefaults`, LCS prefix/suffix trim for large docs).
- New tests: diff engine (word + document), renderer (w:ins/w:del XML), CLI, and HTTP route.
- `pnpm lint` / `typecheck` / `test` green; full monorepo `build` + `test` green.
- End-to-end verified in-browser: Compare → summary → open redline → LibreOffice preview shows the tracked changes.

## Notes

- `skills/.../document.schema.json` regenerated to expose `revision`/`trackRevisions` (Monaco autocomplete). `presentation`/`theme` schemas deliberately left untouched (their only drift was unrelated whitespace).
- Changeset included: minor bump.

Examples: `examples/contract-v1.docx.json` + `examples/contract-v2.docx.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document diffing that produces Word tracked-changes redlines (including accept/reject, author, timestamp)
  * CLI: `jto docx diff <old> <new> -o redline.docx`
  * Playground Compare dialog and server API `POST /api/docx/diff` with live redline preview

* **Documentation**
  * README and examples updated with diff usage and sample contract JSONs

* **Tests**
  * Extensive tests added for word-level diffing, revision rendering, and end-to-end diff behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
