### PR TITLE
feat(skill): document visual component + auto-wire render-server

### DIFF
--- a/skills/json-to-office/SKILL.md
+++ b/skills/json-to-office/SKILL.md
@@ -33,6 +33,8 @@ It writes `<skill>/.skill-out/caps.json` with the runtime's capabilities. Two pa
 - **Full loop**: `can_screenshot: true` — you have Node, LibreOffice, pdftoppm. Validate → render → Read PNGs → iterate.
 - **Validate-only**: `can_screenshot: false` — render the office file but skip the visual loop. Warn the user that pixel-perfection isn't verifiable.
 
+> **Rendering services (charts & visuals).** `highcharts` charts and docx `visual` graphics render out-of-process. `render_preview.py` auto-wires them to the hosted instance `https://jto-render-server.onrender.com` — always for charts (no local fallback exists), and for visuals only when local LibreOffice + `pdftoppm` aren't found (otherwise visuals rasterize locally, which is faster and keeps content on-machine). The first call after the instance is idle can be slow (cold start), and the relevant content is sent to that service when used. Point at your own server, or opt out, via the `HIGHCHARTS_SERVER_URL` / `JTO_PPTX_RASTERIZER_URL` env vars (a value you set always wins).
+
 ### 2. Pick a template, don't author from scratch
 
 The first move is **always** to pick a starting template. Read template manifests:
@@ -115,7 +117,7 @@ Slot user-provided content into the template. Hard rules:
 - **Use the grid for PPTX.** Slides declare `props.grid: { columns: 12, rows: 6 }`. Components position via `grid: { column, row, columnSpan, rowSpan }`. Don't pixel-place.
 - **One idea per slide.** If a slide has >40 words of body text, split it.
 - **Tabular figures on numerics.** Tables, stats, chart axes — never let numbers slide into italic serif.
-- **Don't invent component names.** If the schema doesn't list it, it doesn't exist. Use what's there (`heading`, `paragraph`, `columns`, `table`, `list`, `statistic`, `text-box`, `toc`, `image`, `highcharts` for DOCX; `text`, `chart`, `table`, `shape`, `image`, `highcharts` for PPTX).
+- **Don't invent component names.** If the schema doesn't list it, it doesn't exist. Use what's there (`heading`, `paragraph`, `columns`, `table`, `list`, `statistic`, `text-box`, `toc`, `image`, `visual`, `highcharts` for DOCX; `text`, `chart`, `table`, `shape`, `image`, `highcharts` for PPTX).
 
 ### 6. Validate
 
@@ -178,7 +180,7 @@ Tell the user:
 
 DOCX root: `{ "name": "docx", "props": { "theme": "minimal", ... }, "children": [...] }`
 
-DOCX components (`name` values): `section`, `heading`, `paragraph`, `columns`, `list`, `table`, `statistic`, `text-box`, `toc`, `image`, `highcharts`.
+DOCX components (`name` values): `section`, `heading`, `paragraph`, `columns`, `list`, `table`, `statistic`, `text-box`, `toc`, `image`, `visual`, `highcharts`. `visual` embeds a free-canvas pptx graphic (infographic / diagram / hero art) as a rasterized PNG — see the cheat-sheet.
 
 PPTX root: `{ "name": "pptx", "props": { "theme": "default", "grid": { "columns": 12, "rows": 6 }, ... }, "children": [...] }`
 

