### PR TITLE
fix(docx): dense table-cell paragraph spacing

### DIFF
--- a/.changeset/dense-table-rows.md
+++ b/.changeset/dense-table-rows.md
@@ -1,0 +1,40 @@
+---
+'@json-to-office/core-docx': minor
+'@json-to-office/json-to-docx': minor
+'@json-to-office/jto-cli': minor
+'@json-to-office/jto': minor
+---
+
+fix(docx): table rows no longer inherit body-paragraph spacing
+
+Table cells render as a single wrapper paragraph that previously inherited the
+theme's `normal` style, dragging body-prose rhythm (8–10pt after-spacing +
+1.4–1.5× line) into every row. That inflated row height by ~9pt regardless of
+font size, cell padding, or the cell `height` prop (which is `atLeast`, so it
+can only grow rows). A 5pt-font row still rendered ~22pt tall.
+
+Table cells (and header cells) now get their own dense paragraph spacing by
+default — no extra before/after spacing, single line. Vertical breathing room
+is the job of cell padding. Measured row pitch for a single-line 11pt row drops
+from ~28.9pt to ~13.7pt.
+
+Themes can tune table spacing via two new conventional style keys (standard
+`StyleProperties`, no schema change):
+
+- `styles.tableCell` — paragraph spacing/line for body cells
+- `styles.tableHeader` — paragraph spacing/line for header cells
+
+```json
+{
+  "styles": {
+    "tableCell": {
+      "spacing": { "after": 6 },
+      "lineSpacing": { "type": "multiple", "value": 1.5 }
+    }
+  }
+}
+```
+
+Note: this changes the rendered height of existing tables (rows become tighter).
+Documents relying on the old roomier rows can restore them per-theme via
+`styles.tableCell` / `styles.tableHeader`.

--- a/packages/core-docx/src/core/content.ts
+++ b/packages/core-docx/src/core/content.ts
@@ -1767,6 +1767,7 @@ export async function createTable(
           children: [
             new Paragraph({
               ...(tableConfig.keepInOnePage && { keepNext: true }),
+              spacing: tableStyle.headerParagraph,
               alignment: getAlignment(horizontalAlignment),
               children: cellChildren,
             }),
@@ -1878,6 +1879,7 @@ export async function createTable(
                     (isLastRow && tableConfig.keepNext)
                       ? { keepNext: true }
                       : {}),
+                    spacing: tableStyle.cellParagraph,
                     alignment: AlignmentType.LEFT,
                     children: [],
                   }),
@@ -1961,6 +1963,7 @@ export async function createTable(
                   (isLastRow && tableConfig.keepNext)
                     ? { keepNext: true }
                     : {}),
+                  spacing: tableStyle.cellParagraph,
                   alignment: getAlignment(horizontalAlignment),
                   children: cellChildren,
                 }),

