### PR TITLE
fix(docx): use Menlo for built-in theme mono font (SF Mono is not safe)

### DIFF
--- a/.changeset/theme-mono-font.md
+++ b/.changeset/theme-mono-font.md
@@ -1,0 +1,8 @@
+---
+'@json-to-office/core-docx': patch
+---
+
+fix(docx): built-in minimal/modern themes used "SF Mono" for the mono font,
+which is not a SAFE_FONTS entry — every render logged FONT_UNRESOLVED and fell
+back to a host font. Switched to Menlo (safe, closest match) so built-in
+themes render warning-free out of the box.

--- a/packages/core-docx/src/templates/themes/minimal.docx.theme.json
+++ b/packages/core-docx/src/templates/themes/minimal.docx.theme.json
@@ -29,7 +29,7 @@
       "size": 11
     },
     "mono": {
-      "family": "SF Mono",
+      "family": "Menlo",
       "size": 10
     },
     "light": {

--- a/packages/core-docx/src/templates/themes/modern.docx.theme.json
+++ b/packages/core-docx/src/templates/themes/modern.docx.theme.json
@@ -21,7 +21,7 @@
   "fonts": {
     "heading": { "family": "Helvetica", "size": 28 },
     "body": { "family": "Helvetica", "size": 11 },
-    "mono": { "family": "SF Mono", "size": 10 },
+    "mono": { "family": "Menlo", "size": 10 },
     "light": { "family": "Helvetica", "size": 28 }
   },
   "page": {


### PR DESCRIPTION
## What

The built-in `minimal` and `modern` themes referenced **SF Mono** for the mono font. SF Mono is not a SAFE_FONTS entry and is not registered via `fonts.extraEntries`, so **every render with these themes** logged:

```
FONT_UNRESOLVED: Font "SF Mono" is not a SAFE_FONTS entry and is not registered via fonts.extraEntries. It will render with a host fallback...
```

Switched to **Menlo** — a SAFE_FONTS entry and the closest macOS match — so built-in themes render warning-free out of the box. All other built-in theme fonts (Arial, Calibri, Helvetica, Georgia, Consolas) checked: already safe.

## Verification

- `jto docx generate` with both `minimal` and `modern` themes: zero FONT_UNRESOLVED warnings, documents generated.
- core-docx tests: 392/392 pass (no test or snapshot pinned the font name).
- Changeset: patch bump for `@json-to-office/core-docx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed font resolution warnings in the minimal and modern built-in themes by updating the mono font selection to ensure proper rendering across systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->