--- a/skills/json-to-office/assets/references/docx-cheatsheet.md
+++ b/skills/json-to-office/assets/references/docx-cheatsheet.md
@@ -73,7 +73,7 @@ Only `section` is allowed as a direct child of `docx`. All visible content lives
     ]
   },
   "children": [
-    /* heading | paragraph | image | table | list | columns | statistic | toc | highcharts | text-box */
+    /* heading | paragraph | image | visual | table | list | columns | statistic | toc | highcharts | text-box */
   ]
 }
 ```
@@ -163,6 +163,62 @@ Only `section` is allowed as a direct child of `docx`. All visible content lives
 - `widthRelativeTo`: `"page"` for full-bleed; `"margin"` (default) otherwise.
 - `floating`: floats over/behind content. Essential for cover backgrounds.
 - `path` accepts public URLs or absolute local paths.
+
+### `visual` (free-canvas pptx graphic → embedded PNG)
+
+For infographics, diagrams, hero compositions, layered/overlapping art — anything the docx flow layout can't express. You author a single **pptx canvas** plus its `elements`; the renderer rasterizes the canvas to a PNG and embeds it like an `image` (the component desugars to `image`). Requires a rasterization service — `render_preview.py` wires one automatically (see SKILL.md → "Rendering services").
+
+```json
+{
+  "name": "visual",
+  "props": {
+    "canvas": {
+      "width": 6.5,
+      "height": 3.2,
+      "background": { "color": "background" }
+    },
+    "elements": [
+      {
+        "name": "shape",
+        "props": {
+          "type": "rect",
+          "x": 0,
+          "y": 0,
+          "w": 6.5,
+          "h": 3.2,
+          "fill": { "color": "primary" }
+        }
+      },
+      {
+        "name": "text",
+        "props": {
+          "text": "73%",
+          "x": 0.4,
+          "y": 0.8,
+          "w": 3,
+          "h": 1.4,
+          "fontSize": 54,
+          "color": "background",
+          "bold": true
+        }
+      }
+    ],
+    "dpi": 200,
+    "width": "100%",
+    "alignment": "center",
+    "caption": "Figure 1",
+    "spacing": { "after": 14 }
+  }
+}
+```
+
+- **`canvas.width`/`height` are INCHES** — they set the aspect ratio and the default physical size of the embedded image. (Unlike the rest of DOCX, which uses twips/points.)
+- **`elements` are PPTX slide-content** (`text`, `shape`, `image`, `table`, `chart`, `highcharts`) — author them exactly as in a `.pptx.json` slide; see `pptx-cheatsheet.md`.
+- **Position elements absolutely with `x`/`y`/`w`/`h` in inches** (or `%`). The canvas declares **no grid** — don't use `grid` placement inside a `visual`.
+- **Colors inside `elements` follow PPTX rules** (bare hex, no `#`); shape text uses `fontColor`, text uses `color`. Prefer theme names (`"primary"`, `"text"`) — they sidestep the #/no-# trap and stay themeable.
+- **Placement props mirror `image`:** `width` (default = canvas physical size; override with `"80%"` or a pixel number), `height`, `alignment`, `caption`, `spacing`, `floating`, `alt`, `keepNext`, `keepLines`.
+- **`dpi`:** raster resolution, default 200, range 36–600. Higher = sharper but larger.
+- **When to use:** prefer `visual` over `image` when the graphic is data-driven/themeable (it swaps with the theme), and over `text-box` when shapes overlap or layer. For a plain external picture, use `image`.
 
 ### `table` (column-oriented)
 

--- a/skills/json-to-office/assets/taste/gotchas.md
+++ b/skills/json-to-office/assets/taste/gotchas.md
@@ -19,6 +19,9 @@ Distilled from real-world failures. Scan this list before validating, and again 
 - **Cell color vs fill.** `color` on a cell is the **text** color. `backgroundColor` is the fill. To make a dark header bar with white text, set `backgroundColor` + `font.color` on **each column's `header` object** directly — not on `headerCellDefaults`, which is silently overridden by column-level `cellDefaults`.
 - **Cover-page paragraph defaults.** The theme's `normal` style silently inflates paragraph heights via `spacing` and `lineSpacing`. On cover pages override both: `lineSpacing: "single"`, `spacing: { before: 0, after: 0 }`.
 - **Hex prefix.** DOCX uses `#`. PPTX doesn't. This is **opposite** between formats.