--- a/packages/core-docx/src/styles/__tests__/table-cell-spacing.test.ts
+++ b/packages/core-docx/src/styles/__tests__/table-cell-spacing.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { getTableStyle } from '../utils/layoutUtils';
+import type { ThemeConfig } from '../index';
+
+/**
+ * Fix A: table cells render their own dense paragraph spacing instead of
+ * inheriting the `normal` body-prose rhythm. The wrapper paragraph spacing is
+ * resolved by getTableStyle into `cellParagraph` / `headerParagraph`.
+ */
+const baseTheme = (extraStyles: Record<string, unknown> = {}): ThemeConfig =>
+  ({
+    name: 'test',
+    displayName: 'Test',
+    description: '',
+    version: '1.0.0',
+    colors: { primary: '#000000', backgroundPrimary: '#FFFFFF' },
+    fonts: { body: { family: 'Arial', size: 11 } },
+    page: {},
+    styles: {
+      normal: { font: 'body', size: 11, color: '#000000' },
+      ...extraStyles,
+    },
+  }) as unknown as ThemeConfig;
+
+describe('getTableStyle — table-cell paragraph spacing', () => {
+  it('defaults table cells to dense spacing (no after-spacing, single line)', () => {
+    const style = getTableStyle(baseTheme());
+    expect(style.cellParagraph).toEqual({
+      before: 0,
+      after: 0,
+      line: 240, // single
+      lineRule: 'auto',
+    });
+    // Headers are dense by default too
+    expect(style.headerParagraph).toEqual({
+      before: 0,
+      after: 0,
+      line: 240,
+      lineRule: 'auto',
+    });
+  });
+
+  it('does not inherit the theme normal style after-spacing/line', () => {
+    // normal carries body-prose rhythm; table cells must ignore it
+    const style = getTableStyle(
+      baseTheme({
+        normal: {
+          font: 'body',
+          size: 11,
+          spacing: { after: 9 },
+          lineSpacing: { type: 'multiple', value: 1.5 },
+        },
+      })
+    );
+    expect(style.cellParagraph.after).toBe(0);
+    expect(style.cellParagraph.line).toBe(240);
+  });
+
+  it('honors styles.tableCell override (points → twips, lineSpacing → line/rule)', () => {
+    const style = getTableStyle(
+      baseTheme({
+        tableCell: {
+          spacing: { after: 10 },
+          lineSpacing: { type: 'multiple', value: 1.5 },
+        },
+      })
+    );
+    expect(style.cellParagraph).toEqual({
+      before: 0,
+      after: 200, // 10pt → 200 twips
+      line: 360, // 1.5 × 240
+      lineRule: 'auto',
+    });
+  });
+
+  it('honors styles.tableHeader override independently of cells', () => {
+    const style = getTableStyle(
+      baseTheme({
+        tableHeader: { spacing: { before: 2, after: 2 } },
+      })
+    );
+    expect(style.headerParagraph).toEqual({
+      before: 40, // 2pt → 40 twips
+      after: 40,
+      line: 240,
+      lineRule: 'auto',
+    });
+    // cells remain dense
+    expect(style.cellParagraph.after).toBe(0);
+  });
+});

--- a/packages/core-docx/src/styles/utils/layoutUtils.ts
+++ b/packages/core-docx/src/styles/utils/layoutUtils.ts
@@ -1,7 +1,51 @@
 import { BorderStyle } from 'docx';
+import { LineSpacing } from '@json-to-office/shared-docx';
 import { ThemeConfig } from '../index';
 import { resolveColor } from './colorUtils';