+- **`visual` needs a rasterization service.** A docx `visual` renders by rasterizing a pptx canvas to a PNG. `render_preview.py` auto-wires the service; if neither a local LibreOffice + `pdftoppm` pair nor a reachable server is available, generation **errors out** — it does not silently drop the graphic.
+- **`visual` units & placement.** `canvas.width`/`height` and element `x`/`y`/`w`/`h` are in **inches** (the rest of DOCX is twips/points). The canvas has **no grid** — position elements absolutely; `grid` placement inside a `visual` misbehaves.
+- **Colors inside `visual.elements` are PPTX-style.** The canvas is rendered by the pptx engine, so element hex is **bare (no `#`)** even though the surrounding DOCX uses `#`. Shape text uses `fontColor`, text uses `color`. Theme names (`"primary"`) work in both — prefer them.
 
 ## PPTX
 

--- a/skills/json-to-office/scripts/_lib.py
+++ b/skills/json-to-office/scripts/_lib.py
@@ -11,6 +11,14 @@ from pathlib import Path
 SKILL_ROOT = Path(__file__).resolve().parent.parent
 BOOTSTRAP_PATH = SKILL_ROOT / "scripts" / "bootstrap.py"
 
+# Hosted render service backing the `highcharts` and docx `visual` components.
+# Both render out-of-process: the CLI offloads chart export (POST /export) and
+# pptx-slide rasterization (POST /rasterize) to a service, then embeds the
+# returned PNG. This instance backs both, so the render loop works where no
+# service is otherwise configured. Env contract lives in the CLI:
+# packages/jto-cli/src/format-adapter.ts.
+RENDER_SERVER_URL = "https://jto-render-server.onrender.com"
+
 
 def _candidate_caps_paths() -> list[Path]:
     """Ordered list of locations to try for caps.json.
@@ -68,6 +76,41 @@ def infer_kind(path: Path) -> str:
         f"Cannot infer kind from filename: {path.name} "
         "(expected .docx.json or .pptx.json suffix)"
     )
+
+
+def has_local_rasterizer(caps: dict) -> bool:
+    """True when the CLI can rasterize `visual` components in-process.
+
+    The in-process rasterizer needs LibreOffice (`soffice`) AND the real
+    `pdftoppm` binary. The `pdf2image` Python fallback used for screenshots does
+    NOT satisfy it — the CLI shells out to `pdftoppm` directly. `bootstrap.py`
+    resolves both with the same candidate search the CLI uses (env overrides,
+    macOS app-bundle, Windows defaults, PATH), so a resolved path counts here too.
+    """
+    return bool(caps.get("soffice")) and caps.get("pdftoppm") not in (None, "pdf2image")
+
+
+def render_env(caps: dict, kind: str) -> dict:
+    """Environment for `jto-cli generate`, wiring the out-of-process renderers.
+
+    - HIGHCHARTS_SERVER_URL is always defaulted: there is no local fallback for
+      chart rendering, so `highcharts` needs a server in both docx and pptx.
+    - JTO_PPTX_RASTERIZER_URL is defaulted only for `kind == "docx"` AND only
+      when no local rasterizer is present (see `has_local_rasterizer`). The var
+      is docx-only — `visual` lives in core-docx, and the pptx adapter never
+      reads it — so setting it for a pptx render would be inert and misleading.
+      With local LibreOffice + pdftoppm the CLI's in-process path is faster and
+      keeps document content on the machine; the hosted instance is the fallback.
+
+    Both use setdefault semantics: a user-supplied env var always wins, so the
+    public instance is overridable and can be opted out of. Only relevant to the
+    `generate` step — chart/visual rendering happens there, not at validate time.
+    """
+    env = os.environ.copy()
+    env.setdefault("HIGHCHARTS_SERVER_URL", RENDER_SERVER_URL)
+    if kind == "docx" and not has_local_rasterizer(caps):
+        env.setdefault("JTO_PPTX_RASTERIZER_URL", RENDER_SERVER_URL)
+    return env
 
 
 def run(argv: list[str], **kw) -> subprocess.CompletedProcess:

--- a/skills/json-to-office/scripts/bootstrap.py
+++ b/skills/json-to-office/scripts/bootstrap.py
@@ -24,6 +24,27 @@ def which(cmd: str) -> str | None:
     return shutil.which(cmd)
 
 
+def resolve_binary(candidates: list[str]) -> str | None:
+    """First candidate runnable as an explicit file path or a PATH-resolved name.
+
+    Mirrors the CLI's rasterizer resolver
+    (packages/jto-cli/src/pptx-rasterizer.ts: sofficeCandidates / pdftoppmCandidates)
+    so the skill's capability probe agrees with what the CLI will actually find —
+    otherwise a macOS box with LibreOffice.app off PATH looks rasterizer-less and
+    the skill needlessly routes visuals to the hosted service.
+    """
+    for cand in candidates:
+        if not cand:
+            continue
+        p = Path(cand)
+        if p.is_file() and os.access(cand, os.X_OK):
+            return cand
+        found = shutil.which(cand)
+        if found:
+            return found
+    return None
+
+
 def find_monorepo_root() -> Path | None:
     """Walk up from cwd looking for the json-to-office monorepo root.
 
@@ -64,9 +85,17 @@ def probe_jto_bin(monorepo: Path | None) -> tuple[str | None, list[str]]:
 
 
 def probe_pdftoppm() -> str | None:
-    if which("pdftoppm"):
-        return "pdftoppm"
-    # Python fallback
+    candidates: list[str] = []
+    configured = os.environ.get("PDFTOPPM_PATH", "").strip()
+    if configured:
+        candidates.append(configured)
+    candidates.append("pdftoppm")
+    resolved = resolve_binary(candidates)
+    if resolved:
+        return resolved
+    # Python fallback — screenshot step only. The CLI's in-process visual
+    # rasterizer needs the real binary, so this does NOT enable local
+    # rasterization (has_local_rasterizer treats "pdf2image" as absent).
     try:
         import pdf2image  # noqa: F401
 
@@ -76,10 +105,17 @@ def probe_pdftoppm() -> str | None:
 
 
 def probe_soffice() -> str | None:
-    for candidate in ("soffice", "libreoffice"):
-        if which(candidate):
-            return candidate
-    return None
+    candidates: list[str] = []
+    configured = os.environ.get("LIBREOFFICE_PATH", "").strip()
+    if configured:
+        candidates.append(configured)
+    if sys.platform == "darwin":
+        candidates.append("/Applications/LibreOffice.app/Contents/MacOS/soffice")
+    elif sys.platform == "win32":
+        candidates.append(r"C:\Program Files\LibreOffice\program\soffice.exe")
+        candidates.append(r"C:\Program Files (x86)\LibreOffice\program\soffice.exe")
+    candidates += ["soffice", "libreoffice"]
+    return resolve_binary(candidates)
 
 
 def main() -> int:

--- a/skills/json-to-office/scripts/render_preview.py
+++ b/skills/json-to-office/scripts/render_preview.py
@@ -17,13 +17,14 @@ Degrades gracefully:
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
-from _lib import die, infer_kind, load_caps, run
+from _lib import RENDER_SERVER_URL, die, infer_kind, load_caps, render_env, run
 
 
 def _page_sort_key(path: Path) -> tuple[int, str]:
@@ -73,8 +74,10 @@ def render_pdf_to_pngs(soffice_bin: str, pdftoppm_kind: str, office_path: Path, 
         die(f"expected pdf at {pdf_path}, soffice did not produce it")
 
     pages_prefix = pdf_dir / "page"
-    if pdftoppm_kind == "pdftoppm":
-        proc = run(["pdftoppm", "-r", "144", str(pdf_path), str(pages_prefix), "-png"])
+    # pdftoppm_kind is the resolved binary path/name from caps (or "pdf2image"
+    # for the Python fallback). Invoke whatever was resolved, not a bare name.
+    if pdftoppm_kind != "pdf2image":
+        proc = run([pdftoppm_kind, "-r", "144", str(pdf_path), str(pages_prefix), "-png"])
         if proc.returncode != 0:
             die("pdftoppm failed")
         pngs = sorted(pdf_dir.glob("page-*.png"), key=_page_sort_key)
@@ -163,7 +166,25 @@ def main() -> int:
         str(office_path),
         "--no-google-fonts",
     ]