-import { resolveTheme, resolveFontFamily } from './styleHelpers';
+import {
+  resolveTheme,
+  resolveFontFamily,
+  convertLineSpacing,
+  pointsToTwips,
+} from './styleHelpers';
+
+/**
+ * Subset of a theme StyleProperties entry relevant to paragraph spacing.
+ */
+interface TableParagraphStyle {
+  spacing?: { before?: number; after?: number };
+  lineSpacing?: LineSpacing;
+}
+
+/**
+ * Resolve the paragraph spacing for a table cell/header wrapper paragraph.
+ *
+ * Table cells render as a single wrapper paragraph. Historically that paragraph
+ * inherited the `normal` style, dragging body-prose rhythm (8–10pt after-spacing
+ * + 1.4–1.5x line) into every row and inflating row height regardless of font
+ * size, padding, or the cell `height` prop. Tables should be dense by default:
+ * no extra paragraph spacing, single line. Vertical breathing room is the job of
+ * cell padding, not paragraph spacing.
+ *
+ * Themes may override per context via `styles.tableCell` / `styles.tableHeader`
+ * (standard StyleProperties: `spacing.before/after` in points, `lineSpacing`).
+ */
+const resolveTableParagraphSpacing = (style?: TableParagraphStyle) => {
+  const lineSpacing =
+    convertLineSpacing(style?.lineSpacing) ??
+    convertLineSpacing({ type: 'single' });
+  return {
+    before:
+      style?.spacing?.before !== undefined
+        ? pointsToTwips(style.spacing.before)
+        : 0,
+    after:
+      style?.spacing?.after !== undefined
+        ? pointsToTwips(style.spacing.after)
+        : 0,
+    ...lineSpacing,
+  };
+};
 
 /**
  * Standard page sizes in twips (1/20 of a point, 1/1440 of an inch)
@@ -35,9 +79,14 @@ export const getTableStyle = (theme?: ThemeConfig, themeName?: string) => {
   const themeConfig = resolveTheme(theme, themeName);
 
   if (themeConfig && themeConfig.styles?.normal) {
-    // Use normal style for both header and cell since tableHeader/tableCell styles are removed
+    // Use normal style for run-level header/cell defaults (font, size, color).
+    // Paragraph spacing is resolved separately so table rows stay dense and do
+    // not inherit `normal`'s body-prose after-spacing/line height.
     const normalStyle = themeConfig.styles.normal;
+    const styles = themeConfig.styles as Record<string, TableParagraphStyle>;
     return {
+      cellParagraph: resolveTableParagraphSpacing(styles.tableCell),
+      headerParagraph: resolveTableParagraphSpacing(styles.tableHeader),
       tableHeader: {
         fill: resolveColor(
           themeConfig.colors?.primary || '#000000',
@@ -101,6 +150,8 @@ export const getTableStyle = (theme?: ThemeConfig, themeName?: string) => {
 
   // This shouldn't happen with minimal themes
   return {
+    cellParagraph: resolveTableParagraphSpacing(),
+    headerParagraph: resolveTableParagraphSpacing(),
     tableHeader: {
       fill: '000000',
       color: 'FFFFFF',


### PR DESCRIPTION
## Problem

Table cells render as a single wrapper paragraph that **inherited the theme `normal` style**, dragging body-prose rhythm (8–10pt after-spacing + 1.4–1.5× line) into every row. Result: row height stayed ~22pt even at 5pt font / zero padding, and the cell `height` prop is `hRule="atLeast"` (grow-only) so it can't shrink rows. The renderer emits **no `<w:trHeight>`** — the floor was purely inherited paragraph spacing, with no per-cell/table/JSON path to override it.

## Fix

Table cells (and header cells) now get their **own dense paragraph spacing** by default — no before/after spacing, single line. Cell padding owns vertical breathing room. `getTableStyle` resolves `cellParagraph`/`headerParagraph`, applied at the three wrapper-paragraph sites (header, body, missing-cell).

### Verified (LibreOffice, single-line rows)

| | before | after |
|---|--:|--:|
| 11pt row pitch | 28.9pt | **13.7pt** |
| 5pt row pitch | 22.1pt | **6.8pt** |

OOXML now emits `<w:spacing w:after="0" w:before="0" w:line="240" w:lineRule="auto"/>` on cell paragraphs. The ~13.7pt at 11pt matches the original ~14pt target.

## Themeable (no schema change)

`StyleDefinitionsSchema` already accepts arbitrary style keys, so two conventions are honored:

- `styles.tableCell` — paragraph spacing/line for body cells
- `styles.tableHeader` — paragraph spacing/line for header cells

```json
{ "styles": { "tableCell": { "spacing": { "after": 6 }, "lineSpacing": { "type": "multiple", "value": 1.5 } } } }
```

## ⚠️ Behavior change

Existing tables render **tighter**. Documents relying on the old roomier rows can restore them per-theme via `styles.tableCell` / `styles.tableHeader`. Captured in the changeset (minor).

## Tests

- New `table-cell-spacing.test.ts` (dense default + theme override for cells & headers).
- Full core-docx suite: **406 passing**.

## Out of scope (noted)

While testing I hit a **pre-existing** quirk: the runtime filesystem scan for *custom* theme files resolves `../../../dist/templates/themes` from the bundled `dist/index.js`, which may not exist in a packaged build. Orthogonal to this fix; unconfirmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Table cells no longer inherit unwanted body-paragraph spacing, fixing rendering issues where rows appeared taller than expected.

* **New Features**
  * Introduced theme style keys to customize paragraph spacing and line height for table cells and headers.

**Note:** Existing table rendering heights will change; use new style keys to restore previous spacing if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->