-    proc = run(gen_argv)
+    # Wire the out-of-process renderers for `highcharts` / `visual` components.
+    # render_env defaults the service URLs to the hosted instance unless the user
+    # overrode them (or, for docx visuals, a local rasterizer exists). The pptx
+    # rasterizer URL is docx-only, so it's gated on `kind` inside render_env.
+    env = render_env(caps, kind)
+    remote = []
+    if env.get("HIGHCHARTS_SERVER_URL") == RENDER_SERVER_URL and "HIGHCHARTS_SERVER_URL" not in os.environ:
+        remote.append("highcharts charts")
+    if env.get("JTO_PPTX_RASTERIZER_URL") == RENDER_SERVER_URL and "JTO_PPTX_RASTERIZER_URL" not in os.environ:
+        remote.append("docx visuals")
+    if remote:
+        sys.stderr.write(
+            f"NOTE: {' and '.join(remote)} render via the hosted service "
+            f"{RENDER_SERVER_URL} (only when the document uses them). The first "
+            "call after the instance is idle can take ~30-60s (cold start), and "
+            "the relevant document content is sent to that service. Override with "
+            "HIGHCHARTS_SERVER_URL / JTO_PPTX_RASTERIZER_URL.\n"
+        )
+    proc = run(gen_argv, env=env)
     if proc.returncode != 0 or not office_path.is_file():
         die(f"jto-cli {kind} generate failed for {input_path.name}")
 


### PR DESCRIPTION
## Why

The docx `visual` component shipped in the prior PR, but only its **bundled schema** was added to the skill — every prose surface still told the model `visual` didn't exist (SKILL.md even says *"if the schema doesn't list it, it doesn't exist"*), and the render loop had no way to rasterize `visual`/`highcharts` where local services were absent. So in practice the model never authored a `visual`, and charts/visuals silently degraded.

This closes both gaps: teach the skill the component, and auto-wire the render service.

## What

**Docs**
- `SKILL.md`: add `visual` to both component lists + a "Rendering services" note (auto-wiring, override env vars, cold-start/egress caveats).
- `docx-cheatsheet.md`: full `### visual` section — inches canvas, pptx `elements`, absolute `x/y/w/h`, color rules, placement props, `dpi`, when-to-use.
- `gotchas.md`: 3 `visual` silent-failure entries.

**Code** (`render_preview.py` / `_lib.py` / `bootstrap.py`)
- `render_env(caps, kind)`: default `HIGHCHARTS_SERVER_URL` always (no local chart fallback); default `JTO_PPTX_RASTERIZER_URL` only for **docx** + when **no local rasterizer**. `setdefault` → a user-set env var always wins. Targets the hosted `jto-render-server`.
- Cold-start/egress `NOTE` lists only the services actually going remote (kind-aware — no false "docx visuals" on a pptx render).
- Binary detection now mirrors the CLI's resolver (`LIBREOFFICE_PATH`/`PDFTOPPM_PATH`, macOS app-bundle, Windows defaults, PATH) so visuals aren't needlessly pushed off-machine; the screenshot step invokes the resolved `pdftoppm` path.

## Verification
- `py_compile` clean; unit tests cover both env branches, pdf2image≠local-rasterizer, kind-gating, override precedence.
- **Live render** of a `visual`: validates + renders correctly via the local in-process rasterizer **and** the hosted `/rasterize` server (valid PNG both ways).
- PPTX render confirmed to emit highcharts-only NOTE.
- Adversarial doc fact-check (3 agents) — 13/13 documented claims verified against schema/CLI source.

## Notes
- No changeset — `skills/` isn't a published package.
- Backward-compatible with a stale `caps.json`; re-running `bootstrap.py` picks up the wider detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for DOCX visual components including schema, authoring rules, and color conventions
  * Enhanced documentation for out-of-process rendering fallbacks for Highcharts and visual graphics
  * Added troubleshooting guide for visual rendering with dimension and formatting requirements

* **Improvements**
  * Improved rendering tool detection and configuration with environment variable overrides for fallback services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->