### PR TITLE
fix(docx): validate documents on generation instead of silently dropping invalid props

### DIFF
--- a/.changeset/monaco-collapse-strings.md
+++ b/.changeset/monaco-collapse-strings.md
@@ -1,0 +1,13 @@
+---
+'@json-to-office/jto': minor
+---
+
+feat(playground): collapse very long JSON strings into clickable chips
+
+Long string values (base64 images, embedded SVGs, big data blobs) wrap into hundreds of rows with wordWrap on, making the editor unusable. The JSON editor now collapses the middle of any value over 200 chars into a hidden sentinel rendered as a clickable chip, keeping a visible head and tail (e.g. `"data:image/png;base64,iVBOR …⟨12.4 KB⟩… AAAA"`). Clicking the chip toggles expand/collapse.
+
+- In-place, same-line collapse keeps every other line number valid (validation markers, folding, minimap unaffected).
+- Lossless saves: the full document text is reconstructed before persisting; build/preview/export always see the real value.
+- Controlled-value save echoes are ignored so chips and the cursor never thrash while editing.
+- Escape-safe head/tail slicing so non-base64 strings never get cut mid-escape.
+- Validation markers that fall inside a collapsed chip are filtered out.

--- a/.changeset/strict-generation-validation.md
+++ b/.changeset/strict-generation-validation.md
@@ -1,0 +1,16 @@
+---
+'@json-to-office/json-to-docx': minor
+'@json-to-office/shared-docx': minor
+'@json-to-office/core-docx': minor
+---
+
+fix(docx): surface invalid props on generation instead of silently dropping them
+
+Closes a correctness gap where the object/buffer generation path accepted malformed input and emitted a silently-wrong document. A typo'd prop such as `lineSpacing: { name: 'single' }` (should be `{ type: 'single' }`) used to be quietly discarded, shipping a document with the property missing. Generation now validates by default — the same check the playground already performs — and reports the error instead of producing corrupt output.
+
+- **Validation on generation (default on).** `generateDocumentFromJson` / `generateBufferFromJson` validate both string and object input and throw `JsonValidationError` on invalid documents. The plugin generator (`createDocumentGenerator().generate/generateBuffer/generateFile`) validates plugin-aware (standard + registered custom components) and throws `ComponentValidationError`. Need the old pass-through behavior? Set `validation: { enabled: false }`.
+- **Clearer messages for typo'd keys.** Component prop objects reject unknown properties, so a misspelled key surfaces as `Unexpected property "<key>"` rather than being ignored. Highcharts `options` stays an open passthrough.
+- **`allowUnknownFields` opt-out.** `validation: { allowUnknownFields: true }` strips unknown properties instead of rejecting them — a one-line migration aid for documents carrying stray keys. Required and typed fields are still enforced.
+- **Plugin validation fixes.** The plugin generator previously computed validation and discarded the result (so it never reported anything), and `generator.validate()` always returned `{ valid: true }`. Both now work, and registered custom components are no longer mistakenly rejected.
+
+The playground JSON Schema and the runtime validator both derive from the same TypeBox definitions, so they stay in sync. If a document relied on invalid props being silently dropped, pass `validation: { allowUnknownFields: true }` (strip unknown keys) or `validation: { enabled: false }` (skip validation) to keep the prior behavior.

--- a/packages/core-docx/src/__tests__/e2e/document-generation.test.ts
+++ b/packages/core-docx/src/__tests__/e2e/document-generation.test.ts
@@ -4,7 +4,10 @@ import {
   generateDocumentFromJson,
 } from '../../core/generator';
 import { Packer } from 'docx';
-import type { ComponentDefinition, ReportComponentDefinition } from '../../types';
+import type {
+  ComponentDefinition,
+  ReportComponentDefinition,
+} from '../../types';
 
 describe('E2E: Document Generation', () => {
   describe('Complete Document Generation', () => {
@@ -240,8 +243,8 @@ describe('E2E: Document Generation', () => {
       const jsonDefinition: ReportComponentDefinition = {
         name: 'docx',
         props: {
-          title: 'JSON Document',
           theme: 'minimal',
+          metadata: { title: 'JSON Document' },
         },
         children: [
           {
@@ -260,10 +263,15 @@ describe('E2E: Document Generation', () => {
           {
             name: 'table',
             props: {
-              headers: ['Column A', 'Column B'],
-              rows: [
-                ['A1', 'B1'],
-                ['A2', 'B2'],
+              columns: [
+                {
+                  header: { content: 'Column A' },
+                  cells: [{ content: 'A1' }, { content: 'A2' }],
+                },
+                {
+                  header: { content: 'Column B' },
+                  cells: [{ content: 'B1' }, { content: 'B2' }],
+                },
               ],
             },
           },

--- a/packages/core-docx/src/core/__tests__/generation-validation.test.ts
+++ b/packages/core-docx/src/core/__tests__/generation-validation.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { generateBufferFromJson, generateDocumentFromJson } from '../generator';
+import { JsonValidationError } from '../../json/parser';
+import type { ReportComponentDefinition } from '../../types';
+
+// A minimal valid document used as the base for each case.
+function validDoc(): ReportComponentDefinition {
+  return {
+    name: 'docx',
+    props: { theme: 'minimal' },
+    children: [
+      { name: 'heading', props: { level: 1, text: 'Title' } },
+      { name: 'paragraph', props: { text: 'Hello.' } },
+    ],
+  };
+}
+
+describe('generation validation (standard path)', () => {
+  it('generates a valid document (object input)', async () => {
+    const buf = await generateBufferFromJson(validDoc());
+    expect(buf.length).toBeGreaterThan(0);
+  });
+
+  it('generates a valid document (string input)', async () => {
+    const buf = await generateBufferFromJson(JSON.stringify(validDoc()));
+    expect(buf.length).toBeGreaterThan(0);
+  });
+
+  it('throws on a malformed nested prop on the object path (the reported bug)', async () => {
+    const doc = validDoc();
+    // Wrong key name: should be { type: 'single' }
+    (doc.children[1].props as any).font = {
+      size: 14,
+      lineSpacing: { name: 'single' },
+    };
+
+    await expect(generateBufferFromJson(doc)).rejects.toBeInstanceOf(
+      JsonValidationError
+    );
+    try {
+      await generateBufferFromJson(doc);
+    } catch (e) {
+      const paths = (e as JsonValidationError).validationErrors.map(
+        (v) => v.path
+      );
+      // Strict schema surfaces both the missing required `type` and the
+      // unexpected `name` key.
+      expect(paths.some((p) => p.includes('lineSpacing/type'))).toBe(true);
+      expect(paths.some((p) => p.includes('lineSpacing/name'))).toBe(true);
+    }
+  });
+
+  it('throws on an unknown extra key (strict nested schema)', async () => {
+    const doc = validDoc();
+    (doc.children[1].props as any).font = {
+      lineSpacing: { type: 'single', bogus: 1 },
+    };
+    await expect(generateBufferFromJson(doc)).rejects.toBeInstanceOf(
+      JsonValidationError
+    );
+  });
+
+  it('throws on an unknown top-level prop', async () => {
+    const doc = validDoc();
+    (doc.props as any).title = 'Not a real prop'; // belongs under metadata.title
+    await expect(generateBufferFromJson(doc)).rejects.toBeInstanceOf(
+      JsonValidationError
+    );
+  });
+
+  it('allowUnknownFields strips unknown keys instead of throwing', async () => {
+    const doc = validDoc();
+    (doc.children[1].props as any).font = {
+      lineSpacing: { type: 'single', bogus: 1 },
+    };
+    const buf = await generateBufferFromJson(doc, {
+      validation: { allowUnknownFields: true },
+    });
+    expect(buf.length).toBeGreaterThan(0);
+  });
+
+  it('validation.enabled=false skips validation entirely', async () => {
+    const doc = validDoc();
+    (doc.children[1].props as any).font = {
+      lineSpacing: { name: 'single' },
+    };
+    // Would throw with validation on; opting out lets it through.
+    const document = await generateDocumentFromJson(doc, {
+      validation: { enabled: false },
+    });
+    expect(document).toBeDefined();
+  });
+
+  it('throws on invalid JSON-string structure', async () => {
+    const bad = JSON.stringify({ name: 'docx' }); // missing children
+    await expect(generateBufferFromJson(bad)).rejects.toBeTruthy();
+  });
+});

--- a/packages/core-docx/src/core/__tests__/generator.test.ts
+++ b/packages/core-docx/src/core/__tests__/generator.test.ts
@@ -105,7 +105,6 @@ describe('core/generator', () => {
         name: 'docx',
         $schema: 'https://example.com/schema',
         props: {
-          title: 'JSON Document',
           theme: 'minimal',
         },
         children: [
@@ -153,7 +152,6 @@ describe('core/generator', () => {
       const jsonDef: ReportComponentDefinition = {
         name: 'docx',
         props: {
-          title: 'Test Document',
           theme: 'minimal',
         },
         children: [
@@ -181,7 +179,6 @@ describe('core/generator', () => {
       const jsonWithMetadata: ReportComponentDefinition = {
         name: 'docx',
         props: {
-          title: 'Document with Metadata',
           theme: 'minimal',
           metadata: {
             title: 'JSON Document',

--- a/packages/core-docx/src/core/generator.ts
+++ b/packages/core-docx/src/core/generator.ts
@@ -22,7 +22,11 @@ import { applyExportMode, scopedThemeName } from '@json-to-office/shared';
 // JSON support imports
 import { DocumentValidationResult } from '@json-to-office/shared-docx';
 import type { GenerationWarning } from '@json-to-office/shared';
-import { parseJsonComponent, validateJsonComponent } from '../json/parser';
+import {
+  validateJsonComponent,
+  JsonParsingError,
+  JsonValidationError,
+} from '../json/parser';
 import { normalizeDocument } from '../json/normalizer';
 import { loadJsonDefinition } from '../json/filesystem';
 
@@ -30,8 +34,19 @@ import { loadJsonDefinition } from '../json/filesystem';
 export interface JsonGenerationOptions {
   outputPath?: string;
   validation?: {
-    strict?: boolean;
+    /**
+     * Validate the document against the schema before building, throwing on
+     * errors. Defaults to `true` — invalid props are surfaced rather than
+     * silently dropped into a corrupt/incomplete document.
+     */
+    enabled?: boolean;
+    /**
+     * When true, unknown/extra properties are stripped instead of rejected by
+     * strict (additionalProperties:false) schemas. Escape hatch for migration.
+     */
     allowUnknownFields?: boolean;
+    /** @deprecated No longer consulted; retained for back-compat. */
+    strict?: boolean;
   };
   customThemes?: { [key: string]: ThemeConfig };
   services?: ServicesConfig;
@@ -196,11 +211,38 @@ export async function generateDocumentFromJson(
   jsonConfig: string | ComponentDefinition | ReportComponentDefinition,
   options?: JsonGenerationOptions
 ): Promise<Document> {
-  // Handle string input
+  // Validate before building unless the caller opted out. This runs the same
+  // plugin-unaware validator the public playground uses, so the object/buffer
+  // entry point is as strict as the playground — malformed props throw instead
+  // of being silently dropped into the document.
+  const validation = options?.validation;
+  if (validation?.enabled !== false) {
+    const result = validateJsonComponent(jsonConfig, {
+      allowUnknownFields: validation?.allowUnknownFields,
+    });
+    if (!result.valid) {
+      throw new JsonValidationError(
+        'Document validation failed',
+        result.errors
+      );
+    }
+  }
+
+  // Resolve to an object for the build pipeline.
   let componentToConvert: ComponentDefinition | ReportComponentDefinition;
   if (typeof jsonConfig === 'string') {
-    // Parse and validate - parseJsonComponent returns ComponentDefinition
-    const parsed = parseJsonComponent(jsonConfig) as ComponentDefinition;
+    let parsed: ComponentDefinition;
+    try {
+      parsed = JSON.parse(jsonConfig) as ComponentDefinition;
+    } catch (error) {
+      throw new JsonParsingError('Invalid JSON syntax', [
+        {
+          path: '',
+          message: error instanceof Error ? error.message : 'Invalid JSON',
+          code: 'JSON_PARSE_ERROR',
+        },
+      ]);
+    }
     if (!isReportComponent(parsed)) {
       throw new Error('Parsed JSON must be a docx component');
     }

--- a/packages/core-docx/src/plugin/__tests__/plugin-validation.test.ts
+++ b/packages/core-docx/src/plugin/__tests__/plugin-validation.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { Type } from '@sinclair/typebox';
+import { createComponent, createVersion } from '../createComponent';
+import { createDocumentGenerator } from '../createDocumentGenerator';
+import { ComponentValidationError } from '../validation';
+import { ensureThemeDefaults } from '../../themes/defaults';
+import type { ComponentDefinition } from '../../types';
+
+const testTheme = ensureThemeDefaults({
+  name: 'test',
+  displayName: 'Test Theme',
+  description: 'Simple theme for testing',
+});
+
+const CalloutPropsSchema = Type.Object(
+  {
+    text: Type.String({ description: 'Callout text' }),
+    tone: Type.Optional(
+      Type.Union([Type.Literal('info'), Type.Literal('warn')])
+    ),
+  },
+  { additionalProperties: false }
+);
+
+const calloutComponent = createComponent({
+  name: 'callout',
+  versions: {
+    '1.0.0': createVersion({
+      propsSchema: CalloutPropsSchema,
+      description: 'A callout box',
+      render: async ({ props }): Promise<ComponentDefinition[]> => [
+        { name: 'paragraph', props: { text: props.text } },
+      ],
+    }),
+  },
+});
+
+function makeGenerator() {
+  return createDocumentGenerator({ theme: testTheme }).addComponent(
+    calloutComponent
+  );
+}
+
+function docWith(children: any[]) {
+  return {
+    name: 'docx' as const,
+    props: { theme: 'test' },
+    children,
+  };
+}
+
+describe('plugin generation validation', () => {
+  it('generates a valid document containing a custom component', async () => {
+    const gen = makeGenerator();
+    const { buffer } = await gen.generateBuffer(
+      docWith([
+        { name: 'paragraph', props: { text: 'Intro' } },
+        { name: 'callout', props: { text: 'Heads up', tone: 'info' } },
+      ]) as any
+    );
+    expect(buffer.length).toBeGreaterThan(0);
+  });
+
+  it('throws when a required custom prop is missing', async () => {
+    const gen = makeGenerator();
+    await expect(
+      gen.generateBuffer(
+        docWith([{ name: 'callout', props: { tone: 'info' } }]) as any
+      )
+    ).rejects.toBeInstanceOf(ComponentValidationError);
+  });
+
+  it('throws on an unknown key in custom props (strict)', async () => {
+    const gen = makeGenerator();
+    await expect(
+      gen.generateBuffer(
+        docWith([{ name: 'callout', props: { text: 'x', bogus: true } }]) as any
+      )
+    ).rejects.toBeInstanceOf(ComponentValidationError);
+  });
+
+  it('throws on a malformed standard-component prop inside a plugin doc', async () => {
+    const gen = makeGenerator();
+    await expect(
+      gen.generateBuffer(
+        docWith([
+          { name: 'callout', props: { text: 'x' } },
+          {
+            name: 'paragraph',
+            props: { text: 'y', font: { lineSpacing: { name: 'single' } } },
+          },
+        ]) as any
+      )
+    ).rejects.toBeInstanceOf(ComponentValidationError);
+  });
+
+  it('validate() returns valid for a good doc and invalid for a malformed one', () => {
+    const gen = makeGenerator();
+    const good = gen.validate(
+      docWith([{ name: 'callout', props: { text: 'ok' } }]) as any
+    );
+    expect(good.valid).toBe(true);
+
+    const bad = gen.validate(
+      docWith([
+        {
+          name: 'paragraph',
+          props: { text: 'y', font: { lineSpacing: { name: 'single' } } },
+        },
+      ]) as any
+    );
+    expect(bad.valid).toBe(false);
+    expect(bad.errors && bad.errors.length).toBeGreaterThan(0);
+  });
+
+  it('allowUnknownFields lets a doc with unknown standard keys through', async () => {
+    const gen = makeGenerator();
+    const { buffer } = await gen.generateBuffer(
+      docWith([
+        {
+          name: 'paragraph',
+          props: { text: 'y', font: { lineSpacing: { type: 'single', x: 1 } } },
+        },
+      ]) as any,
+      { validation: { allowUnknownFields: true } }
+    );
+    expect(buffer.length).toBeGreaterThan(0);
+  });
+
+  it('validation.enabled=false skips validation', async () => {
+    const gen = makeGenerator();
+    const { buffer } = await gen.generateBuffer(
+      docWith([
+        {
+          name: 'paragraph',
+          props: { text: 'y', font: { lineSpacing: { name: 'single' } } },
+        },
+      ]) as any,
+      { validation: { enabled: false } }
+    );
+    expect(buffer.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core-docx/src/plugin/createDocumentGenerator.ts
+++ b/packages/core-docx/src/plugin/createDocumentGenerator.ts
@@ -16,6 +16,7 @@ import type {
   BufferGenerationResult,
   FileGenerationResult,
   ValidationResult,
+  GenerationValidationOptions,
 } from './types';
 import {
   validateDocument,
@@ -47,6 +48,12 @@ export interface DocumentGeneratorOptions {
   services?: ServicesConfig;
   /** Font resolution options — extraEntries, Google Fonts config, onResolved hook. */
   fonts?: FontRuntimeOpts;
+  /**
+   * Default validation behavior for every generate/generateBuffer/generateFile
+   * call. Per-call `options.validation` overrides these. Validation is on by
+   * default; pass `{ enabled: false }` to opt out.
+   */
+  validation?: GenerationValidationOptions;
 }
 
 /**
@@ -61,6 +68,7 @@ interface BuilderState {
   enableCache: boolean;
   services?: ServicesConfig;
   fonts?: FontRuntimeOpts;
+  validation?: GenerationValidationOptions;
 }
 
 /**
@@ -349,11 +357,29 @@ function createBuilderImpl<
       // Cast to ReportComponentDefinition for internal processing
       const internalDocument = document as unknown as ReportComponentDefinition;
 
-      // Validate the document first
-      validateDocument(
-        internalDocument,
-        state.components as unknown as CustomComponent<TSchema>[]
-      );
+      // Validate the document first (plugin-aware), unless disabled. Throwing
+      // here stops a malformed document from silently building into a corrupt
+      // or incomplete DOCX.
+      const vOpts: GenerationValidationOptions = {
+        ...state.validation,
+        ...options?.validation,
+      };
+      if (vOpts.enabled !== false) {
+        const result = validateDocument(
+          internalDocument,
+          state.components as unknown as CustomComponent<TSchema>[],
+          { allowUnknownFields: vOpts.allowUnknownFields }
+        );
+        if (!result.valid) {
+          throw new ComponentValidationError(
+            (result.errors ?? []).map((e) => ({
+              path: e.path ?? '',
+              message: e.message,
+            })),
+            internalDocument
+          );
+        }
+      }
 
       // Resolve theme per-document: customThemes → built-in → constructor fallback
       const baseThemeName = internalDocument.props.theme || 'minimal';
@@ -511,21 +537,21 @@ function createBuilderImpl<
     try {
       // Cast to ReportComponentDefinition for internal validation
       const internalDocument = document as unknown as ReportComponentDefinition;
-      validateDocument(
+      const result = validateDocument(
         internalDocument,
         state.components as unknown as CustomComponent<TSchema>[]
       );
-      return { valid: true };
-    } catch (error) {
-      if (error instanceof ComponentValidationError) {
-        return {
-          valid: false,
-          errors: error.errors.map((e) => ({
-            path: e.path,
-            message: e.message,
-          })),
-        };
+      if (result.valid) {
+        return { valid: true };
       }
+      return {
+        valid: false,
+        errors: (result.errors ?? []).map((e) => ({
+          path: e.path ?? '',
+          message: e.message,
+        })),
+      };
+    } catch (error) {
       return {
         valid: false,
         errors: [
@@ -607,6 +633,7 @@ export function createDocumentGenerator(
     enableCache: options.enableCache ?? false,
     services: options.services,
     fonts: options.fonts,
+    validation: options.validation,
   };
 
   return createBuilderImpl<readonly []>(initialState);

--- a/packages/core-docx/src/plugin/types.ts
+++ b/packages/core-docx/src/plugin/types.ts
@@ -122,8 +122,24 @@ export type InferCustomComponents<T> = T extends { customComponents: infer M }
  * `preservedDefinition`. The DOCX output is unaffected — it always renders
  * the fully-expanded tree.
  */
+/**
+ * Validation behavior for the generation entry points.
+ *
+ * `enabled` (default true) runs the plugin-aware validator before building and
+ * throws `ComponentValidationError` on errors, rather than emitting a corrupt
+ * or incomplete document. `allowUnknownFields` strips unknown properties
+ * instead of rejecting them under strict (additionalProperties:false) schemas —
+ * an escape hatch for migration.
+ */
+export interface GenerationValidationOptions {
+  enabled?: boolean;
+  allowUnknownFields?: boolean;
+}
+
 export interface GenerateOptions {
   preserveCustomComponents?: string[];
+  /** Override the generator's validation behavior for this call. */
+  validation?: GenerationValidationOptions;
 }
 
 /**

--- a/packages/core-docx/src/plugin/validation.ts
+++ b/packages/core-docx/src/plugin/validation.ts
@@ -27,34 +27,44 @@ export {
 export function validateComponentProps<TPropsSchema extends TSchema>(
   schema: { propsSchema: TPropsSchema },
   props: unknown,
-  componentName?: string
+  componentName?: string,
+  opts?: { clean?: boolean; applyDefaults?: boolean }
 ): ComponentValidationResult<TPropsSchema> {
+  // `clean` defaults to true so the render path (getValidatedProps) keeps
+  // normalizing props (strip unknown + apply defaults). The validation path
+  // passes `clean: false` to reject unknown keys instead of silently dropping
+  // them — strict unless the caller opts into allowUnknownFields.
   return validateCustomComponentProps<TPropsSchema>(schema.propsSchema, props, {
-    clean: true,
-    applyDefaults: true,
+    clean: opts?.clean ?? true,
+    applyDefaults: opts?.applyDefaults ?? true,
     componentName,
   });
 }
 
 /**
- * Validate document and all custom components (version-aware)
+ * Validate document and all custom components (version-aware).
+ *
+ * Standard components (paragraph, section, …) are validated against their
+ * schemas via the unified validator, which is told the registered custom names
+ * so it neither rejects them as unknown nor checks them against a standard
+ * schema. Custom component props are then validated version-aware below. Errors
+ * from both passes are merged so a single call reports the whole document.
  */
 export function validateDocument(
   document: ReportComponentDefinition,
-  customComponents: CustomComponent<any, any, any>[]
+  customComponents: CustomComponent<any, any, any>[],
+  options?: { allowUnknownFields?: boolean }
 ): ValidationResult & { success: boolean } {
-  // First validate the document structure
+  const knownCustomNames = new Set(customComponents.map((c) => c.name));
+
+  // Validate the standard-component structure (custom components deferred).
   const documentResult = validateDocumentUnified(document, {
-    clean: true,
-    applyDefaults: true,
+    knownCustomNames,
+    allowUnknownFields: options?.allowUnknownFields,
   });
 
-  if (!documentResult.valid) {
-    return { ...documentResult, success: false };
-  }
-
-  // Then validate each custom component if present
-  const errors: ValidationError[] = [];
+  // Collect standard-structure errors, then append custom-component errors.
+  const errors: ValidationError[] = [...(documentResult.errors || [])];
 
   function validateComponents(components: any[], pathPrefix = 'children') {
     components.forEach((componentData, index) => {
@@ -74,7 +84,9 @@ export function validateDocument(
       const validation = validateComponentProps(
         versionEntry,
         componentData.props,
-        customComponent.name
+        customComponent.name,
+        // Reject unknown custom props unless the caller allows them.
+        { clean: options?.allowUnknownFields === true }
       );
 
       if (!validation.valid && validation.errors) {

--- a/packages/jto/src/client/components/json-editor/editor-monaco-json.tsx
+++ b/packages/jto/src/client/components/json-editor/editor-monaco-json.tsx
@@ -13,6 +13,10 @@ import {
   getSelectionContext,
   createContextSnippet,
 } from '../../lib/monaco-selection-utils';
+import {
+  installLongStringCollapser,
+  type CollapseController,
+} from '../../lib/monaco-collapse-strings';
 import { ValidationPanel, ValidationStatusBar } from './validation-panel';
 
 interface EditorMonacoJsonProps {
@@ -46,11 +50,36 @@ function EditorMonacoJson({
   const [isValidationPanelMinimized, setIsValidationPanelMinimized] =
     useState(false);
   const decorationIdsRef = useRef<string[]>([]);
+  const collapseRef = useRef<CollapseController | null>(null);
+  // The full text we last wrote to the store. When the controlled `value` prop
+  // echoes this back, we must NOT let Monaco replace the (collapsed) model with
+  // it — that would expand every chip and jump the cursor on each save.
+  const lastSavedRef = useRef<string | null>(null);
+  // The value actually handed to <Editor>: updated only on genuine external
+  // changes (document switch, AI apply), never on our own save echoes.
+  const [editorValue, setEditorValue] = useState<string | undefined>(
+    value ?? defaultValue
+  );
   const { registerEditor, unregisterEditor, setActiveEditor } =
     useEditorRefsStore();
 
   const debouncedSaveDocumentRef = useRef(
     debounce(saveDocument, saveDocumentDebounceWait)
+  );
+
+  // Collapse newly-pasted long strings after typing settles (skips the string
+  // under the cursor so it never yanks text mid-edit).
+  const debouncedCollapseNewRef = useRef(
+    debounce(() => {
+      const editorInstance = editorRef.current;
+      const controller = collapseRef.current;
+      if (!editorInstance || !controller) return;
+      const position = editorInstance.getPosition();
+      const model = editorInstance.getModel();
+      const cursorOffset =
+        position && model ? model.getOffsetAt(position) : undefined;
+      controller.collapseNew(cursorOffset);
+    }, 600)
   );
 
   // Setup Monaco editor for JSON with schema validation
@@ -60,6 +89,15 @@ function EditorMonacoJson({
   const handleEditorWillMount = useCallback((_monaco: Monaco) => {
     console.debug('Setting up Monaco for JSON editor');
   }, []);
+
+  // Reconstruct the full document (collapsed sentinels → original values) before persisting.
+  const toStorageValue = useCallback(
+    (modelText: string) =>
+      collapseRef.current
+        ? collapseRef.current.toStorageValue(modelText)
+        : modelText,
+    []
+  );
 
   function handleEditorDidMount(
     editor: editor.IStandaloneCodeEditor,
@@ -79,6 +117,10 @@ function EditorMonacoJson({
       monaco.editor.setModelLanguage(model, 'json');
       console.debug('Model language set to JSON for:', model.uri.toString());
     }
+
+    // Collapse very long string values (base64, big blobs, …) into clickable chips
+    collapseRef.current = installLongStringCollapser(editor, monaco);
+    collapseRef.current.recollapse();
 
     // Add context menu action for AI assistant
     editor.addAction({
@@ -126,14 +168,20 @@ function EditorMonacoJson({
 
     // Cmd+S => save command
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
-      const currentValue = editor.getValue();
-      if (currentValue) saveDocument(name, currentValue);
+      const currentValue = toStorageValue(editor.getValue());
+      if (currentValue) {
+        lastSavedRef.current = currentValue;
+        saveDocument(name, currentValue);
+      }
     });
 
     // Cmd+W => close command
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyW, () => {
-      const currentValue = editor.getValue();
-      if (currentValue) saveDocument(name, currentValue);
+      const currentValue = toStorageValue(editor.getValue());
+      if (currentValue) {
+        lastSavedRef.current = currentValue;
+        saveDocument(name, currentValue);
+      }
       closeDocument(name);
     });
 
@@ -152,7 +200,21 @@ function EditorMonacoJson({
     // Convert Monaco's native JSON validation markers to our error format
     console.debug('Monaco validation markers:', markers);
 
-    const errors: JsonEditorError[] = markers.map((marker) => ({
+    // Drop markers that fall inside a collapsed sentinel — the user is seeing a
+    // chip, not the real value, so a complaint about it would be confusing.
+    const visibleMarkers = collapseRef.current
+      ? markers.filter(
+          (marker) =>
+            !collapseRef.current!.isRangeCollapsed({
+              startLineNumber: marker.startLineNumber,
+              startColumn: marker.startColumn,
+              endLineNumber: marker.endLineNumber,
+              endColumn: marker.endColumn,
+            })
+        )
+      : markers;
+
+    const errors: JsonEditorError[] = visibleMarkers.map((marker) => ({
       path: '', // Monaco doesn't provide JSON path, but we don't need it for display
       message: marker.message,
       code:
@@ -189,13 +251,40 @@ function EditorMonacoJson({
   // Flush debounced saveDocument on unmount and unregister editor
   useEffect(() => {
     const debouncedSaveDocument = debouncedSaveDocumentRef?.current;
+    const debouncedCollapseNew = debouncedCollapseNewRef?.current;
     return () => {
       debouncedSaveDocument?.flush();
+      debouncedCollapseNew?.cancel();
+      collapseRef.current?.dispose();
+      collapseRef.current = null;
       // Decorations cleanup handled by Monaco
       unregisterEditor(name);
       console.debug(`EditorWillUnMount: (name: ${name})`);
     };
   }, [name, unregisterEditor]);
+
+  // Detect genuine external content changes. Our own save echoes (value ===
+  // lastSaved) are ignored, so Monaco never sees a value change for them and
+  // leaves the collapsed model untouched.
+  useEffect(() => {
+    if (value === undefined) return;
+    if (value === lastSavedRef.current) return;
+    setEditorValue(value);
+  }, [value]);
+
+  // When an external change actually lands, Monaco replaces the model — re-run
+  // the collapse pass on the new text. Skip the first run: the initial collapse
+  // happens in handleEditorDidMount.
+  const didMountValueEffectRef = useRef(false);
+  useEffect(() => {
+    if (!didMountValueEffectRef.current) {
+      didMountValueEffectRef.current = true;
+      return;
+    }
+    if (!collapseRef.current) return;
+    const handle = setTimeout(() => collapseRef.current?.recollapse(), 0);
+    return () => clearTimeout(handle);
+  }, [editorValue]);
 
   // Handle error click - navigate to error in editor
   const handleErrorClick = useCallback((error: JsonEditorError) => {
@@ -259,14 +348,20 @@ function EditorMonacoJson({
           defaultLanguage="json"
           theme={`vs-${resolvedTheme}`}
           defaultPath={name.endsWith('.json') ? name : `${name}.json`}
-          value={value ?? defaultValue}
+          value={editorValue}
           beforeMount={handleEditorWillMount}
           onMount={handleEditorDidMount}
           onValidate={handleEditorValidation}
           onChange={(value) => {
+            // Ignore our own collapse/expand edits — they don't change the
+            // real document and saving the sentinel would lose data.
+            if (collapseRef.current?.isApplyingEdits()) return;
             if (value) {
               bumpEditSequence();
-              debouncedSaveDocumentRef.current(name, value);
+              const storage = toStorageValue(value);
+              lastSavedRef.current = storage;
+              debouncedSaveDocumentRef.current(name, storage);
+              debouncedCollapseNewRef.current();
             }
           }}
           options={{

--- a/packages/jto/src/client/lib/monaco-collapse-strings.ts
+++ b/packages/jto/src/client/lib/monaco-collapse-strings.ts
@@ -1,0 +1,495 @@
+/**
+ * Long-string collapser for the JSON Monaco editor.
+ *
+ * Very long string *values* (base64 images, embedded SVGs, big data blobs, …)
+ * make the editor unusable: with wordWrap on they wrap into hundreds of rows.
+ *
+ * Monaco cannot hide a substring of a line (decorations only style/inject
+ * text; folding/setHiddenAreas work on whole lines). So the only way to
+ * actually reclaim vertical space is to remove the characters from the model.
+ *
+ * Strategy: keep a short head and tail of the real value visible and replace
+ * only the MIDDLE (in place, on the same logical line — so every OTHER line
+ * number stays valid) with a short sentinel `§jtoc:<id>§`. The sentinel is
+ * hidden via CSS and a clickable chip is rendered in its place, so a value
+ * reads like:  "data:image/png;base64,iVBOR …⟨12.4 KB⟩… AAAA". Clicking the
+ * chip toggles expand/collapse. The hidden middle is kept in a map and
+ * re-inserted before the value is saved, so persistence is lossless.
+ *
+ * Save safety: collapse/expand edits run with an `applying` flag set; the
+ * editor component skips its save side-effect for those programmatic changes,
+ * and `toStorageValue()` reconstructs the full document before any real save.
+ */
+import type { Monaco } from '@monaco-editor/react';
+import type { editor, IDisposable, IRange, IPosition } from 'monaco-editor';
+
+/** Collapse string values longer than this many (escaped) characters. */
+const THRESHOLD = 200;
+/** How much of the start / end of the value to keep visible. */
+const HEAD_CHARS = 32;
+const TAIL_CHARS = 12;
+/** Don't bother collapsing if less than this would be hidden. */
+const MIN_MIDDLE_CHARS = 40;
+
+const SENTINEL_PREFIX = '§jtoc:';
+const SENTINEL_SUFFIX = '§';
+
+const STYLE_ID = 'jto-collapse-strings-styles';
+
+interface TrackedString {
+  id: number;
+  middle: string; // the hidden middle slice, exactly as it appears in the model
+  expanded: boolean;
+  decorationId: string;
+}
+
+interface ScanHit {
+  innerStart: number; // offset of first char after the opening quote
+  innerEnd: number; // offset of the closing quote
+  inner: string;
+}
+
+export interface CollapseController {
+  /** Reset state and collapse all long strings in the current model. */
+  recollapse(): void;
+  /** Collapse newly-introduced long strings, skipping the one under the cursor. */
+  collapseNew(cursorOffset?: number): void;
+  /** Reconstruct the full document text (sentinels → original values) for saving. */
+  toStorageValue(modelText: string): string;
+  /** True while collapse/expand edits are being applied programmatically. */
+  isApplyingEdits(): boolean;
+  /** True if a marker range falls inside a currently-collapsed value. */
+  isRangeCollapsed(range: IRange): boolean;
+  dispose(): void;
+}
+
+function ensureStyles(): void {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+.jto-collapsed-token { display: none !important; }
+.jto-collapsed-chip, .jto-expand-collapse-chip {
+  color: #7c8595;
+  background: rgba(127,127,127,0.14);
+  border: 1px solid rgba(127,127,127,0.30);
+  border-radius: 4px;
+  padding: 0 6px;
+  cursor: pointer;
+  font-style: italic;
+  font-size: 0.85em;
+}
+.jto-collapsed-chip { margin: 0 2px; }
+.jto-expand-collapse-chip { margin-right: 4px; }
+.jto-collapsed-chip:hover, .jto-expand-collapse-chip:hover {
+  background: rgba(127,127,127,0.28);
+  color: #aab3c2;
+}
+`;
+  document.head.appendChild(style);
+}
+
+/** Scan JSON text for string values longer than the threshold (skips ones that already hold a sentinel). */
+function scanLongStrings(text: string): ScanHit[] {
+  const hits: ScanHit[] = [];
+  const n = text.length;
+  let i = 0;
+  while (i < n) {
+    if (text[i] !== '"') {
+      i++;
+      continue;
+    }
+    const innerStart = i + 1;
+    let j = innerStart;
+    while (j < n) {
+      const c = text[j];
+      if (c === '\\') {
+        j += 2;
+        continue;
+      }
+      if (c === '"') break;
+      j++;
+    }
+    if (j < n) {
+      const inner = text.slice(innerStart, j);
+      if (inner.length > THRESHOLD && !inner.includes(SENTINEL_PREFIX)) {
+        hits.push({ innerStart, innerEnd: j, inner });
+      }
+    }
+    i = j + 1;
+  }
+  return hits;
+}
+
+/**
+ * Split an escaped JSON string into {prefix, middle, suffix}, cutting only at
+ * escape-safe boundaries so neither piece ends mid-escape (`\"`, `\uXXXX`, …).
+ * Returns null when there isn't enough middle to be worth collapsing.
+ */
+function splitPreserveEscapes(
+  raw: string
+): { prefix: string; middle: string; suffix: string } | null {
+  const n = raw.length;
+  // Offsets that sit between complete characters/escape sequences.
+  const safe = new Set<number>([0]);
+  let i = 0;
+  while (i < n) {
+    if (raw[i] === '\\') {
+      i = Math.min(i + (raw[i + 1] === 'u' ? 6 : 2), n);
+    } else {
+      i += 1;
+    }
+    safe.add(i);
+  }
+  let headCut = Math.min(HEAD_CHARS, n);
+  while (headCut > 0 && !safe.has(headCut)) headCut--;
+  let tailStart = Math.max(n - TAIL_CHARS, headCut);
+  while (tailStart < n && !safe.has(tailStart)) tailStart++;
+  const middle = raw.slice(headCut, tailStart);
+  if (middle.length < MIN_MIDDLE_CHARS) return null;
+  return {
+    prefix: raw.slice(0, headCut),
+    middle,
+    suffix: raw.slice(tailStart),
+  };
+}
+
+function formatSize(chars: number): string {
+  // String length ≈ byte count for the typical ASCII payloads we collapse.
+  if (chars < 1024) return `${chars} chars`;
+  if (chars < 1024 * 1024) return `${(chars / 1024).toFixed(1)} KB`;
+  return `${(chars / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function positionTouchesRange(pos: IPosition, range: IRange): boolean {
+  // Pad by one column: injected chip text (before/after) anchors at the range
+  // edge, so a click on the chip can map to the column just outside it.
+  if (
+    pos.lineNumber < range.startLineNumber ||
+    pos.lineNumber > range.endLineNumber
+  ) {
+    return false;
+  }
+  if (
+    pos.lineNumber === range.startLineNumber &&
+    pos.column < range.startColumn - 1
+  ) {
+    return false;
+  }
+  if (
+    pos.lineNumber === range.endLineNumber &&
+    pos.column > range.endColumn + 1
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function rangesOverlap(a: IRange, b: IRange): boolean {
+  if (
+    a.endLineNumber < b.startLineNumber ||
+    b.endLineNumber < a.startLineNumber
+  ) {
+    return false;
+  }
+  if (a.endLineNumber === b.startLineNumber && a.endColumn < b.startColumn) {
+    return false;
+  }
+  if (b.endLineNumber === a.startLineNumber && b.endColumn < a.startColumn) {
+    return false;
+  }
+  return true;
+}
+
+export function installLongStringCollapser(
+  editorInstance: editor.IStandaloneCodeEditor,
+  monaco: Monaco
+): CollapseController {
+  ensureStyles();
+
+  const tracked = new Map<number, TrackedString>();
+  const disposables: IDisposable[] = [];
+  let nextId = 1;
+  let applying = false;
+
+  const makeSentinel = (id: number) =>
+    `${SENTINEL_PREFIX}${id}${SENTINEL_SUFFIX}`;
+
+  function collapsedDecoration(
+    middleLen: number
+  ): editor.IModelDecorationOptions {
+    return {
+      inlineClassName: 'jto-collapsed-token',
+      after: {
+        content: ` … ⟨ ${formatSize(middleLen)} ⟩ … `,
+        inlineClassName: 'jto-collapsed-chip',
+      },
+      stickiness:
+        monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+      hoverMessage: { value: 'Click to expand the collapsed value' },
+    };
+  }
+
+  function expandedDecoration(): editor.IModelDecorationOptions {
+    return {
+      before: {
+        content: ' ⟨ collapse ⟩ ',
+        inlineClassName: 'jto-expand-collapse-chip',
+      },
+      stickiness:
+        monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+      hoverMessage: { value: 'Click to collapse this value again' },
+    };
+  }
+
+  /** Live ranges of currently-expanded tracked values (to avoid re-collapsing them). */
+  function expandedRanges(model: editor.ITextModel): IRange[] {
+    const ranges: IRange[] = [];
+    for (const t of tracked.values()) {
+      if (!t.expanded) continue;
+      const r = model.getDecorationRange(t.decorationId);
+      if (r) ranges.push(r);
+    }
+    return ranges;
+  }
+
+  function collapseHits(hits: ScanHit[]): void {
+    const model = editorInstance.getModel();
+    if (!model || hits.length === 0) return;
+    applying = true;
+    try {
+      // Bottom-up: editing a lower region never invalidates the offsets above it.
+      for (let k = hits.length - 1; k >= 0; k--) {
+        const hit = hits[k];
+        const split = splitPreserveEscapes(hit.inner);
+        if (!split) continue;
+        const id = nextId++;
+        const sentinel = makeSentinel(id);
+        const startPos = model.getPositionAt(hit.innerStart);
+        const endPos = model.getPositionAt(hit.innerEnd);
+        const innerRange = new monaco.Range(
+          startPos.lineNumber,
+          startPos.column,
+          endPos.lineNumber,
+          endPos.column
+        );
+        model.applyEdits([
+          {
+            range: innerRange,
+            text: split.prefix + sentinel + split.suffix,
+            forceMoveMarkers: true,
+          },
+        ]);
+        // The sentinel sits between the (still-visible) head and tail.
+        const sentinelStart = hit.innerStart + split.prefix.length;
+        const tokenStart = model.getPositionAt(sentinelStart);
+        const tokenEnd = model.getPositionAt(sentinelStart + sentinel.length);
+        const tokenRange = new monaco.Range(
+          tokenStart.lineNumber,
+          tokenStart.column,
+          tokenEnd.lineNumber,
+          tokenEnd.column
+        );
+        const [decorationId] = editorInstance.deltaDecorations(
+          [],
+          [
+            {
+              range: tokenRange,
+              options: collapsedDecoration(split.middle.length),
+            },
+          ]
+        );
+        tracked.set(id, {
+          id,
+          middle: split.middle,
+          expanded: false,
+          decorationId,
+        });
+      }
+    } finally {
+      applying = false;
+    }
+  }
+
+  function expand(id: number): void {
+    const model = editorInstance.getModel();
+    const t = tracked.get(id);
+    if (!model || !t || t.expanded) return;
+    const range = model.getDecorationRange(t.decorationId);
+    if (!range) return;
+    applying = true;
+    try {
+      model.applyEdits([{ range, text: t.middle, forceMoveMarkers: true }]);
+      const startOff = model.getOffsetAt({
+        lineNumber: range.startLineNumber,
+        column: range.startColumn,
+      });
+      const endPos = model.getPositionAt(startOff + t.middle.length);
+      const middleRange = new monaco.Range(
+        range.startLineNumber,
+        range.startColumn,
+        endPos.lineNumber,
+        endPos.column
+      );
+      const [decorationId] = editorInstance.deltaDecorations(
+        [t.decorationId],
+        [{ range: middleRange, options: expandedDecoration() }]
+      );
+      t.decorationId = decorationId;
+      t.expanded = true;
+    } finally {
+      applying = false;
+    }
+  }
+
+  function recollapseOne(id: number): void {
+    const model = editorInstance.getModel();
+    const t = tracked.get(id);
+    if (!model || !t || !t.expanded) return;
+    const range = model.getDecorationRange(t.decorationId);
+    if (!range) return;
+    // Re-read in case the user edited the middle while it was expanded.
+    const currentMiddle = model.getValueInRange(range);
+    t.middle = currentMiddle;
+    const sentinel = makeSentinel(id);
+    applying = true;
+    try {
+      model.applyEdits([{ range, text: sentinel, forceMoveMarkers: true }]);
+      const startOff = model.getOffsetAt({
+        lineNumber: range.startLineNumber,
+        column: range.startColumn,
+      });
+      const tokenEnd = model.getPositionAt(startOff + sentinel.length);
+      const tokenRange = new monaco.Range(
+        range.startLineNumber,
+        range.startColumn,
+        tokenEnd.lineNumber,
+        tokenEnd.column
+      );
+      const [decorationId] = editorInstance.deltaDecorations(
+        [t.decorationId],
+        [
+          {
+            range: tokenRange,
+            options: collapsedDecoration(currentMiddle.length),
+          },
+        ]
+      );
+      t.decorationId = decorationId;
+      t.expanded = false;
+    } finally {
+      applying = false;
+    }
+  }
+
+  disposables.push(
+    editorInstance.onMouseDown((e) => {
+      const pos = e.target.position;
+      if (!pos) return;
+      const model = editorInstance.getModel();
+      if (!model) return;
+      for (const t of tracked.values()) {
+        const range = model.getDecorationRange(t.decorationId);
+        if (!range) continue;
+        if (positionTouchesRange(pos, range)) {
+          if (t.expanded) recollapseOne(t.id);
+          else expand(t.id);
+          e.event.preventDefault();
+          e.event.stopPropagation();
+          return;
+        }
+      }
+    })
+  );
+
+  return {
+    recollapse() {
+      const model = editorInstance.getModel();
+      if (!model) return;
+      // Restore any live sentinels to their full text first, so a redundant
+      // call (or one after the model was edited) never strands a sentinel in
+      // the model with no mapping — which would otherwise be saved verbatim.
+      applying = true;
+      try {
+        for (const t of tracked.values()) {
+          if (t.expanded) continue;
+          const r = model.getDecorationRange(t.decorationId);
+          if (r) {
+            model.applyEdits([
+              { range: r, text: t.middle, forceMoveMarkers: true },
+            ]);
+          }
+        }
+      } finally {
+        applying = false;
+      }
+      const stale = [...tracked.values()].map((t) => t.decorationId);
+      if (stale.length) editorInstance.deltaDecorations(stale, []);
+      tracked.clear();
+      collapseHits(scanLongStrings(model.getValue()));
+    },
+
+    collapseNew(cursorOffset?: number) {
+      const model = editorInstance.getModel();
+      if (!model) return;
+      const skip = expandedRanges(model);
+      const hits = scanLongStrings(model.getValue()).filter((hit) => {
+        // Don't yank the string the user is currently typing into.
+        if (
+          cursorOffset !== undefined &&
+          cursorOffset >= hit.innerStart - 1 &&
+          cursorOffset <= hit.innerEnd + 1
+        ) {
+          return false;
+        }
+        // Don't re-collapse a value the user has deliberately expanded.
+        const start = model.getPositionAt(hit.innerStart);
+        const end = model.getPositionAt(hit.innerEnd);
+        const hitRange: IRange = {
+          startLineNumber: start.lineNumber,
+          startColumn: start.column,
+          endLineNumber: end.lineNumber,
+          endColumn: end.column,
+        };
+        return !skip.some((r) => rangesOverlap(r, hitRange));
+      });
+      collapseHits(hits);
+    },
+
+    toStorageValue(modelText: string): string {
+      if (tracked.size === 0) return modelText;
+      let out = modelText;
+      for (const t of tracked.values()) {
+        if (t.expanded) continue; // already full text in the model
+        out = out.split(makeSentinel(t.id)).join(t.middle);
+      }
+      return out;
+    },
+
+    isApplyingEdits() {
+      return applying;
+    },
+
+    isRangeCollapsed(range: IRange): boolean {
+      const model = editorInstance.getModel();
+      if (!model) return false;
+      for (const t of tracked.values()) {
+        if (t.expanded) continue;
+        const r = model.getDecorationRange(t.decorationId);
+        if (r && rangesOverlap(r, range)) return true;
+      }
+      return false;
+    },
+
+    dispose() {
+      for (const d of disposables) d.dispose();
+      const model = editorInstance.getModel();
+      if (model) {
+        const ids = [...tracked.values()].map((t) => t.decorationId);
+        if (ids.length) editorInstance.deltaDecorations(ids, []);
+      }
+      tracked.clear();
+    },
+  };
+}

--- a/packages/shared-docx/src/schemas/components/common.ts
+++ b/packages/shared-docx/src/schemas/components/common.ts
@@ -93,7 +93,7 @@ export const MarginsSchema = Type.Object(
     left: Type.Optional(Type.Number({ minimum: 0 })),
     right: Type.Optional(Type.Number({ minimum: 0 })),
   },
-  { description: 'Margin configuration' }
+  { description: 'Margin configuration', additionalProperties: false }
 );
 
 export const BorderSchema = Type.Object(
@@ -110,7 +110,7 @@ export const BorderSchema = Type.Object(
     width: Type.Optional(Type.Number({ minimum: 0 })),
     color: Type.Optional(HexColorSchema),
   },
-  { description: 'Border configuration' }
+  { description: 'Border configuration', additionalProperties: false }
 );
 
 export const LineSpacingSchema = Type.Object(
@@ -124,7 +124,7 @@ export const LineSpacingSchema = Type.Object(
     ]),
     value: Type.Optional(Type.Number({ minimum: 0 })),
   },
-  { description: 'Line spacing configuration' }
+  { description: 'Line spacing configuration', additionalProperties: false }
 );
 
 export const IndentSchema = Type.Object(
@@ -132,7 +132,7 @@ export const IndentSchema = Type.Object(
     left: Type.Optional(Type.Number({ minimum: 0 })),
     hanging: Type.Optional(Type.Number({ minimum: 0 })),
   },
-  { description: 'Indentation configuration' }
+  { description: 'Indentation configuration', additionalProperties: false }
 );
 
 // ============================================================================
@@ -240,6 +240,7 @@ export const FloatingPropertiesSchema = Type.Object(
         {
           description:
             'Horizontal positioning (use either align or offset, not both)',
+          additionalProperties: false,
         }
       )
     ),
@@ -264,6 +265,7 @@ export const FloatingPropertiesSchema = Type.Object(
         {
           description:
             'Vertical positioning (use either align or offset, not both)',
+          additionalProperties: false,
         }
       )
     ),
@@ -314,12 +316,14 @@ export const FloatingPropertiesSchema = Type.Object(
               },
               {
                 description: 'Distance from text margins',
+                additionalProperties: false,
               }
             )
           ),
         },
         {
           description: 'Text wrapping configuration',
+          additionalProperties: false,
         }
       )
     ),
@@ -362,6 +366,7 @@ export const FloatingPropertiesSchema = Type.Object(
   },
   {
     description: 'Floating element properties',
+    additionalProperties: false,
   }
 );
 
@@ -393,7 +398,10 @@ export const NumberingSchema = Type.Object(
     ),
     separator: Type.Optional(Type.String()),
   },
-  { description: 'Numbering configuration for lists' }
+  {
+    description: 'Numbering configuration for lists',
+    additionalProperties: false,
+  }
 );
 
 // ============================================================================

--- a/packages/shared-docx/src/schemas/components/list.ts
+++ b/packages/shared-docx/src/schemas/components/list.ts
@@ -123,6 +123,7 @@ export const ListLevelPropsSchema = Type.Object(
   },
   {
     description: 'Configuration for a single list level',
+    additionalProperties: false,
   }
 );
 
@@ -131,17 +132,20 @@ export const ListPropsSchema = Type.Object(
     items: Type.Array(
       Type.Union([
         Type.String(),
-        Type.Object({
-          text: Type.String(),
-          level: Type.Optional(
-            Type.Number({
-              minimum: 0,
-              maximum: 8,
-              description: 'Nesting level for this item',
-            })
-          ),
-          revision: Type.Optional(RevisionSchema),
-        }),
+        Type.Object(
+          {
+            text: Type.String(),
+            level: Type.Optional(
+              Type.Number({
+                minimum: 0,
+                maximum: 8,
+                description: 'Nesting level for this item',
+              })
+            ),
+            revision: Type.Optional(RevisionSchema),
+          },
+          { additionalProperties: false }
+        ),
       ]),
       {
         description: 'List items (required)',

--- a/packages/shared-docx/src/schemas/components/paragraph.ts
+++ b/packages/shared-docx/src/schemas/components/paragraph.ts
@@ -82,6 +82,7 @@ const FloatingFramePropertiesSchema = Type.Object(
         {
           description:
             'Horizontal positioning (use either align or offset, not both)',
+          additionalProperties: false,
         }
       )
     ),
@@ -106,6 +107,7 @@ const FloatingFramePropertiesSchema = Type.Object(
         {
           description:
             'Vertical positioning (use either align or offset, not both)',
+          additionalProperties: false,
         }
       )
     ),
@@ -116,6 +118,7 @@ const FloatingFramePropertiesSchema = Type.Object(
         },
         {
           description: 'Text wrapping configuration',
+          additionalProperties: false,
         }
       )
     ),
@@ -139,6 +142,7 @@ const FloatingFramePropertiesSchema = Type.Object(
   },
   {
     description: 'Floating text frame properties',
+    additionalProperties: false,
   }
 );
 

--- a/packages/shared-docx/src/schemas/components/table.ts
+++ b/packages/shared-docx/src/schemas/components/table.ts
@@ -38,40 +38,46 @@ const VerticalAlignmentSchema = Type.Union(
 );
 
 // Font configuration schema
-const FontConfigSchema = Type.Object({
-  family: Type.Optional(Type.String({ description: 'Font family name' })),
-  size: Type.Optional(
-    Type.Number({ minimum: 0, description: 'Font size in points' })
-  ),
-  bold: Type.Optional(Type.Boolean({ description: 'Bold text' })),
-  fontWeight: Type.Optional(
-    Type.Integer({
-      minimum: 100,
-      maximum: 900,
-      description: 'Per-cell weight (100–900). Overrides `bold` when set.',
-    })
-  ),
-  italic: Type.Optional(Type.Boolean({ description: 'Italic text' })),
-  underline: Type.Optional(Type.Boolean({ description: 'Underlined text' })),
-});
+const FontConfigSchema = Type.Object(
+  {
+    family: Type.Optional(Type.String({ description: 'Font family name' })),
+    size: Type.Optional(
+      Type.Number({ minimum: 0, description: 'Font size in points' })
+    ),
+    bold: Type.Optional(Type.Boolean({ description: 'Bold text' })),
+    fontWeight: Type.Optional(
+      Type.Integer({
+        minimum: 100,
+        maximum: 900,
+        description: 'Per-cell weight (100–900). Overrides `bold` when set.',
+      })
+    ),
+    italic: Type.Optional(Type.Boolean({ description: 'Italic text' })),
+    underline: Type.Optional(Type.Boolean({ description: 'Underlined text' })),
+  },
+  { additionalProperties: false }
+);
 
 // Border color - can be a single string or an object with sides
 const BorderColorSchema = Type.Union([
   Type.String({ description: 'Border color for all sides (hex without #)' }),
-  Type.Object({
-    bottom: Type.Optional(
-      Type.String({ description: 'Bottom border color (hex without #)' })
-    ),
-    top: Type.Optional(
-      Type.String({ description: 'Top border color (hex without #)' })
-    ),
-    right: Type.Optional(
-      Type.String({ description: 'Right border color (hex without #)' })
-    ),
-    left: Type.Optional(
-      Type.String({ description: 'Left border color (hex without #)' })
-    ),
-  }),
+  Type.Object(
+    {
+      bottom: Type.Optional(
+        Type.String({ description: 'Bottom border color (hex without #)' })
+      ),
+      top: Type.Optional(
+        Type.String({ description: 'Top border color (hex without #)' })
+      ),
+      right: Type.Optional(
+        Type.String({ description: 'Right border color (hex without #)' })
+      ),
+      left: Type.Optional(
+        Type.String({ description: 'Left border color (hex without #)' })
+      ),
+    },
+    { additionalProperties: false }
+  ),
 ]);
 
 // Border size - can be a single number or an object with sides
@@ -80,20 +86,23 @@ const BorderSizeSchema = Type.Union([
     minimum: 0,
     description: 'Border size for all sides in points',
   }),
-  Type.Object({
-    bottom: Type.Optional(
-      Type.Number({ minimum: 0, description: 'Bottom border size in points' })
-    ),
-    top: Type.Optional(
-      Type.Number({ minimum: 0, description: 'Top border size in points' })
-    ),
-    right: Type.Optional(
-      Type.Number({ minimum: 0, description: 'Right border size in points' })
-    ),
-    left: Type.Optional(
-      Type.Number({ minimum: 0, description: 'Left border size in points' })
-    ),
-  }),
+  Type.Object(
+    {
+      bottom: Type.Optional(
+        Type.Number({ minimum: 0, description: 'Bottom border size in points' })
+      ),
+      top: Type.Optional(
+        Type.Number({ minimum: 0, description: 'Top border size in points' })
+      ),
+      right: Type.Optional(
+        Type.Number({ minimum: 0, description: 'Right border size in points' })
+      ),
+      left: Type.Optional(
+        Type.Number({ minimum: 0, description: 'Left border size in points' })
+      ),
+    },
+    { additionalProperties: false }
+  ),
 ]);
 
 // Hide borders - can be a boolean or an object with sides
@@ -116,43 +125,52 @@ const HideBordersSchema = Type.Union([
         Type.Boolean({ description: 'Hide vertical borders between columns' })
       ),
     },
-    { description: 'Selectively hide specific borders' }
+    {
+      description: 'Selectively hide specific borders',
+      additionalProperties: false,
+    }
   ),
 ]);
 
 // Padding - can be a single number or an object with sides
 const PaddingSchema = Type.Union([
   Type.Number({ minimum: 0, description: 'Padding for all sides in points' }),
-  Type.Object({
-    bottom: Type.Optional(
-      Type.Number({ minimum: 0, description: 'Bottom padding in points' })
-    ),
-    top: Type.Optional(
-      Type.Number({ minimum: 0, description: 'Top padding in points' })
-    ),
-    right: Type.Optional(
-      Type.Number({ minimum: 0, description: 'Right padding in points' })
-    ),
-    left: Type.Optional(
-      Type.Number({ minimum: 0, description: 'Left padding in points' })
-    ),
-  }),
+  Type.Object(
+    {
+      bottom: Type.Optional(
+        Type.Number({ minimum: 0, description: 'Bottom padding in points' })
+      ),
+      top: Type.Optional(
+        Type.Number({ minimum: 0, description: 'Top padding in points' })
+      ),
+      right: Type.Optional(
+        Type.Number({ minimum: 0, description: 'Right padding in points' })
+      ),
+      left: Type.Optional(
+        Type.Number({ minimum: 0, description: 'Left padding in points' })
+      ),
+    },
+    { additionalProperties: false }
+  ),
 ]);
 
 // Cell defaults configuration
-const CellDefaultsSchema = Type.Object({
-  color: Type.Optional(HexColorSchema),
-  backgroundColor: Type.Optional(HexColorOrTransparentSchema),
-  horizontalAlignment: Type.Optional(HorizontalAlignmentSchema),
-  verticalAlignment: Type.Optional(VerticalAlignmentSchema),
-  font: Type.Optional(FontConfigSchema),
-  borderColor: Type.Optional(BorderColorSchema),
-  borderSize: Type.Optional(BorderSizeSchema),
-  padding: Type.Optional(PaddingSchema),
-  height: Type.Optional(
-    Type.Number({ minimum: 0, description: 'Cell height in points' })
-  ),
-});
+const CellDefaultsSchema = Type.Object(
+  {
+    color: Type.Optional(HexColorSchema),
+    backgroundColor: Type.Optional(HexColorOrTransparentSchema),
+    horizontalAlignment: Type.Optional(HorizontalAlignmentSchema),
+    verticalAlignment: Type.Optional(VerticalAlignmentSchema),
+    font: Type.Optional(FontConfigSchema),
+    borderColor: Type.Optional(BorderColorSchema),
+    borderSize: Type.Optional(BorderSizeSchema),
+    padding: Type.Optional(PaddingSchema),
+    height: Type.Optional(
+      Type.Number({ minimum: 0, description: 'Cell height in points' })
+    ),
+  },
+  { additionalProperties: false }
+);
 
 /**
  * Build TablePropsSchema with a given cell-content type.
@@ -176,35 +194,44 @@ export function createTablePropsSchema(componentRef: TSchema): TSchema {
     ),
   };
 
-  const headerSchema = Type.Object({
-    ...cellFields,
-    content: Type.Optional(cellContent),
-  });
+  const headerSchema = Type.Object(
+    {
+      ...cellFields,
+      content: Type.Optional(cellContent),
+    },
+    { additionalProperties: false }
+  );
 
-  const cellSchema = Type.Object({
-    ...cellFields,
-    content: Type.Optional(cellContent),
-  });
+  const cellSchema = Type.Object(
+    {
+      ...cellFields,
+      content: Type.Optional(cellContent),
+    },
+    { additionalProperties: false }
+  );
 
-  const columnSchema = Type.Object({
-    width: Type.Optional(
-      Type.Union([
-        Type.Number({
-          minimum: 0,
-          description:
-            'Column width in points. When set on some columns, remaining columns will automatically share the leftover table space equally. Leave undefined to distribute space evenly among unspecified columns.',
-        }),
-        Type.String({
-          pattern: '^\\d+(\\.\\d+)?%$',
-          description:
-            'Column width as percentage of available width (e.g., "40%")',
-        }),
-      ])
-    ),
-    cellDefaults: Type.Optional(CellDefaultsSchema),
-    header: Type.Optional(headerSchema),
-    cells: Type.Optional(Type.Array(cellSchema)),
-  });
+  const columnSchema = Type.Object(
+    {
+      width: Type.Optional(
+        Type.Union([
+          Type.Number({
+            minimum: 0,
+            description:
+              'Column width in points. When set on some columns, remaining columns will automatically share the leftover table space equally. Leave undefined to distribute space evenly among unspecified columns.',
+          }),
+          Type.String({
+            pattern: '^\\d+(\\.\\d+)?%$',
+            description:
+              'Column width as percentage of available width (e.g., "40%")',
+          }),
+        ])
+      ),
+      cellDefaults: Type.Optional(CellDefaultsSchema),
+      header: Type.Optional(headerSchema),
+      cells: Type.Optional(Type.Array(cellSchema)),
+    },
+    { additionalProperties: false }
+  );
 
   return Type.Object(
     {
@@ -246,6 +273,7 @@ export function createTablePropsSchema(componentRef: TSchema): TSchema {
     },
     {
       description: 'Table component props with column-based structure',
+      additionalProperties: false,
     }
   );
 }

--- a/packages/shared-docx/src/schemas/components/text-box.ts
+++ b/packages/shared-docx/src/schemas/components/text-box.ts
@@ -74,64 +74,76 @@ export const TextBoxPropsSchema = Type.Object(
               {
                 top: Type.Optional(
                   // Reuse border schema semantics: style/width/color
-                  Type.Object({
-                    style: Type.Optional(
-                      Type.Union([
-                        Type.Literal('solid'),
-                        Type.Literal('dashed'),
-                        Type.Literal('dotted'),
-                        Type.Literal('double'),
-                        Type.Literal('none'),
-                      ])
-                    ),
-                    width: Type.Optional(Type.Number({ minimum: 0 })),
-                    color: Type.Optional(HexColorSchema),
-                  })
+                  Type.Object(
+                    {
+                      style: Type.Optional(
+                        Type.Union([
+                          Type.Literal('solid'),
+                          Type.Literal('dashed'),
+                          Type.Literal('dotted'),
+                          Type.Literal('double'),
+                          Type.Literal('none'),
+                        ])
+                      ),
+                      width: Type.Optional(Type.Number({ minimum: 0 })),
+                      color: Type.Optional(HexColorSchema),
+                    },
+                    { additionalProperties: false }
+                  )
                 ),
                 right: Type.Optional(
-                  Type.Object({
-                    style: Type.Optional(
-                      Type.Union([
-                        Type.Literal('solid'),
-                        Type.Literal('dashed'),
-                        Type.Literal('dotted'),
-                        Type.Literal('double'),
-                        Type.Literal('none'),
-                      ])
-                    ),
-                    width: Type.Optional(Type.Number({ minimum: 0 })),
-                    color: Type.Optional(HexColorSchema),
-                  })
+                  Type.Object(
+                    {
+                      style: Type.Optional(
+                        Type.Union([
+                          Type.Literal('solid'),
+                          Type.Literal('dashed'),
+                          Type.Literal('dotted'),
+                          Type.Literal('double'),
+                          Type.Literal('none'),
+                        ])
+                      ),
+                      width: Type.Optional(Type.Number({ minimum: 0 })),
+                      color: Type.Optional(HexColorSchema),
+                    },
+                    { additionalProperties: false }
+                  )
                 ),
                 bottom: Type.Optional(
-                  Type.Object({
-                    style: Type.Optional(
-                      Type.Union([
-                        Type.Literal('solid'),
-                        Type.Literal('dashed'),
-                        Type.Literal('dotted'),
-                        Type.Literal('double'),
-                        Type.Literal('none'),
-                      ])
-                    ),
-                    width: Type.Optional(Type.Number({ minimum: 0 })),
-                    color: Type.Optional(HexColorSchema),
-                  })
+                  Type.Object(
+                    {
+                      style: Type.Optional(
+                        Type.Union([
+                          Type.Literal('solid'),
+                          Type.Literal('dashed'),
+                          Type.Literal('dotted'),
+                          Type.Literal('double'),
+                          Type.Literal('none'),
+                        ])
+                      ),
+                      width: Type.Optional(Type.Number({ minimum: 0 })),
+                      color: Type.Optional(HexColorSchema),
+                    },
+                    { additionalProperties: false }
+                  )
                 ),
                 left: Type.Optional(
-                  Type.Object({
-                    style: Type.Optional(
-                      Type.Union([
-                        Type.Literal('solid'),
-                        Type.Literal('dashed'),
-                        Type.Literal('dotted'),
-                        Type.Literal('double'),
-                        Type.Literal('none'),
-                      ])
-                    ),
-                    width: Type.Optional(Type.Number({ minimum: 0 })),
-                    color: Type.Optional(HexColorSchema),
-                  })
+                  Type.Object(
+                    {
+                      style: Type.Optional(
+                        Type.Union([
+                          Type.Literal('solid'),
+                          Type.Literal('dashed'),
+                          Type.Literal('dotted'),
+                          Type.Literal('double'),
+                          Type.Literal('none'),
+                        ])
+                      ),
+                      width: Type.Optional(Type.Number({ minimum: 0 })),
+                      color: Type.Optional(HexColorSchema),
+                    },
+                    { additionalProperties: false }
+                  )
                 ),
               },
               { additionalProperties: false }

--- a/packages/shared-docx/src/schemas/font.ts
+++ b/packages/shared-docx/src/schemas/font.ts
@@ -46,28 +46,40 @@ export const TextFormattingPropertiesSchema = Type.Object(
     italic: Type.Optional(Type.Boolean()),
     underline: Type.Optional(Type.Boolean()),
     lineSpacing: Type.Optional(
-      Type.Object({
-        type: Type.Union([
-          Type.Literal('single'),
-          Type.Literal('atLeast'),
-          Type.Literal('exactly'),
-          Type.Literal('double'),
-          Type.Literal('multiple'),
-        ]),
-        value: Type.Optional(Type.Number({ minimum: 0 })),
-      })
+      Type.Object(
+        {
+          type: Type.Union([
+            Type.Literal('single'),
+            Type.Literal('atLeast'),
+            Type.Literal('exactly'),
+            Type.Literal('double'),
+            Type.Literal('multiple'),
+          ]),
+          value: Type.Optional(Type.Number({ minimum: 0 })),
+        },
+        { additionalProperties: false }
+      )
     ),
     spacing: Type.Optional(
-      Type.Object({
-        before: Type.Optional(Type.Number({ minimum: 0 })),
-        after: Type.Optional(Type.Number({ minimum: 0 })),
-      })
+      Type.Object(
+        {
+          before: Type.Optional(Type.Number({ minimum: 0 })),
+          after: Type.Optional(Type.Number({ minimum: 0 })),
+        },
+        { additionalProperties: false }
+      )
     ),
     characterSpacing: Type.Optional(
-      Type.Object({
-        type: Type.Union([Type.Literal('condensed'), Type.Literal('expanded')]),
-        value: Type.Number(),
-      })
+      Type.Object(
+        {
+          type: Type.Union([
+            Type.Literal('condensed'),
+            Type.Literal('expanded'),
+          ]),
+          value: Type.Number(),
+        },
+        { additionalProperties: false }
+      )
     ),
   },
   { additionalProperties: false }

--- a/packages/shared-docx/src/validation/unified/deep-validator.ts
+++ b/packages/shared-docx/src/validation/unified/deep-validator.ts
@@ -26,9 +26,28 @@ const ROOT_COMPONENT_NAMES = new Set(
 );
 
 /**
+ * Options that tune deep validation.
+ *
+ * `knownCustomNames` — names of registered plugin components. The deep
+ * validator neither flags these as "unknown component" nor validates their
+ * props here; the plugin layer validates custom props version-aware separately.
+ *
+ * `allowUnknownFields` — when true, unknown properties are stripped before the
+ * per-component check instead of being rejected. The escape hatch for callers
+ * migrating onto strict schemas.
+ */
+export interface DeepValidateOptions {
+  knownCustomNames?: Set<string>;
+  allowUnknownFields?: boolean;
+}
+
+/**
  * Deep validate a document to collect ALL errors, not just union-level errors
  */
-export function deepValidateDocument(data: any): ValidationError[] {
+export function deepValidateDocument(
+  data: any,
+  opts: DeepValidateOptions = {}
+): ValidationError[] {
   const allErrors: ValidationError[] = [];
 
   // Validate the document structure
@@ -61,7 +80,12 @@ export function deepValidateDocument(data: any): ValidationError[] {
   // falsy non-object) is checked against the component's schema instead of
   // silently passing.
   if (ROOT_COMPONENT_NAMES.has(data.name) && 'props' in data) {
-    const propsErrors = validateComponentProps(data.name, data.props, '/props');
+    const propsErrors = validateComponentProps(
+      data.name,
+      data.props,
+      '/props',
+      opts
+    );
     allErrors.push(...propsErrors);
   }
 
@@ -102,21 +126,30 @@ export function deepValidateDocument(data: any): ValidationError[] {
         return;
       }
 
-      // Validate component props based on name
-      if (child.props) {
-        const componentErrors = validateComponentProps(
-          child.name,
-          child.props,
-          `${childPath}/props`
+      // Registered plugin components are validated version-aware by the plugin
+      // layer; skip them here so they are neither flagged as unknown nor
+      // checked against a standard schema.
+      if (opts.knownCustomNames?.has(child.name)) {
+        return;
+      }
+
+      // Validate props against the component's schema. When props is omitted,
+      // validate an empty object so the schema decides whether props are
+      // required (e.g. `section` needs none; `heading` requires text+level)
+      // rather than assuming every component requires a props field.
+      if (child.props != null) {
+        allErrors.push(
+          ...validateComponentProps(
+            child.name,
+            child.props,
+            `${childPath}/props`,
+            opts
+          )
         );
-        allErrors.push(...componentErrors);
       } else if (child.name !== 'custom') {
-        // Most components require props
-        allErrors.push({
-          path: `${childPath}/props`,
-          message: 'Component missing required field "props"',
-          code: 'required_property',
-        });
+        allErrors.push(
+          ...validateComponentProps(child.name, {}, `${childPath}/props`, opts)
+        );
       }
 
       // Special handling for section components (recursive)
@@ -146,22 +179,26 @@ export function deepValidateDocument(data: any): ValidationError[] {
                 message: 'Nested component missing required field "name"',
                 code: 'required_property',
               });
-            } else {
-              if (nestedChild.props) {
-                const nestedErrors = validateComponentProps(
+            } else if (opts.knownCustomNames?.has(nestedChild.name)) {
+              // Registered plugin component — validated separately.
+            } else if (nestedChild.props != null) {
+              allErrors.push(
+                ...validateComponentProps(
                   nestedChild.name,
                   nestedChild.props,
-                  `${nestedChildPath}/props`
-                );
-                allErrors.push(...nestedErrors);
-              } else if (nestedChild.name !== 'custom') {
-                // Most components require props
-                allErrors.push({
-                  path: `${nestedChildPath}/props`,
-                  message: 'Component missing required field "props"',
-                  code: 'required_property',
-                });
-              }
+                  `${nestedChildPath}/props`,
+                  opts
+                )
+              );
+            } else if (nestedChild.name !== 'custom') {
+              allErrors.push(
+                ...validateComponentProps(
+                  nestedChild.name,
+                  {},
+                  `${nestedChildPath}/props`,
+                  opts
+                )
+              );
             }
           });
         }
@@ -178,7 +215,8 @@ export function deepValidateDocument(data: any): ValidationError[] {
 function validateComponentProps(
   componentName: string,
   props: any,
-  basePath: string
+  basePath: string,
+  opts: DeepValidateOptions = {}
 ): ValidationError[] {
   const errors: ValidationError[] = [];
 
@@ -194,9 +232,16 @@ function validateComponentProps(
     return errors;
   }
 
+  // When unknown fields are explicitly allowed, strip them before checking so
+  // additionalProperties:false no longer rejects — required/typed fields are
+  // still enforced.
+  const toCheck = opts.allowUnknownFields
+    ? Value.Clean(schema, Value.Clone(props))
+    : props;
+
   // Use TypeBox to validate against the specific schema
-  if (!Value.Check(schema, props)) {
-    const valueErrors = [...Value.Errors(schema, props)];
+  if (!Value.Check(schema, toCheck)) {
+    const valueErrors = [...Value.Errors(schema, toCheck)];
     const transformedErrors = transformValueErrors(valueErrors, {
       maxErrors: 100,
     });
@@ -231,9 +276,10 @@ function validateComponentProps(
  */
 export function comprehensiveValidateDocument(
   data: any,
-  existingErrors: ValidationError[] = []
+  existingErrors: ValidationError[] = [],
+  opts: DeepValidateOptions = {}
 ): ValidationError[] {
-  const deepErrors = deepValidateDocument(data);
+  const deepErrors = deepValidateDocument(data, opts);
 
   const filteredExisting = existingErrors.filter(
     (e) => !isGenericUnionCatchAll(e)

--- a/packages/shared-docx/src/validation/unified/document-validator.ts
+++ b/packages/shared-docx/src/validation/unified/document-validator.ts
@@ -33,7 +33,10 @@ export function validateDocument(
   let finalErrors = result.errors || [];
   let finalValid = result.valid;
   if (!result.valid && data) {
-    finalErrors = comprehensiveValidateDocument(data, result.errors);
+    finalErrors = comprehensiveValidateDocument(data, result.errors, {
+      allowUnknownFields: options?.allowUnknownFields,
+      knownCustomNames: options?.knownCustomNames,
+    });
     // If TypeBox's union check produced only generic catch-all errors and the
     // deep validator finds nothing actionable, treat the document as valid.
     if (finalErrors.length === 0) {
@@ -90,7 +93,10 @@ export function validateJsonDocument(
   let finalErrors = result.errors || [];
   let finalValid = result.valid;
   if (!result.valid && result.parsed) {
-    finalErrors = comprehensiveValidateDocument(result.parsed, result.errors);
+    finalErrors = comprehensiveValidateDocument(result.parsed, result.errors, {
+      allowUnknownFields: options?.allowUnknownFields,
+      knownCustomNames: options?.knownCustomNames,
+    });
     if (finalErrors.length === 0) {
       finalValid = true;
     }

--- a/packages/shared-docx/src/validation/unified/types.ts
+++ b/packages/shared-docx/src/validation/unified/types.ts
@@ -39,6 +39,18 @@ export interface ValidationOptions {
   jsonString?: string;
   /** Maximum number of errors to collect */
   maxErrors?: number;
+  /**
+   * When true, unknown/extra properties are stripped before validation instead
+   * of being rejected by additionalProperties:false. Escape hatch for callers
+   * migrating onto strict schemas.
+   */
+  allowUnknownFields?: boolean;
+  /**
+   * Names of registered plugin components. They are not flagged as unknown and
+   * their props are not checked against a standard schema here — the plugin
+   * layer validates custom props version-aware separately.
+   */
+  knownCustomNames?: Set<string>;
 }
 
 /**

--- a/skills/json-to-office/assets/schemas/document.schema.json
+++ b/skills/json-to-office/assets/schemas/document.schema.json
@@ -63,10 +63,12 @@
                 },
                 "floating": {
                   "description": "Floating element properties",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "horizontalPosition": {
                       "description": "Horizontal positioning (use either align or offset, not both)",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "relative": {
@@ -136,6 +138,7 @@
                     },
                     "verticalPosition": {
                       "description": "Vertical positioning (use either align or offset, not both)",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "relative": {
@@ -205,6 +208,7 @@
                     },
                     "wrap": {
                       "description": "Text wrapping configuration",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -259,6 +263,7 @@
                         },
                         "margins": {
                           "description": "Distance from text margins",
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "top": {
@@ -389,6 +394,7 @@
                       "type": "object",
                       "properties": {
                         "top": {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "style": {
@@ -427,6 +433,7 @@
                           }
                         },
                         "right": {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "style": {
@@ -465,6 +472,7 @@
                           }
                         },
                         "bottom": {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "style": {
@@ -503,6 +511,7 @@
                           }
                         },
                         "left": {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "style": {
@@ -655,6 +664,7 @@
                                 "type": "boolean"
                               },
                               "lineSpacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -689,6 +699,7 @@
                                 "required": ["type"]
                               },
                               "spacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "before": {
@@ -702,6 +713,7 @@
                                 }
                               },
                               "characterSpacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -770,6 +782,7 @@
                               },
                               {
                                 "description": "Line spacing configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -949,6 +962,7 @@
                                 "type": "boolean"
                               },
                               "lineSpacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -983,6 +997,7 @@
                                 "required": ["type"]
                               },
                               "spacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "before": {
@@ -996,6 +1011,7 @@
                                 }
                               },
                               "characterSpacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -1072,10 +1088,12 @@
                           },
                           "floating": {
                             "description": "Floating text frame properties",
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "horizontalPosition": {
                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -1137,6 +1155,7 @@
                               },
                               "verticalPosition": {
                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -1198,6 +1217,7 @@
                               },
                               "wrap": {
                                 "description": "Text wrapping configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -1449,10 +1469,12 @@
                           },
                           "floating": {
                             "description": "Floating element properties",
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "horizontalPosition": {
                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -1522,6 +1544,7 @@
                               },
                               "verticalPosition": {
                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -1591,6 +1614,7 @@
                               },
                               "wrap": {
                                 "description": "Text wrapping configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -1645,6 +1669,7 @@
                                   },
                                   "margins": {
                                     "description": "Distance from text margins",
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "top": {
@@ -1954,6 +1979,7 @@
                                 "type": "boolean"
                               },
                               "lineSpacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -1988,6 +2014,7 @@
                                 "required": ["type"]
                               },
                               "spacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "before": {
@@ -2001,6 +2028,7 @@
                                 }
                               },
                               "characterSpacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -2069,6 +2097,7 @@
                               },
                               {
                                 "description": "Line spacing configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -2248,6 +2277,7 @@
                                 "type": "boolean"
                               },
                               "lineSpacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -2282,6 +2312,7 @@
                                 "required": ["type"]
                               },
                               "spacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "before": {
@@ -2295,6 +2326,7 @@
                                 }
                               },
                               "characterSpacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -2371,10 +2403,12 @@
                           },
                           "floating": {
                             "description": "Floating text frame properties",
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "horizontalPosition": {
                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -2436,6 +2470,7 @@
                               },
                               "verticalPosition": {
                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -2497,6 +2532,7 @@
                               },
                               "wrap": {
                                 "description": "Text wrapping configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -2748,10 +2784,12 @@
                           },
                           "floating": {
                             "description": "Floating element properties",
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "horizontalPosition": {
                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -2821,6 +2859,7 @@
                               },
                               "verticalPosition": {
                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -2890,6 +2929,7 @@
                               },
                               "wrap": {
                                 "description": "Text wrapping configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -2944,6 +2984,7 @@
                                   },
                                   "margins": {
                                     "description": "Distance from text margins",
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "top": {
@@ -3193,6 +3234,7 @@
                       },
                       "props": {
                         "description": "Table component props with column-based structure",
+                        "additionalProperties": false,
                         "type": "object",
                         "properties": {
                           "borderColor": {
@@ -3202,6 +3244,7 @@
                                 "type": "string"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -3232,6 +3275,7 @@
                                 "type": "number"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -3266,6 +3310,7 @@
                               },
                               {
                                 "description": "Selectively hide specific borders",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -3297,6 +3342,7 @@
                             ]
                           },
                           "cellDefaults": {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "color": {
@@ -3348,6 +3394,7 @@
                                 ]
                               },
                               "font": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "family": {
@@ -3386,6 +3433,7 @@
                                     "type": "string"
                                   },
                                   {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "bottom": {
@@ -3416,6 +3464,7 @@
                                     "type": "number"
                                   },
                                   {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "bottom": {
@@ -3450,6 +3499,7 @@
                                     "type": "number"
                                   },
                                   {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "bottom": {
@@ -3484,6 +3534,7 @@
                             }
                           },
                           "headerCellDefaults": {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "color": {
@@ -3535,6 +3586,7 @@
                                 ]
                               },
                               "font": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "family": {
@@ -3573,6 +3625,7 @@
                                     "type": "string"
                                   },
                                   {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "bottom": {
@@ -3603,6 +3656,7 @@
                                     "type": "number"
                                   },
                                   {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "bottom": {
@@ -3637,6 +3691,7 @@
                                     "type": "number"
                                   },
                                   {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "bottom": {
@@ -3681,6 +3736,7 @@
                             "minItems": 1,
                             "type": "array",
                             "items": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "width": {
@@ -3698,6 +3754,7 @@
                                   ]
                                 },
                                 "cellDefaults": {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "color": {
@@ -3749,6 +3806,7 @@
                                       ]
                                     },
                                     "font": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "family": {
@@ -3787,6 +3845,7 @@
                                           "type": "string"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -3817,6 +3876,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -3851,6 +3911,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -3885,6 +3946,7 @@
                                   }
                                 },
                                 "header": {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "color": {
@@ -3936,6 +3998,7 @@
                                       ]
                                     },
                                     "font": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "family": {
@@ -3974,6 +4037,7 @@
                                           "type": "string"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -4004,6 +4068,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -4038,6 +4103,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -4084,6 +4150,7 @@
                                 "cells": {
                                   "type": "array",
                                   "items": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "color": {
@@ -4135,6 +4202,7 @@
                                         ]
                                       },
                                       "font": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "family": {
@@ -4173,6 +4241,7 @@
                                             "type": "string"
                                           },
                                           {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "bottom": {
@@ -4203,6 +4272,7 @@
                                             "type": "number"
                                           },
                                           {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "bottom": {
@@ -4237,6 +4307,7 @@
                                             "type": "number"
                                           },
                                           {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "bottom": {
@@ -4334,6 +4405,7 @@
                                   "type": "string"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "text": {
@@ -4413,6 +4485,7 @@
                             "type": "array",
                             "items": {
                               "description": "Configuration for a single list level",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "level": {
@@ -4697,6 +4770,7 @@
                                 },
                                 "indent": {
                                   "description": "Indentation configuration",
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "left": {
@@ -5036,6 +5110,7 @@
                               },
                               {
                                 "description": "Indentation configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "left": {
@@ -5453,10 +5528,12 @@
                           },
                           "floating": {
                             "description": "Floating element properties",
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "horizontalPosition": {
                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -5526,6 +5603,7 @@
                               },
                               "verticalPosition": {
                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -5595,6 +5673,7 @@
                               },
                               "wrap": {
                                 "description": "Text wrapping configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -5649,6 +5728,7 @@
                                   },
                                   "margins": {
                                     "description": "Distance from text margins",
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "top": {
@@ -5814,10 +5894,12 @@
                           },
                           "floating": {
                             "description": "Floating element properties",
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "horizontalPosition": {
                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -5887,6 +5969,7 @@
                               },
                               "verticalPosition": {
                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -5956,6 +6039,7 @@
                               },
                               "wrap": {
                                 "description": "Text wrapping configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -6010,6 +6094,7 @@
                                   },
                                   "margins": {
                                     "description": "Distance from text margins",
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "top": {
@@ -6140,6 +6225,7 @@
                                 "type": "object",
                                 "properties": {
                                   "top": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "style": {
@@ -6178,6 +6264,7 @@
                                     }
                                   },
                                   "right": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "style": {
@@ -6216,6 +6303,7 @@
                                     }
                                   },
                                   "bottom": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "style": {
@@ -6254,6 +6342,7 @@
                                     }
                                   },
                                   "left": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "style": {
@@ -6406,6 +6495,7 @@
                                           "type": "boolean"
                                         },
                                         "lineSpacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -6440,6 +6530,7 @@
                                           "required": ["type"]
                                         },
                                         "spacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "before": {
@@ -6453,6 +6544,7 @@
                                           }
                                         },
                                         "characterSpacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -6521,6 +6613,7 @@
                                         },
                                         {
                                           "description": "Line spacing configuration",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -6700,6 +6793,7 @@
                                           "type": "boolean"
                                         },
                                         "lineSpacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -6734,6 +6828,7 @@
                                           "required": ["type"]
                                         },
                                         "spacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "before": {
@@ -6747,6 +6842,7 @@
                                           }
                                         },
                                         "characterSpacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -6823,10 +6919,12 @@
                                     },
                                     "floating": {
                                       "description": "Floating text frame properties",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "horizontalPosition": {
                                           "description": "Horizontal positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -6888,6 +6986,7 @@
                                         },
                                         "verticalPosition": {
                                           "description": "Vertical positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -6949,6 +7048,7 @@
                                         },
                                         "wrap": {
                                           "description": "Text wrapping configuration",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -7200,10 +7300,12 @@
                                     },
                                     "floating": {
                                       "description": "Floating element properties",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "horizontalPosition": {
                                           "description": "Horizontal positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -7273,6 +7375,7 @@
                                         },
                                         "verticalPosition": {
                                           "description": "Vertical positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -7342,6 +7445,7 @@
                                         },
                                         "wrap": {
                                           "description": "Text wrapping configuration",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -7396,6 +7500,7 @@
                                             },
                                             "margins": {
                                               "description": "Distance from text margins",
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "top": {
@@ -7783,6 +7888,7 @@
                                 "type": "boolean"
                               },
                               "lineSpacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -7817,6 +7923,7 @@
                                 "required": ["type"]
                               },
                               "spacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "before": {
@@ -7830,6 +7937,7 @@
                                 }
                               },
                               "characterSpacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -7898,6 +8006,7 @@
                               },
                               {
                                 "description": "Line spacing configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -8077,6 +8186,7 @@
                                 "type": "boolean"
                               },
                               "lineSpacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -8111,6 +8221,7 @@
                                 "required": ["type"]
                               },
                               "spacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "before": {
@@ -8124,6 +8235,7 @@
                                 }
                               },
                               "characterSpacing": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -8200,10 +8312,12 @@
                           },
                           "floating": {
                             "description": "Floating text frame properties",
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "horizontalPosition": {
                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -8265,6 +8379,7 @@
                               },
                               "verticalPosition": {
                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -8326,6 +8441,7 @@
                               },
                               "wrap": {
                                 "description": "Text wrapping configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -8577,10 +8693,12 @@
                           },
                           "floating": {
                             "description": "Floating element properties",
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "horizontalPosition": {
                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -8650,6 +8768,7 @@
                               },
                               "verticalPosition": {
                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -8719,6 +8838,7 @@
                               },
                               "wrap": {
                                 "description": "Text wrapping configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -8773,6 +8893,7 @@
                                   },
                                   "margins": {
                                     "description": "Distance from text margins",
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "top": {
@@ -9022,6 +9143,7 @@
                       },
                       "props": {
                         "description": "Table component props with column-based structure",
+                        "additionalProperties": false,
                         "type": "object",
                         "properties": {
                           "borderColor": {
@@ -9031,6 +9153,7 @@
                                 "type": "string"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -9061,6 +9184,7 @@
                                 "type": "number"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -9095,6 +9219,7 @@
                               },
                               {
                                 "description": "Selectively hide specific borders",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -9126,6 +9251,7 @@
                             ]
                           },
                           "cellDefaults": {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "color": {
@@ -9177,6 +9303,7 @@
                                 ]
                               },
                               "font": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "family": {
@@ -9215,6 +9342,7 @@
                                     "type": "string"
                                   },
                                   {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "bottom": {
@@ -9245,6 +9373,7 @@
                                     "type": "number"
                                   },
                                   {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "bottom": {
@@ -9279,6 +9408,7 @@
                                     "type": "number"
                                   },
                                   {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "bottom": {
@@ -9313,6 +9443,7 @@
                             }
                           },
                           "headerCellDefaults": {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "color": {
@@ -9364,6 +9495,7 @@
                                 ]
                               },
                               "font": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "family": {
@@ -9402,6 +9534,7 @@
                                     "type": "string"
                                   },
                                   {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "bottom": {
@@ -9432,6 +9565,7 @@
                                     "type": "number"
                                   },
                                   {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "bottom": {
@@ -9466,6 +9600,7 @@
                                     "type": "number"
                                   },
                                   {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "bottom": {
@@ -9510,6 +9645,7 @@
                             "minItems": 1,
                             "type": "array",
                             "items": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "width": {
@@ -9527,6 +9663,7 @@
                                   ]
                                 },
                                 "cellDefaults": {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "color": {
@@ -9578,6 +9715,7 @@
                                       ]
                                     },
                                     "font": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "family": {
@@ -9616,6 +9754,7 @@
                                           "type": "string"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -9646,6 +9785,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -9680,6 +9820,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -9714,6 +9855,7 @@
                                   }
                                 },
                                 "header": {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "color": {
@@ -9765,6 +9907,7 @@
                                       ]
                                     },
                                     "font": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "family": {
@@ -9803,6 +9946,7 @@
                                           "type": "string"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -9833,6 +9977,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -9867,6 +10012,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -9913,6 +10059,7 @@
                                 "cells": {
                                   "type": "array",
                                   "items": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "color": {
@@ -9964,6 +10111,7 @@
                                         ]
                                       },
                                       "font": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "family": {
@@ -10002,6 +10150,7 @@
                                             "type": "string"
                                           },
                                           {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "bottom": {
@@ -10032,6 +10181,7 @@
                                             "type": "number"
                                           },
                                           {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "bottom": {
@@ -10066,6 +10216,7 @@
                                             "type": "number"
                                           },
                                           {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "bottom": {
@@ -10163,6 +10314,7 @@
                                   "type": "string"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "text": {
@@ -10242,6 +10394,7 @@
                             "type": "array",
                             "items": {
                               "description": "Configuration for a single list level",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "level": {
@@ -10526,6 +10679,7 @@
                                 },
                                 "indent": {
                                   "description": "Indentation configuration",
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "left": {
@@ -10865,6 +11019,7 @@
                               },
                               {
                                 "description": "Indentation configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "left": {
@@ -11282,10 +11437,12 @@
                           },
                           "floating": {
                             "description": "Floating element properties",
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "horizontalPosition": {
                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -11355,6 +11512,7 @@
                               },
                               "verticalPosition": {
                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -11424,6 +11582,7 @@
                               },
                               "wrap": {
                                 "description": "Text wrapping configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -11478,6 +11637,7 @@
                                   },
                                   "margins": {
                                     "description": "Distance from text margins",
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "top": {
@@ -11782,6 +11942,7 @@
                                           "type": "boolean"
                                         },
                                         "lineSpacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -11816,6 +11977,7 @@
                                           "required": ["type"]
                                         },
                                         "spacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "before": {
@@ -11829,6 +11991,7 @@
                                           }
                                         },
                                         "characterSpacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -11897,6 +12060,7 @@
                                         },
                                         {
                                           "description": "Line spacing configuration",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -12076,6 +12240,7 @@
                                           "type": "boolean"
                                         },
                                         "lineSpacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -12110,6 +12275,7 @@
                                           "required": ["type"]
                                         },
                                         "spacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "before": {
@@ -12123,6 +12289,7 @@
                                           }
                                         },
                                         "characterSpacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -12199,10 +12366,12 @@
                                     },
                                     "floating": {
                                       "description": "Floating text frame properties",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "horizontalPosition": {
                                           "description": "Horizontal positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -12264,6 +12433,7 @@
                                         },
                                         "verticalPosition": {
                                           "description": "Vertical positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -12325,6 +12495,7 @@
                                         },
                                         "wrap": {
                                           "description": "Text wrapping configuration",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -12576,10 +12747,12 @@
                                     },
                                     "floating": {
                                       "description": "Floating element properties",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "horizontalPosition": {
                                           "description": "Horizontal positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -12649,6 +12822,7 @@
                                         },
                                         "verticalPosition": {
                                           "description": "Vertical positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -12718,6 +12892,7 @@
                                         },
                                         "wrap": {
                                           "description": "Text wrapping configuration",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -12772,6 +12947,7 @@
                                             },
                                             "margins": {
                                               "description": "Distance from text margins",
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "top": {
@@ -13021,6 +13197,7 @@
                                 },
                                 "props": {
                                   "description": "Table component props with column-based structure",
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "borderColor": {
@@ -13030,6 +13207,7 @@
                                           "type": "string"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -13060,6 +13238,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -13094,6 +13273,7 @@
                                         },
                                         {
                                           "description": "Selectively hide specific borders",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -13125,6 +13305,7 @@
                                       ]
                                     },
                                     "cellDefaults": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "color": {
@@ -13176,6 +13357,7 @@
                                           ]
                                         },
                                         "font": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "family": {
@@ -13214,6 +13396,7 @@
                                               "type": "string"
                                             },
                                             {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "bottom": {
@@ -13244,6 +13427,7 @@
                                               "type": "number"
                                             },
                                             {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "bottom": {
@@ -13278,6 +13462,7 @@
                                               "type": "number"
                                             },
                                             {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "bottom": {
@@ -13312,6 +13497,7 @@
                                       }
                                     },
                                     "headerCellDefaults": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "color": {
@@ -13363,6 +13549,7 @@
                                           ]
                                         },
                                         "font": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "family": {
@@ -13401,6 +13588,7 @@
                                               "type": "string"
                                             },
                                             {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "bottom": {
@@ -13431,6 +13619,7 @@
                                               "type": "number"
                                             },
                                             {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "bottom": {
@@ -13465,6 +13654,7 @@
                                               "type": "number"
                                             },
                                             {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "bottom": {
@@ -13509,6 +13699,7 @@
                                       "minItems": 1,
                                       "type": "array",
                                       "items": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "width": {
@@ -13526,6 +13717,7 @@
                                             ]
                                           },
                                           "cellDefaults": {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "color": {
@@ -13577,6 +13769,7 @@
                                                 ]
                                               },
                                               "font": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "family": {
@@ -13615,6 +13808,7 @@
                                                     "type": "string"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -13645,6 +13839,7 @@
                                                     "type": "number"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -13679,6 +13874,7 @@
                                                     "type": "number"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -13713,6 +13909,7 @@
                                             }
                                           },
                                           "header": {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "color": {
@@ -13764,6 +13961,7 @@
                                                 ]
                                               },
                                               "font": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "family": {
@@ -13802,6 +14000,7 @@
                                                     "type": "string"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -13832,6 +14031,7 @@
                                                     "type": "number"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -13866,6 +14066,7 @@
                                                     "type": "number"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -13912,6 +14113,7 @@
                                           "cells": {
                                             "type": "array",
                                             "items": {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "color": {
@@ -13963,6 +14165,7 @@
                                                   ]
                                                 },
                                                 "font": {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "family": {
@@ -14001,6 +14204,7 @@
                                                       "type": "string"
                                                     },
                                                     {
+                                                      "additionalProperties": false,
                                                       "type": "object",
                                                       "properties": {
                                                         "bottom": {
@@ -14031,6 +14235,7 @@
                                                       "type": "number"
                                                     },
                                                     {
+                                                      "additionalProperties": false,
                                                       "type": "object",
                                                       "properties": {
                                                         "bottom": {
@@ -14065,6 +14270,7 @@
                                                       "type": "number"
                                                     },
                                                     {
+                                                      "additionalProperties": false,
                                                       "type": "object",
                                                       "properties": {
                                                         "bottom": {
@@ -14162,6 +14368,7 @@
                                             "type": "string"
                                           },
                                           {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "text": {
@@ -14244,6 +14451,7 @@
                                       "type": "array",
                                       "items": {
                                         "description": "Configuration for a single list level",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "level": {
@@ -14528,6 +14736,7 @@
                                           },
                                           "indent": {
                                             "description": "Indentation configuration",
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "left": {
@@ -14867,6 +15076,7 @@
                                         },
                                         {
                                           "description": "Indentation configuration",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "left": {
@@ -15284,10 +15494,12 @@
                                     },
                                     "floating": {
                                       "description": "Floating element properties",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "horizontalPosition": {
                                           "description": "Horizontal positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -15357,6 +15569,7 @@
                                         },
                                         "verticalPosition": {
                                           "description": "Vertical positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -15426,6 +15639,7 @@
                                         },
                                         "wrap": {
                                           "description": "Text wrapping configuration",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -15480,6 +15694,7 @@
                                             },
                                             "margins": {
                                               "description": "Distance from text margins",
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "top": {
@@ -15645,10 +15860,12 @@
                                     },
                                     "floating": {
                                       "description": "Floating element properties",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "horizontalPosition": {
                                           "description": "Horizontal positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -15718,6 +15935,7 @@
                                         },
                                         "verticalPosition": {
                                           "description": "Vertical positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -15787,6 +16005,7 @@
                                         },
                                         "wrap": {
                                           "description": "Text wrapping configuration",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -15841,6 +16060,7 @@
                                             },
                                             "margins": {
                                               "description": "Distance from text margins",
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "top": {
@@ -15971,6 +16191,7 @@
                                           "type": "object",
                                           "properties": {
                                             "top": {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "style": {
@@ -16009,6 +16230,7 @@
                                               }
                                             },
                                             "right": {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "style": {
@@ -16047,6 +16269,7 @@
                                               }
                                             },
                                             "bottom": {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "style": {
@@ -16085,6 +16308,7 @@
                                               }
                                             },
                                             "left": {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "style": {
@@ -16237,6 +16461,7 @@
                                                     "type": "boolean"
                                                   },
                                                   "lineSpacing": {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "type": {
@@ -16271,6 +16496,7 @@
                                                     "required": ["type"]
                                                   },
                                                   "spacing": {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "before": {
@@ -16284,6 +16510,7 @@
                                                     }
                                                   },
                                                   "characterSpacing": {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "type": {
@@ -16355,6 +16582,7 @@
                                                   },
                                                   {
                                                     "description": "Line spacing configuration",
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "type": {
@@ -16537,6 +16765,7 @@
                                                     "type": "boolean"
                                                   },
                                                   "lineSpacing": {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "type": {
@@ -16571,6 +16800,7 @@
                                                     "required": ["type"]
                                                   },
                                                   "spacing": {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "before": {
@@ -16584,6 +16814,7 @@
                                                     }
                                                   },
                                                   "characterSpacing": {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "type": {
@@ -16663,10 +16894,12 @@
                                               },
                                               "floating": {
                                                 "description": "Floating text frame properties",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "horizontalPosition": {
                                                     "description": "Horizontal positioning (use either align or offset, not both)",
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "relative": {
@@ -16728,6 +16961,7 @@
                                                   },
                                                   "verticalPosition": {
                                                     "description": "Vertical positioning (use either align or offset, not both)",
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "relative": {
@@ -16789,6 +17023,7 @@
                                                   },
                                                   "wrap": {
                                                     "description": "Text wrapping configuration",
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "type": {
@@ -17043,10 +17278,12 @@
                                               },
                                               "floating": {
                                                 "description": "Floating element properties",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "horizontalPosition": {
                                                     "description": "Horizontal positioning (use either align or offset, not both)",
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "relative": {
@@ -17116,6 +17353,7 @@
                                                   },
                                                   "verticalPosition": {
                                                     "description": "Vertical positioning (use either align or offset, not both)",
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "relative": {
@@ -17185,6 +17423,7 @@
                                                   },
                                                   "wrap": {
                                                     "description": "Text wrapping configuration",
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "type": {
@@ -17239,6 +17478,7 @@
                                                       },
                                                       "margins": {
                                                         "description": "Distance from text margins",
+                                                        "additionalProperties": false,
                                                         "type": "object",
                                                         "properties": {
                                                           "top": {
@@ -17415,10 +17655,12 @@
                           },
                           "floating": {
                             "description": "Floating element properties",
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "horizontalPosition": {
                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -17488,6 +17730,7 @@
                               },
                               "verticalPosition": {
                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "relative": {
@@ -17557,6 +17800,7 @@
                               },
                               "wrap": {
                                 "description": "Text wrapping configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "type": {
@@ -17611,6 +17855,7 @@
                                   },
                                   "margins": {
                                     "description": "Distance from text margins",
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "top": {
@@ -17741,6 +17986,7 @@
                                 "type": "object",
                                 "properties": {
                                   "top": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "style": {
@@ -17779,6 +18025,7 @@
                                     }
                                   },
                                   "right": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "style": {
@@ -17817,6 +18064,7 @@
                                     }
                                   },
                                   "bottom": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "style": {
@@ -17855,6 +18103,7 @@
                                     }
                                   },
                                   "left": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "style": {
@@ -18007,6 +18256,7 @@
                                           "type": "boolean"
                                         },
                                         "lineSpacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -18041,6 +18291,7 @@
                                           "required": ["type"]
                                         },
                                         "spacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "before": {
@@ -18054,6 +18305,7 @@
                                           }
                                         },
                                         "characterSpacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -18122,6 +18374,7 @@
                                         },
                                         {
                                           "description": "Line spacing configuration",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -18301,6 +18554,7 @@
                                           "type": "boolean"
                                         },
                                         "lineSpacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -18335,6 +18589,7 @@
                                           "required": ["type"]
                                         },
                                         "spacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "before": {
@@ -18348,6 +18603,7 @@
                                           }
                                         },
                                         "characterSpacing": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -18424,10 +18680,12 @@
                                     },
                                     "floating": {
                                       "description": "Floating text frame properties",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "horizontalPosition": {
                                           "description": "Horizontal positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -18489,6 +18747,7 @@
                                         },
                                         "verticalPosition": {
                                           "description": "Vertical positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -18550,6 +18809,7 @@
                                         },
                                         "wrap": {
                                           "description": "Text wrapping configuration",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -18801,10 +19061,12 @@
                                     },
                                     "floating": {
                                       "description": "Floating element properties",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "horizontalPosition": {
                                           "description": "Horizontal positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -18874,6 +19136,7 @@
                                         },
                                         "verticalPosition": {
                                           "description": "Vertical positioning (use either align or offset, not both)",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "relative": {
@@ -18943,6 +19206,7 @@
                                         },
                                         "wrap": {
                                           "description": "Text wrapping configuration",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "type": {
@@ -18997,6 +19261,7 @@
                                             },
                                             "margins": {
                                               "description": "Distance from text margins",
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "top": {
@@ -19236,6 +19501,7 @@
                               "type": "boolean"
                             },
                             "lineSpacing": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -19270,6 +19536,7 @@
                               "required": ["type"]
                             },
                             "spacing": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "before": {
@@ -19283,6 +19550,7 @@
                               }
                             },
                             "characterSpacing": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -19351,6 +19619,7 @@
                             },
                             {
                               "description": "Line spacing configuration",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -19459,6 +19728,7 @@
                               "type": "boolean"
                             },
                             "lineSpacing": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -19493,6 +19763,7 @@
                               "required": ["type"]
                             },
                             "spacing": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "before": {
@@ -19506,6 +19777,7 @@
                               }
                             },
                             "characterSpacing": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -19582,10 +19854,12 @@
                         },
                         "floating": {
                           "description": "Floating text frame properties",
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "horizontalPosition": {
                               "description": "Horizontal positioning (use either align or offset, not both)",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "relative": {
@@ -19647,6 +19921,7 @@
                             },
                             "verticalPosition": {
                               "description": "Vertical positioning (use either align or offset, not both)",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "relative": {
@@ -19708,6 +19983,7 @@
                             },
                             "wrap": {
                               "description": "Text wrapping configuration",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -19888,10 +20164,12 @@
                         },
                         "floating": {
                           "description": "Floating element properties",
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "horizontalPosition": {
                               "description": "Horizontal positioning (use either align or offset, not both)",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "relative": {
@@ -19961,6 +20239,7 @@
                             },
                             "verticalPosition": {
                               "description": "Vertical positioning (use either align or offset, not both)",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "relative": {
@@ -20030,6 +20309,7 @@
                             },
                             "wrap": {
                               "description": "Text wrapping configuration",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -20084,6 +20364,7 @@
                                 },
                                 "margins": {
                                   "description": "Distance from text margins",
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "top": {
@@ -20294,6 +20575,7 @@
                     },
                     "table": {
                       "description": "Table component props with column-based structure",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "borderColor": {
@@ -20303,6 +20585,7 @@
                               "type": "string"
                             },
                             {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "bottom": {
@@ -20333,6 +20616,7 @@
                               "type": "number"
                             },
                             {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "bottom": {
@@ -20367,6 +20651,7 @@
                             },
                             {
                               "description": "Selectively hide specific borders",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "bottom": {
@@ -20398,6 +20683,7 @@
                           ]
                         },
                         "cellDefaults": {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "color": {
@@ -20449,6 +20735,7 @@
                               ]
                             },
                             "font": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "family": {
@@ -20487,6 +20774,7 @@
                                   "type": "string"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -20517,6 +20805,7 @@
                                   "type": "number"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -20551,6 +20840,7 @@
                                   "type": "number"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -20585,6 +20875,7 @@
                           }
                         },
                         "headerCellDefaults": {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "color": {
@@ -20636,6 +20927,7 @@
                               ]
                             },
                             "font": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "family": {
@@ -20674,6 +20966,7 @@
                                   "type": "string"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -20704,6 +20997,7 @@
                                   "type": "number"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -20738,6 +21032,7 @@
                                   "type": "number"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -20782,6 +21077,7 @@
                           "minItems": 1,
                           "type": "array",
                           "items": {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "width": {
@@ -20799,6 +21095,7 @@
                                 ]
                               },
                               "cellDefaults": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "color": {
@@ -20850,6 +21147,7 @@
                                     ]
                                   },
                                   "font": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "family": {
@@ -20888,6 +21186,7 @@
                                         "type": "string"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -20918,6 +21217,7 @@
                                         "type": "number"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -20952,6 +21252,7 @@
                                         "type": "number"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -20986,6 +21287,7 @@
                                 }
                               },
                               "header": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "color": {
@@ -21037,6 +21339,7 @@
                                     ]
                                   },
                                   "font": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "family": {
@@ -21075,6 +21378,7 @@
                                         "type": "string"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -21105,6 +21409,7 @@
                                         "type": "number"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -21139,6 +21444,7 @@
                                         "type": "number"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -21185,6 +21491,7 @@
                               "cells": {
                                 "type": "array",
                                 "items": {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "color": {
@@ -21236,6 +21543,7 @@
                                       ]
                                     },
                                     "font": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "family": {
@@ -21274,6 +21582,7 @@
                                           "type": "string"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -21304,6 +21613,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -21338,6 +21648,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -21636,6 +21947,7 @@
                                 "type": "string"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "text": {
@@ -21715,6 +22027,7 @@
                           "type": "array",
                           "items": {
                             "description": "Configuration for a single list level",
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "level": {
@@ -21999,6 +22312,7 @@
                               },
                               "indent": {
                                 "description": "Indentation configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "left": {
@@ -22338,6 +22652,7 @@
                             },
                             {
                               "description": "Indentation configuration",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "left": {
@@ -22675,6 +22990,7 @@
                                       "type": "boolean"
                                     },
                                     "lineSpacing": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "type": {
@@ -22709,6 +23025,7 @@
                                       "required": ["type"]
                                     },
                                     "spacing": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "before": {
@@ -22722,6 +23039,7 @@
                                       }
                                     },
                                     "characterSpacing": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "type": {
@@ -22790,6 +23108,7 @@
                                     },
                                     {
                                       "description": "Line spacing configuration",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "type": {
@@ -22969,6 +23288,7 @@
                                       "type": "boolean"
                                     },
                                     "lineSpacing": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "type": {
@@ -23003,6 +23323,7 @@
                                       "required": ["type"]
                                     },
                                     "spacing": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "before": {
@@ -23016,6 +23337,7 @@
                                       }
                                     },
                                     "characterSpacing": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "type": {
@@ -23092,10 +23414,12 @@
                                 },
                                 "floating": {
                                   "description": "Floating text frame properties",
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "horizontalPosition": {
                                       "description": "Horizontal positioning (use either align or offset, not both)",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "relative": {
@@ -23157,6 +23481,7 @@
                                     },
                                     "verticalPosition": {
                                       "description": "Vertical positioning (use either align or offset, not both)",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "relative": {
@@ -23218,6 +23543,7 @@
                                     },
                                     "wrap": {
                                       "description": "Text wrapping configuration",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "type": {
@@ -23469,10 +23795,12 @@
                                 },
                                 "floating": {
                                   "description": "Floating element properties",
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "horizontalPosition": {
                                       "description": "Horizontal positioning (use either align or offset, not both)",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "relative": {
@@ -23542,6 +23870,7 @@
                                     },
                                     "verticalPosition": {
                                       "description": "Vertical positioning (use either align or offset, not both)",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "relative": {
@@ -23611,6 +23940,7 @@
                                     },
                                     "wrap": {
                                       "description": "Text wrapping configuration",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "type": {
@@ -23665,6 +23995,7 @@
                                         },
                                         "margins": {
                                           "description": "Distance from text margins",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "top": {
@@ -23914,6 +24245,7 @@
                             },
                             "props": {
                               "description": "Table component props with column-based structure",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "borderColor": {
@@ -23923,6 +24255,7 @@
                                       "type": "string"
                                     },
                                     {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "bottom": {
@@ -23953,6 +24286,7 @@
                                       "type": "number"
                                     },
                                     {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "bottom": {
@@ -23987,6 +24321,7 @@
                                     },
                                     {
                                       "description": "Selectively hide specific borders",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "bottom": {
@@ -24018,6 +24353,7 @@
                                   ]
                                 },
                                 "cellDefaults": {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "color": {
@@ -24069,6 +24405,7 @@
                                       ]
                                     },
                                     "font": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "family": {
@@ -24107,6 +24444,7 @@
                                           "type": "string"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -24137,6 +24475,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -24171,6 +24510,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -24205,6 +24545,7 @@
                                   }
                                 },
                                 "headerCellDefaults": {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "color": {
@@ -24256,6 +24597,7 @@
                                       ]
                                     },
                                     "font": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "family": {
@@ -24294,6 +24636,7 @@
                                           "type": "string"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -24324,6 +24667,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -24358,6 +24702,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -24402,6 +24747,7 @@
                                   "minItems": 1,
                                   "type": "array",
                                   "items": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "width": {
@@ -24419,6 +24765,7 @@
                                         ]
                                       },
                                       "cellDefaults": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "color": {
@@ -24470,6 +24817,7 @@
                                             ]
                                           },
                                           "font": {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "family": {
@@ -24508,6 +24856,7 @@
                                                 "type": "string"
                                               },
                                               {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "bottom": {
@@ -24538,6 +24887,7 @@
                                                 "type": "number"
                                               },
                                               {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "bottom": {
@@ -24572,6 +24922,7 @@
                                                 "type": "number"
                                               },
                                               {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "bottom": {
@@ -24606,6 +24957,7 @@
                                         }
                                       },
                                       "header": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "color": {
@@ -24657,6 +25009,7 @@
                                             ]
                                           },
                                           "font": {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "family": {
@@ -24695,6 +25048,7 @@
                                                 "type": "string"
                                               },
                                               {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "bottom": {
@@ -24725,6 +25079,7 @@
                                                 "type": "number"
                                               },
                                               {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "bottom": {
@@ -24759,6 +25114,7 @@
                                                 "type": "number"
                                               },
                                               {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "bottom": {
@@ -24805,6 +25161,7 @@
                                       "cells": {
                                         "type": "array",
                                         "items": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "color": {
@@ -24856,6 +25213,7 @@
                                               ]
                                             },
                                             "font": {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "family": {
@@ -24894,6 +25252,7 @@
                                                   "type": "string"
                                                 },
                                                 {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "bottom": {
@@ -24924,6 +25283,7 @@
                                                   "type": "number"
                                                 },
                                                 {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "bottom": {
@@ -24958,6 +25318,7 @@
                                                   "type": "number"
                                                 },
                                                 {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "bottom": {
@@ -25055,6 +25416,7 @@
                                         "type": "string"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "text": {
@@ -25134,6 +25496,7 @@
                                   "type": "array",
                                   "items": {
                                     "description": "Configuration for a single list level",
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "level": {
@@ -25418,6 +25781,7 @@
                                       },
                                       "indent": {
                                         "description": "Indentation configuration",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "left": {
@@ -25757,6 +26121,7 @@
                                     },
                                     {
                                       "description": "Indentation configuration",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "left": {
@@ -26174,10 +26539,12 @@
                                 },
                                 "floating": {
                                   "description": "Floating element properties",
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "horizontalPosition": {
                                       "description": "Horizontal positioning (use either align or offset, not both)",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "relative": {
@@ -26247,6 +26614,7 @@
                                     },
                                     "verticalPosition": {
                                       "description": "Vertical positioning (use either align or offset, not both)",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "relative": {
@@ -26316,6 +26684,7 @@
                                     },
                                     "wrap": {
                                       "description": "Text wrapping configuration",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "type": {
@@ -26370,6 +26739,7 @@
                                         },
                                         "margins": {
                                           "description": "Distance from text margins",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "top": {
@@ -26674,6 +27044,7 @@
                                                 "type": "boolean"
                                               },
                                               "lineSpacing": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -26708,6 +27079,7 @@
                                                 "required": ["type"]
                                               },
                                               "spacing": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "before": {
@@ -26721,6 +27093,7 @@
                                                 }
                                               },
                                               "characterSpacing": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -26789,6 +27162,7 @@
                                               },
                                               {
                                                 "description": "Line spacing configuration",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -26968,6 +27342,7 @@
                                                 "type": "boolean"
                                               },
                                               "lineSpacing": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -27002,6 +27377,7 @@
                                                 "required": ["type"]
                                               },
                                               "spacing": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "before": {
@@ -27015,6 +27391,7 @@
                                                 }
                                               },
                                               "characterSpacing": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -27091,10 +27468,12 @@
                                           },
                                           "floating": {
                                             "description": "Floating text frame properties",
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "horizontalPosition": {
                                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "relative": {
@@ -27156,6 +27535,7 @@
                                               },
                                               "verticalPosition": {
                                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "relative": {
@@ -27217,6 +27597,7 @@
                                               },
                                               "wrap": {
                                                 "description": "Text wrapping configuration",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -27468,10 +27849,12 @@
                                           },
                                           "floating": {
                                             "description": "Floating element properties",
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "horizontalPosition": {
                                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "relative": {
@@ -27541,6 +27924,7 @@
                                               },
                                               "verticalPosition": {
                                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "relative": {
@@ -27610,6 +27994,7 @@
                                               },
                                               "wrap": {
                                                 "description": "Text wrapping configuration",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -27664,6 +28049,7 @@
                                                   },
                                                   "margins": {
                                                     "description": "Distance from text margins",
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "top": {
@@ -27913,6 +28299,7 @@
                                       },
                                       "props": {
                                         "description": "Table component props with column-based structure",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "borderColor": {
@@ -27922,6 +28309,7 @@
                                                 "type": "string"
                                               },
                                               {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "bottom": {
@@ -27952,6 +28340,7 @@
                                                 "type": "number"
                                               },
                                               {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "bottom": {
@@ -27986,6 +28375,7 @@
                                               },
                                               {
                                                 "description": "Selectively hide specific borders",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "bottom": {
@@ -28017,6 +28407,7 @@
                                             ]
                                           },
                                           "cellDefaults": {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "color": {
@@ -28068,6 +28459,7 @@
                                                 ]
                                               },
                                               "font": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "family": {
@@ -28106,6 +28498,7 @@
                                                     "type": "string"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -28136,6 +28529,7 @@
                                                     "type": "number"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -28170,6 +28564,7 @@
                                                     "type": "number"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -28204,6 +28599,7 @@
                                             }
                                           },
                                           "headerCellDefaults": {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "color": {
@@ -28255,6 +28651,7 @@
                                                 ]
                                               },
                                               "font": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "family": {
@@ -28293,6 +28690,7 @@
                                                     "type": "string"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -28323,6 +28721,7 @@
                                                     "type": "number"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -28357,6 +28756,7 @@
                                                     "type": "number"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -28401,6 +28801,7 @@
                                             "minItems": 1,
                                             "type": "array",
                                             "items": {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "width": {
@@ -28418,6 +28819,7 @@
                                                   ]
                                                 },
                                                 "cellDefaults": {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "color": {
@@ -28469,6 +28871,7 @@
                                                       ]
                                                     },
                                                     "font": {
+                                                      "additionalProperties": false,
                                                       "type": "object",
                                                       "properties": {
                                                         "family": {
@@ -28507,6 +28910,7 @@
                                                           "type": "string"
                                                         },
                                                         {
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "bottom": {
@@ -28537,6 +28941,7 @@
                                                           "type": "number"
                                                         },
                                                         {
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "bottom": {
@@ -28571,6 +28976,7 @@
                                                           "type": "number"
                                                         },
                                                         {
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "bottom": {
@@ -28605,6 +29011,7 @@
                                                   }
                                                 },
                                                 "header": {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "color": {
@@ -28656,6 +29063,7 @@
                                                       ]
                                                     },
                                                     "font": {
+                                                      "additionalProperties": false,
                                                       "type": "object",
                                                       "properties": {
                                                         "family": {
@@ -28694,6 +29102,7 @@
                                                           "type": "string"
                                                         },
                                                         {
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "bottom": {
@@ -28724,6 +29133,7 @@
                                                           "type": "number"
                                                         },
                                                         {
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "bottom": {
@@ -28758,6 +29168,7 @@
                                                           "type": "number"
                                                         },
                                                         {
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "bottom": {
@@ -28804,6 +29215,7 @@
                                                 "cells": {
                                                   "type": "array",
                                                   "items": {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "color": {
@@ -28855,6 +29267,7 @@
                                                         ]
                                                       },
                                                       "font": {
+                                                        "additionalProperties": false,
                                                         "type": "object",
                                                         "properties": {
                                                           "family": {
@@ -28893,6 +29306,7 @@
                                                             "type": "string"
                                                           },
                                                           {
+                                                            "additionalProperties": false,
                                                             "type": "object",
                                                             "properties": {
                                                               "bottom": {
@@ -28923,6 +29337,7 @@
                                                             "type": "number"
                                                           },
                                                           {
+                                                            "additionalProperties": false,
                                                             "type": "object",
                                                             "properties": {
                                                               "bottom": {
@@ -28957,6 +29372,7 @@
                                                             "type": "number"
                                                           },
                                                           {
+                                                            "additionalProperties": false,
                                                             "type": "object",
                                                             "properties": {
                                                               "bottom": {
@@ -29054,6 +29470,7 @@
                                                   "type": "string"
                                                 },
                                                 {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "text": {
@@ -29136,6 +29553,7 @@
                                             "type": "array",
                                             "items": {
                                               "description": "Configuration for a single list level",
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "level": {
@@ -29420,6 +29838,7 @@
                                                 },
                                                 "indent": {
                                                   "description": "Indentation configuration",
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "left": {
@@ -29759,6 +30178,7 @@
                                               },
                                               {
                                                 "description": "Indentation configuration",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "left": {
@@ -30179,10 +30599,12 @@
                                           },
                                           "floating": {
                                             "description": "Floating element properties",
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "horizontalPosition": {
                                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "relative": {
@@ -30252,6 +30674,7 @@
                                               },
                                               "verticalPosition": {
                                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "relative": {
@@ -30321,6 +30744,7 @@
                                               },
                                               "wrap": {
                                                 "description": "Text wrapping configuration",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -30375,6 +30799,7 @@
                                                   },
                                                   "margins": {
                                                     "description": "Distance from text margins",
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "top": {
@@ -30540,10 +30965,12 @@
                                           },
                                           "floating": {
                                             "description": "Floating element properties",
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "horizontalPosition": {
                                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "relative": {
@@ -30613,6 +31040,7 @@
                                               },
                                               "verticalPosition": {
                                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "relative": {
@@ -30682,6 +31110,7 @@
                                               },
                                               "wrap": {
                                                 "description": "Text wrapping configuration",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -30736,6 +31165,7 @@
                                                   },
                                                   "margins": {
                                                     "description": "Distance from text margins",
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "top": {
@@ -30866,6 +31296,7 @@
                                                 "type": "object",
                                                 "properties": {
                                                   "top": {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "style": {
@@ -30904,6 +31335,7 @@
                                                     }
                                                   },
                                                   "right": {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "style": {
@@ -30942,6 +31374,7 @@
                                                     }
                                                   },
                                                   "bottom": {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "style": {
@@ -30980,6 +31413,7 @@
                                                     }
                                                   },
                                                   "left": {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "style": {
@@ -31132,6 +31566,7 @@
                                                           "type": "boolean"
                                                         },
                                                         "lineSpacing": {
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "type": {
@@ -31166,6 +31601,7 @@
                                                           "required": ["type"]
                                                         },
                                                         "spacing": {
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "before": {
@@ -31179,6 +31615,7 @@
                                                           }
                                                         },
                                                         "characterSpacing": {
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "type": {
@@ -31250,6 +31687,7 @@
                                                         },
                                                         {
                                                           "description": "Line spacing configuration",
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "type": {
@@ -31432,6 +31870,7 @@
                                                           "type": "boolean"
                                                         },
                                                         "lineSpacing": {
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "type": {
@@ -31466,6 +31905,7 @@
                                                           "required": ["type"]
                                                         },
                                                         "spacing": {
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "before": {
@@ -31479,6 +31919,7 @@
                                                           }
                                                         },
                                                         "characterSpacing": {
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "type": {
@@ -31558,10 +31999,12 @@
                                                     },
                                                     "floating": {
                                                       "description": "Floating text frame properties",
+                                                      "additionalProperties": false,
                                                       "type": "object",
                                                       "properties": {
                                                         "horizontalPosition": {
                                                           "description": "Horizontal positioning (use either align or offset, not both)",
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "relative": {
@@ -31623,6 +32066,7 @@
                                                         },
                                                         "verticalPosition": {
                                                           "description": "Vertical positioning (use either align or offset, not both)",
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "relative": {
@@ -31684,6 +32128,7 @@
                                                         },
                                                         "wrap": {
                                                           "description": "Text wrapping configuration",
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "type": {
@@ -31938,10 +32383,12 @@
                                                     },
                                                     "floating": {
                                                       "description": "Floating element properties",
+                                                      "additionalProperties": false,
                                                       "type": "object",
                                                       "properties": {
                                                         "horizontalPosition": {
                                                           "description": "Horizontal positioning (use either align or offset, not both)",
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "relative": {
@@ -32011,6 +32458,7 @@
                                                         },
                                                         "verticalPosition": {
                                                           "description": "Vertical positioning (use either align or offset, not both)",
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "relative": {
@@ -32080,6 +32528,7 @@
                                                         },
                                                         "wrap": {
                                                           "description": "Text wrapping configuration",
+                                                          "additionalProperties": false,
                                                           "type": "object",
                                                           "properties": {
                                                             "type": {
@@ -32134,6 +32583,7 @@
                                                             },
                                                             "margins": {
                                                               "description": "Distance from text margins",
+                                                              "additionalProperties": false,
                                                               "type": "object",
                                                               "properties": {
                                                                 "top": {
@@ -32310,10 +32760,12 @@
                                 },
                                 "floating": {
                                   "description": "Floating element properties",
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "horizontalPosition": {
                                       "description": "Horizontal positioning (use either align or offset, not both)",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "relative": {
@@ -32383,6 +32835,7 @@
                                     },
                                     "verticalPosition": {
                                       "description": "Vertical positioning (use either align or offset, not both)",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "relative": {
@@ -32452,6 +32905,7 @@
                                     },
                                     "wrap": {
                                       "description": "Text wrapping configuration",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "type": {
@@ -32506,6 +32960,7 @@
                                         },
                                         "margins": {
                                           "description": "Distance from text margins",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "top": {
@@ -32636,6 +33091,7 @@
                                       "type": "object",
                                       "properties": {
                                         "top": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "style": {
@@ -32674,6 +33130,7 @@
                                           }
                                         },
                                         "right": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "style": {
@@ -32712,6 +33169,7 @@
                                           }
                                         },
                                         "bottom": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "style": {
@@ -32750,6 +33208,7 @@
                                           }
                                         },
                                         "left": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "style": {
@@ -32902,6 +33361,7 @@
                                                 "type": "boolean"
                                               },
                                               "lineSpacing": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -32936,6 +33396,7 @@
                                                 "required": ["type"]
                                               },
                                               "spacing": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "before": {
@@ -32949,6 +33410,7 @@
                                                 }
                                               },
                                               "characterSpacing": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -33017,6 +33479,7 @@
                                               },
                                               {
                                                 "description": "Line spacing configuration",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -33196,6 +33659,7 @@
                                                 "type": "boolean"
                                               },
                                               "lineSpacing": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -33230,6 +33694,7 @@
                                                 "required": ["type"]
                                               },
                                               "spacing": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "before": {
@@ -33243,6 +33708,7 @@
                                                 }
                                               },
                                               "characterSpacing": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -33319,10 +33785,12 @@
                                           },
                                           "floating": {
                                             "description": "Floating text frame properties",
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "horizontalPosition": {
                                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "relative": {
@@ -33384,6 +33852,7 @@
                                               },
                                               "verticalPosition": {
                                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "relative": {
@@ -33445,6 +33914,7 @@
                                               },
                                               "wrap": {
                                                 "description": "Text wrapping configuration",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -33696,10 +34166,12 @@
                                           },
                                           "floating": {
                                             "description": "Floating element properties",
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "horizontalPosition": {
                                                 "description": "Horizontal positioning (use either align or offset, not both)",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "relative": {
@@ -33769,6 +34241,7 @@
                                               },
                                               "verticalPosition": {
                                                 "description": "Vertical positioning (use either align or offset, not both)",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "relative": {
@@ -33838,6 +34311,7 @@
                                               },
                                               "wrap": {
                                                 "description": "Text wrapping configuration",
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "type": {
@@ -33892,6 +34366,7 @@
                                                   },
                                                   "margins": {
                                                     "description": "Distance from text margins",
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "top": {
@@ -34116,6 +34591,7 @@
                       "type": "boolean"
                     },
                     "lineSpacing": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -34150,6 +34626,7 @@
                       "required": ["type"]
                     },
                     "spacing": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "before": {
@@ -34163,6 +34640,7 @@
                       }
                     },
                     "characterSpacing": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -34231,6 +34709,7 @@
                     },
                     {
                       "description": "Line spacing configuration",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -34410,6 +34889,7 @@
                       "type": "boolean"
                     },
                     "lineSpacing": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -34444,6 +34924,7 @@
                       "required": ["type"]
                     },
                     "spacing": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "before": {
@@ -34457,6 +34938,7 @@
                       }
                     },
                     "characterSpacing": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -34533,10 +35015,12 @@
                 },
                 "floating": {
                   "description": "Floating text frame properties",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "horizontalPosition": {
                       "description": "Horizontal positioning (use either align or offset, not both)",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "relative": {
@@ -34598,6 +35082,7 @@
                     },
                     "verticalPosition": {
                       "description": "Vertical positioning (use either align or offset, not both)",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "relative": {
@@ -34659,6 +35144,7 @@
                     },
                     "wrap": {
                       "description": "Text wrapping configuration",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -34910,10 +35396,12 @@
                 },
                 "floating": {
                   "description": "Floating element properties",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "horizontalPosition": {
                       "description": "Horizontal positioning (use either align or offset, not both)",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "relative": {
@@ -34983,6 +35471,7 @@
                     },
                     "verticalPosition": {
                       "description": "Vertical positioning (use either align or offset, not both)",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "relative": {
@@ -35052,6 +35541,7 @@
                     },
                     "wrap": {
                       "description": "Text wrapping configuration",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -35106,6 +35596,7 @@
                         },
                         "margins": {
                           "description": "Distance from text margins",
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "top": {
@@ -35355,6 +35846,7 @@
             },
             "props": {
               "description": "Table component props with column-based structure",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "borderColor": {
@@ -35364,6 +35856,7 @@
                       "type": "string"
                     },
                     {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "bottom": {
@@ -35394,6 +35887,7 @@
                       "type": "number"
                     },
                     {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "bottom": {
@@ -35428,6 +35922,7 @@
                     },
                     {
                       "description": "Selectively hide specific borders",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "bottom": {
@@ -35459,6 +35954,7 @@
                   ]
                 },
                 "cellDefaults": {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "color": {
@@ -35510,6 +36006,7 @@
                       ]
                     },
                     "font": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "family": {
@@ -35548,6 +36045,7 @@
                           "type": "string"
                         },
                         {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "bottom": {
@@ -35578,6 +36076,7 @@
                           "type": "number"
                         },
                         {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "bottom": {
@@ -35612,6 +36111,7 @@
                           "type": "number"
                         },
                         {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "bottom": {
@@ -35646,6 +36146,7 @@
                   }
                 },
                 "headerCellDefaults": {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "color": {
@@ -35697,6 +36198,7 @@
                       ]
                     },
                     "font": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "family": {
@@ -35735,6 +36237,7 @@
                           "type": "string"
                         },
                         {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "bottom": {
@@ -35765,6 +36268,7 @@
                           "type": "number"
                         },
                         {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "bottom": {
@@ -35799,6 +36303,7 @@
                           "type": "number"
                         },
                         {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "bottom": {
@@ -35843,6 +36348,7 @@
                   "minItems": 1,
                   "type": "array",
                   "items": {
+                    "additionalProperties": false,
                     "type": "object",
                     "properties": {
                       "width": {
@@ -35860,6 +36366,7 @@
                         ]
                       },
                       "cellDefaults": {
+                        "additionalProperties": false,
                         "type": "object",
                         "properties": {
                           "color": {
@@ -35911,6 +36418,7 @@
                             ]
                           },
                           "font": {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "family": {
@@ -35949,6 +36457,7 @@
                                 "type": "string"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -35979,6 +36488,7 @@
                                 "type": "number"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -36013,6 +36523,7 @@
                                 "type": "number"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -36047,6 +36558,7 @@
                         }
                       },
                       "header": {
+                        "additionalProperties": false,
                         "type": "object",
                         "properties": {
                           "color": {
@@ -36098,6 +36610,7 @@
                             ]
                           },
                           "font": {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "family": {
@@ -36136,6 +36649,7 @@
                                 "type": "string"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -36166,6 +36680,7 @@
                                 "type": "number"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -36200,6 +36715,7 @@
                                 "type": "number"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -36246,6 +36762,7 @@
                       "cells": {
                         "type": "array",
                         "items": {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "color": {
@@ -36297,6 +36814,7 @@
                               ]
                             },
                             "font": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "family": {
@@ -36335,6 +36853,7 @@
                                   "type": "string"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -36365,6 +36884,7 @@
                                   "type": "number"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -36399,6 +36919,7 @@
                                   "type": "number"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -36496,6 +37017,7 @@
                         "type": "string"
                       },
                       {
+                        "additionalProperties": false,
                         "type": "object",
                         "properties": {
                           "text": {
@@ -36575,6 +37097,7 @@
                   "type": "array",
                   "items": {
                     "description": "Configuration for a single list level",
+                    "additionalProperties": false,
                     "type": "object",
                     "properties": {
                       "level": {
@@ -36859,6 +37382,7 @@
                       },
                       "indent": {
                         "description": "Indentation configuration",
+                        "additionalProperties": false,
                         "type": "object",
                         "properties": {
                           "left": {
@@ -37198,6 +37722,7 @@
                     },
                     {
                       "description": "Indentation configuration",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "left": {
@@ -37615,10 +38140,12 @@
                 },
                 "floating": {
                   "description": "Floating element properties",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "horizontalPosition": {
                       "description": "Horizontal positioning (use either align or offset, not both)",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "relative": {
@@ -37688,6 +38215,7 @@
                     },
                     "verticalPosition": {
                       "description": "Vertical positioning (use either align or offset, not both)",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "relative": {
@@ -37757,6 +38285,7 @@
                     },
                     "wrap": {
                       "description": "Text wrapping configuration",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -37811,6 +38340,7 @@
                         },
                         "margins": {
                           "description": "Distance from text margins",
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "top": {
@@ -40333,6 +40863,7 @@
                       "type": "boolean"
                     },
                     "lineSpacing": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -40367,6 +40898,7 @@
                       "required": ["type"]
                     },
                     "spacing": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "before": {
@@ -40380,6 +40912,7 @@
                       }
                     },
                     "characterSpacing": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -40448,6 +40981,7 @@
                     },
                     {
                       "description": "Line spacing configuration",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -40556,6 +41090,7 @@
                       "type": "boolean"
                     },
                     "lineSpacing": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -40590,6 +41125,7 @@
                       "required": ["type"]
                     },
                     "spacing": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "before": {
@@ -40603,6 +41139,7 @@
                       }
                     },
                     "characterSpacing": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -40679,10 +41216,12 @@
                 },
                 "floating": {
                   "description": "Floating text frame properties",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "horizontalPosition": {
                       "description": "Horizontal positioning (use either align or offset, not both)",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "relative": {
@@ -40744,6 +41283,7 @@
                     },
                     "verticalPosition": {
                       "description": "Vertical positioning (use either align or offset, not both)",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "relative": {
@@ -40805,6 +41345,7 @@
                     },
                     "wrap": {
                       "description": "Text wrapping configuration",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -40985,10 +41526,12 @@
                 },
                 "floating": {
                   "description": "Floating element properties",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "horizontalPosition": {
                       "description": "Horizontal positioning (use either align or offset, not both)",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "relative": {
@@ -41058,6 +41601,7 @@
                     },
                     "verticalPosition": {
                       "description": "Vertical positioning (use either align or offset, not both)",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "relative": {
@@ -41127,6 +41671,7 @@
                     },
                     "wrap": {
                       "description": "Text wrapping configuration",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "type": {
@@ -41181,6 +41726,7 @@
                         },
                         "margins": {
                           "description": "Distance from text margins",
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "top": {
@@ -41391,6 +41937,7 @@
             },
             "table": {
               "description": "Table component props with column-based structure",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "borderColor": {
@@ -41400,6 +41947,7 @@
                       "type": "string"
                     },
                     {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "bottom": {
@@ -41430,6 +41978,7 @@
                       "type": "number"
                     },
                     {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "bottom": {
@@ -41464,6 +42013,7 @@
                     },
                     {
                       "description": "Selectively hide specific borders",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "bottom": {
@@ -41495,6 +42045,7 @@
                   ]
                 },
                 "cellDefaults": {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "color": {
@@ -41546,6 +42097,7 @@
                       ]
                     },
                     "font": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "family": {
@@ -41584,6 +42136,7 @@
                           "type": "string"
                         },
                         {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "bottom": {
@@ -41614,6 +42167,7 @@
                           "type": "number"
                         },
                         {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "bottom": {
@@ -41648,6 +42202,7 @@
                           "type": "number"
                         },
                         {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "bottom": {
@@ -41682,6 +42237,7 @@
                   }
                 },
                 "headerCellDefaults": {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "color": {
@@ -41733,6 +42289,7 @@
                       ]
                     },
                     "font": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "family": {
@@ -41771,6 +42328,7 @@
                           "type": "string"
                         },
                         {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "bottom": {
@@ -41801,6 +42359,7 @@
                           "type": "number"
                         },
                         {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "bottom": {
@@ -41835,6 +42394,7 @@
                           "type": "number"
                         },
                         {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "bottom": {
@@ -41879,6 +42439,7 @@
                   "minItems": 1,
                   "type": "array",
                   "items": {
+                    "additionalProperties": false,
                     "type": "object",
                     "properties": {
                       "width": {
@@ -41896,6 +42457,7 @@
                         ]
                       },
                       "cellDefaults": {
+                        "additionalProperties": false,
                         "type": "object",
                         "properties": {
                           "color": {
@@ -41947,6 +42509,7 @@
                             ]
                           },
                           "font": {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "family": {
@@ -41985,6 +42548,7 @@
                                 "type": "string"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -42015,6 +42579,7 @@
                                 "type": "number"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -42049,6 +42614,7 @@
                                 "type": "number"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -42083,6 +42649,7 @@
                         }
                       },
                       "header": {
+                        "additionalProperties": false,
                         "type": "object",
                         "properties": {
                           "color": {
@@ -42134,6 +42701,7 @@
                             ]
                           },
                           "font": {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "family": {
@@ -42172,6 +42740,7 @@
                                 "type": "string"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -42202,6 +42771,7 @@
                                 "type": "number"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -42236,6 +42806,7 @@
                                 "type": "number"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "bottom": {
@@ -42282,6 +42853,7 @@
                       "cells": {
                         "type": "array",
                         "items": {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "color": {
@@ -42333,6 +42905,7 @@
                               ]
                             },
                             "font": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "family": {
@@ -42371,6 +42944,7 @@
                                   "type": "string"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -42401,6 +42975,7 @@
                                   "type": "number"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -42435,6 +43010,7 @@
                                   "type": "number"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -42733,6 +43309,7 @@
                         "type": "string"
                       },
                       {
+                        "additionalProperties": false,
                         "type": "object",
                         "properties": {
                           "text": {
@@ -42812,6 +43389,7 @@
                   "type": "array",
                   "items": {
                     "description": "Configuration for a single list level",
+                    "additionalProperties": false,
                     "type": "object",
                     "properties": {
                       "level": {
@@ -43096,6 +43674,7 @@
                       },
                       "indent": {
                         "description": "Indentation configuration",
+                        "additionalProperties": false,
                         "type": "object",
                         "properties": {
                           "left": {
@@ -43435,6 +44014,7 @@
                     },
                     {
                       "description": "Indentation configuration",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "left": {
@@ -43769,6 +44349,7 @@
                               "type": "boolean"
                             },
                             "lineSpacing": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -43803,6 +44384,7 @@
                               "required": ["type"]
                             },
                             "spacing": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "before": {
@@ -43816,6 +44398,7 @@
                               }
                             },
                             "characterSpacing": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -43884,6 +44467,7 @@
                             },
                             {
                               "description": "Line spacing configuration",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -44063,6 +44647,7 @@
                               "type": "boolean"
                             },
                             "lineSpacing": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -44097,6 +44682,7 @@
                               "required": ["type"]
                             },
                             "spacing": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "before": {
@@ -44110,6 +44696,7 @@
                               }
                             },
                             "characterSpacing": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -44186,10 +44773,12 @@
                         },
                         "floating": {
                           "description": "Floating text frame properties",
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "horizontalPosition": {
                               "description": "Horizontal positioning (use either align or offset, not both)",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "relative": {
@@ -44251,6 +44840,7 @@
                             },
                             "verticalPosition": {
                               "description": "Vertical positioning (use either align or offset, not both)",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "relative": {
@@ -44312,6 +44902,7 @@
                             },
                             "wrap": {
                               "description": "Text wrapping configuration",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -44563,10 +45154,12 @@
                         },
                         "floating": {
                           "description": "Floating element properties",
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "horizontalPosition": {
                               "description": "Horizontal positioning (use either align or offset, not both)",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "relative": {
@@ -44636,6 +45229,7 @@
                             },
                             "verticalPosition": {
                               "description": "Vertical positioning (use either align or offset, not both)",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "relative": {
@@ -44705,6 +45299,7 @@
                             },
                             "wrap": {
                               "description": "Text wrapping configuration",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -44759,6 +45354,7 @@
                                 },
                                 "margins": {
                                   "description": "Distance from text margins",
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "top": {
@@ -45008,6 +45604,7 @@
                     },
                     "props": {
                       "description": "Table component props with column-based structure",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "borderColor": {
@@ -45017,6 +45614,7 @@
                               "type": "string"
                             },
                             {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "bottom": {
@@ -45047,6 +45645,7 @@
                               "type": "number"
                             },
                             {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "bottom": {
@@ -45081,6 +45680,7 @@
                             },
                             {
                               "description": "Selectively hide specific borders",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "bottom": {
@@ -45112,6 +45712,7 @@
                           ]
                         },
                         "cellDefaults": {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "color": {
@@ -45163,6 +45764,7 @@
                               ]
                             },
                             "font": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "family": {
@@ -45201,6 +45803,7 @@
                                   "type": "string"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -45231,6 +45834,7 @@
                                   "type": "number"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -45265,6 +45869,7 @@
                                   "type": "number"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -45299,6 +45904,7 @@
                           }
                         },
                         "headerCellDefaults": {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "color": {
@@ -45350,6 +45956,7 @@
                               ]
                             },
                             "font": {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "family": {
@@ -45388,6 +45995,7 @@
                                   "type": "string"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -45418,6 +46026,7 @@
                                   "type": "number"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -45452,6 +46061,7 @@
                                   "type": "number"
                                 },
                                 {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "bottom": {
@@ -45496,6 +46106,7 @@
                           "minItems": 1,
                           "type": "array",
                           "items": {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "width": {
@@ -45513,6 +46124,7 @@
                                 ]
                               },
                               "cellDefaults": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "color": {
@@ -45564,6 +46176,7 @@
                                     ]
                                   },
                                   "font": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "family": {
@@ -45602,6 +46215,7 @@
                                         "type": "string"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -45632,6 +46246,7 @@
                                         "type": "number"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -45666,6 +46281,7 @@
                                         "type": "number"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -45700,6 +46316,7 @@
                                 }
                               },
                               "header": {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "color": {
@@ -45751,6 +46368,7 @@
                                     ]
                                   },
                                   "font": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "family": {
@@ -45789,6 +46407,7 @@
                                         "type": "string"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -45819,6 +46438,7 @@
                                         "type": "number"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -45853,6 +46473,7 @@
                                         "type": "number"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -45899,6 +46520,7 @@
                               "cells": {
                                 "type": "array",
                                 "items": {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "color": {
@@ -45950,6 +46572,7 @@
                                       ]
                                     },
                                     "font": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "family": {
@@ -45988,6 +46611,7 @@
                                           "type": "string"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -46018,6 +46642,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -46052,6 +46677,7 @@
                                           "type": "number"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "bottom": {
@@ -46149,6 +46775,7 @@
                                 "type": "string"
                               },
                               {
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "text": {
@@ -46228,6 +46855,7 @@
                           "type": "array",
                           "items": {
                             "description": "Configuration for a single list level",
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "level": {
@@ -46512,6 +47140,7 @@
                               },
                               "indent": {
                                 "description": "Indentation configuration",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "left": {
@@ -46851,6 +47480,7 @@
                             },
                             {
                               "description": "Indentation configuration",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "left": {
@@ -47268,10 +47898,12 @@
                         },
                         "floating": {
                           "description": "Floating element properties",
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "horizontalPosition": {
                               "description": "Horizontal positioning (use either align or offset, not both)",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "relative": {
@@ -47341,6 +47973,7 @@
                             },
                             "verticalPosition": {
                               "description": "Vertical positioning (use either align or offset, not both)",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "relative": {
@@ -47410,6 +48043,7 @@
                             },
                             "wrap": {
                               "description": "Text wrapping configuration",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -47464,6 +48098,7 @@
                                 },
                                 "margins": {
                                   "description": "Distance from text margins",
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "top": {
@@ -47768,6 +48403,7 @@
                                         "type": "boolean"
                                       },
                                       "lineSpacing": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -47802,6 +48438,7 @@
                                         "required": ["type"]
                                       },
                                       "spacing": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "before": {
@@ -47815,6 +48452,7 @@
                                         }
                                       },
                                       "characterSpacing": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -47883,6 +48521,7 @@
                                       },
                                       {
                                         "description": "Line spacing configuration",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -48062,6 +48701,7 @@
                                         "type": "boolean"
                                       },
                                       "lineSpacing": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -48096,6 +48736,7 @@
                                         "required": ["type"]
                                       },
                                       "spacing": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "before": {
@@ -48109,6 +48750,7 @@
                                         }
                                       },
                                       "characterSpacing": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -48185,10 +48827,12 @@
                                   },
                                   "floating": {
                                     "description": "Floating text frame properties",
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "horizontalPosition": {
                                         "description": "Horizontal positioning (use either align or offset, not both)",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "relative": {
@@ -48250,6 +48894,7 @@
                                       },
                                       "verticalPosition": {
                                         "description": "Vertical positioning (use either align or offset, not both)",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "relative": {
@@ -48311,6 +48956,7 @@
                                       },
                                       "wrap": {
                                         "description": "Text wrapping configuration",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -48562,10 +49208,12 @@
                                   },
                                   "floating": {
                                     "description": "Floating element properties",
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "horizontalPosition": {
                                         "description": "Horizontal positioning (use either align or offset, not both)",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "relative": {
@@ -48635,6 +49283,7 @@
                                       },
                                       "verticalPosition": {
                                         "description": "Vertical positioning (use either align or offset, not both)",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "relative": {
@@ -48704,6 +49353,7 @@
                                       },
                                       "wrap": {
                                         "description": "Text wrapping configuration",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -48758,6 +49408,7 @@
                                           },
                                           "margins": {
                                             "description": "Distance from text margins",
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "top": {
@@ -49007,6 +49658,7 @@
                               },
                               "props": {
                                 "description": "Table component props with column-based structure",
+                                "additionalProperties": false,
                                 "type": "object",
                                 "properties": {
                                   "borderColor": {
@@ -49016,6 +49668,7 @@
                                         "type": "string"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -49046,6 +49699,7 @@
                                         "type": "number"
                                       },
                                       {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -49080,6 +49734,7 @@
                                       },
                                       {
                                         "description": "Selectively hide specific borders",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "bottom": {
@@ -49111,6 +49766,7 @@
                                     ]
                                   },
                                   "cellDefaults": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "color": {
@@ -49162,6 +49818,7 @@
                                         ]
                                       },
                                       "font": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "family": {
@@ -49200,6 +49857,7 @@
                                             "type": "string"
                                           },
                                           {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "bottom": {
@@ -49230,6 +49888,7 @@
                                             "type": "number"
                                           },
                                           {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "bottom": {
@@ -49264,6 +49923,7 @@
                                             "type": "number"
                                           },
                                           {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "bottom": {
@@ -49298,6 +49958,7 @@
                                     }
                                   },
                                   "headerCellDefaults": {
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "color": {
@@ -49349,6 +50010,7 @@
                                         ]
                                       },
                                       "font": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "family": {
@@ -49387,6 +50049,7 @@
                                             "type": "string"
                                           },
                                           {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "bottom": {
@@ -49417,6 +50080,7 @@
                                             "type": "number"
                                           },
                                           {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "bottom": {
@@ -49451,6 +50115,7 @@
                                             "type": "number"
                                           },
                                           {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "bottom": {
@@ -49495,6 +50160,7 @@
                                     "minItems": 1,
                                     "type": "array",
                                     "items": {
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "width": {
@@ -49512,6 +50178,7 @@
                                           ]
                                         },
                                         "cellDefaults": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "color": {
@@ -49563,6 +50230,7 @@
                                               ]
                                             },
                                             "font": {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "family": {
@@ -49601,6 +50269,7 @@
                                                   "type": "string"
                                                 },
                                                 {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "bottom": {
@@ -49631,6 +50300,7 @@
                                                   "type": "number"
                                                 },
                                                 {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "bottom": {
@@ -49665,6 +50335,7 @@
                                                   "type": "number"
                                                 },
                                                 {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "bottom": {
@@ -49699,6 +50370,7 @@
                                           }
                                         },
                                         "header": {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "color": {
@@ -49750,6 +50422,7 @@
                                               ]
                                             },
                                             "font": {
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "family": {
@@ -49788,6 +50461,7 @@
                                                   "type": "string"
                                                 },
                                                 {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "bottom": {
@@ -49818,6 +50492,7 @@
                                                   "type": "number"
                                                 },
                                                 {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "bottom": {
@@ -49852,6 +50527,7 @@
                                                   "type": "number"
                                                 },
                                                 {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "bottom": {
@@ -49898,6 +50574,7 @@
                                         "cells": {
                                           "type": "array",
                                           "items": {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "color": {
@@ -49949,6 +50626,7 @@
                                                 ]
                                               },
                                               "font": {
+                                                "additionalProperties": false,
                                                 "type": "object",
                                                 "properties": {
                                                   "family": {
@@ -49987,6 +50665,7 @@
                                                     "type": "string"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -50017,6 +50696,7 @@
                                                     "type": "number"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -50051,6 +50731,7 @@
                                                     "type": "number"
                                                   },
                                                   {
+                                                    "additionalProperties": false,
                                                     "type": "object",
                                                     "properties": {
                                                       "bottom": {
@@ -50148,6 +50829,7 @@
                                           "type": "string"
                                         },
                                         {
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "text": {
@@ -50227,6 +50909,7 @@
                                     "type": "array",
                                     "items": {
                                       "description": "Configuration for a single list level",
+                                      "additionalProperties": false,
                                       "type": "object",
                                       "properties": {
                                         "level": {
@@ -50511,6 +51194,7 @@
                                         },
                                         "indent": {
                                           "description": "Indentation configuration",
+                                          "additionalProperties": false,
                                           "type": "object",
                                           "properties": {
                                             "left": {
@@ -50850,6 +51534,7 @@
                                       },
                                       {
                                         "description": "Indentation configuration",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "left": {
@@ -51267,10 +51952,12 @@
                                   },
                                   "floating": {
                                     "description": "Floating element properties",
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "horizontalPosition": {
                                         "description": "Horizontal positioning (use either align or offset, not both)",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "relative": {
@@ -51340,6 +52027,7 @@
                                       },
                                       "verticalPosition": {
                                         "description": "Vertical positioning (use either align or offset, not both)",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "relative": {
@@ -51409,6 +52097,7 @@
                                       },
                                       "wrap": {
                                         "description": "Text wrapping configuration",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -51463,6 +52152,7 @@
                                           },
                                           "margins": {
                                             "description": "Distance from text margins",
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "top": {
@@ -51628,10 +52318,12 @@
                                   },
                                   "floating": {
                                     "description": "Floating element properties",
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "horizontalPosition": {
                                         "description": "Horizontal positioning (use either align or offset, not both)",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "relative": {
@@ -51701,6 +52393,7 @@
                                       },
                                       "verticalPosition": {
                                         "description": "Vertical positioning (use either align or offset, not both)",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "relative": {
@@ -51770,6 +52463,7 @@
                                       },
                                       "wrap": {
                                         "description": "Text wrapping configuration",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -51824,6 +52518,7 @@
                                           },
                                           "margins": {
                                             "description": "Distance from text margins",
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "top": {
@@ -51954,6 +52649,7 @@
                                         "type": "object",
                                         "properties": {
                                           "top": {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "style": {
@@ -51992,6 +52688,7 @@
                                             }
                                           },
                                           "right": {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "style": {
@@ -52030,6 +52727,7 @@
                                             }
                                           },
                                           "bottom": {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "style": {
@@ -52068,6 +52766,7 @@
                                             }
                                           },
                                           "left": {
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "style": {
@@ -52220,6 +52919,7 @@
                                                   "type": "boolean"
                                                 },
                                                 "lineSpacing": {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "type": {
@@ -52254,6 +52954,7 @@
                                                   "required": ["type"]
                                                 },
                                                 "spacing": {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "before": {
@@ -52267,6 +52968,7 @@
                                                   }
                                                 },
                                                 "characterSpacing": {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "type": {
@@ -52335,6 +53037,7 @@
                                                 },
                                                 {
                                                   "description": "Line spacing configuration",
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "type": {
@@ -52514,6 +53217,7 @@
                                                   "type": "boolean"
                                                 },
                                                 "lineSpacing": {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "type": {
@@ -52548,6 +53252,7 @@
                                                   "required": ["type"]
                                                 },
                                                 "spacing": {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "before": {
@@ -52561,6 +53266,7 @@
                                                   }
                                                 },
                                                 "characterSpacing": {
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "type": {
@@ -52637,10 +53343,12 @@
                                             },
                                             "floating": {
                                               "description": "Floating text frame properties",
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "horizontalPosition": {
                                                   "description": "Horizontal positioning (use either align or offset, not both)",
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "relative": {
@@ -52702,6 +53410,7 @@
                                                 },
                                                 "verticalPosition": {
                                                   "description": "Vertical positioning (use either align or offset, not both)",
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "relative": {
@@ -52763,6 +53472,7 @@
                                                 },
                                                 "wrap": {
                                                   "description": "Text wrapping configuration",
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "type": {
@@ -53014,10 +53724,12 @@
                                             },
                                             "floating": {
                                               "description": "Floating element properties",
+                                              "additionalProperties": false,
                                               "type": "object",
                                               "properties": {
                                                 "horizontalPosition": {
                                                   "description": "Horizontal positioning (use either align or offset, not both)",
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "relative": {
@@ -53087,6 +53799,7 @@
                                                 },
                                                 "verticalPosition": {
                                                   "description": "Vertical positioning (use either align or offset, not both)",
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "relative": {
@@ -53156,6 +53869,7 @@
                                                 },
                                                 "wrap": {
                                                   "description": "Text wrapping configuration",
+                                                  "additionalProperties": false,
                                                   "type": "object",
                                                   "properties": {
                                                     "type": {
@@ -53210,6 +53924,7 @@
                                                     },
                                                     "margins": {
                                                       "description": "Distance from text margins",
+                                                      "additionalProperties": false,
                                                       "type": "object",
                                                       "properties": {
                                                         "top": {
@@ -53386,10 +54101,12 @@
                         },
                         "floating": {
                           "description": "Floating element properties",
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "horizontalPosition": {
                               "description": "Horizontal positioning (use either align or offset, not both)",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "relative": {
@@ -53459,6 +54176,7 @@
                             },
                             "verticalPosition": {
                               "description": "Vertical positioning (use either align or offset, not both)",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "relative": {
@@ -53528,6 +54246,7 @@
                             },
                             "wrap": {
                               "description": "Text wrapping configuration",
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "type": {
@@ -53582,6 +54301,7 @@
                                 },
                                 "margins": {
                                   "description": "Distance from text margins",
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "top": {
@@ -53712,6 +54432,7 @@
                               "type": "object",
                               "properties": {
                                 "top": {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "style": {
@@ -53750,6 +54471,7 @@
                                   }
                                 },
                                 "right": {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "style": {
@@ -53788,6 +54510,7 @@
                                   }
                                 },
                                 "bottom": {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "style": {
@@ -53826,6 +54549,7 @@
                                   }
                                 },
                                 "left": {
+                                  "additionalProperties": false,
                                   "type": "object",
                                   "properties": {
                                     "style": {
@@ -53978,6 +54702,7 @@
                                         "type": "boolean"
                                       },
                                       "lineSpacing": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -54012,6 +54737,7 @@
                                         "required": ["type"]
                                       },
                                       "spacing": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "before": {
@@ -54025,6 +54751,7 @@
                                         }
                                       },
                                       "characterSpacing": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -54093,6 +54820,7 @@
                                       },
                                       {
                                         "description": "Line spacing configuration",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -54272,6 +55000,7 @@
                                         "type": "boolean"
                                       },
                                       "lineSpacing": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -54306,6 +55035,7 @@
                                         "required": ["type"]
                                       },
                                       "spacing": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "before": {
@@ -54319,6 +55049,7 @@
                                         }
                                       },
                                       "characterSpacing": {
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -54395,10 +55126,12 @@
                                   },
                                   "floating": {
                                     "description": "Floating text frame properties",
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "horizontalPosition": {
                                         "description": "Horizontal positioning (use either align or offset, not both)",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "relative": {
@@ -54460,6 +55193,7 @@
                                       },
                                       "verticalPosition": {
                                         "description": "Vertical positioning (use either align or offset, not both)",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "relative": {
@@ -54521,6 +55255,7 @@
                                       },
                                       "wrap": {
                                         "description": "Text wrapping configuration",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -54772,10 +55507,12 @@
                                   },
                                   "floating": {
                                     "description": "Floating element properties",
+                                    "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
                                       "horizontalPosition": {
                                         "description": "Horizontal positioning (use either align or offset, not both)",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "relative": {
@@ -54845,6 +55582,7 @@
                                       },
                                       "verticalPosition": {
                                         "description": "Vertical positioning (use either align or offset, not both)",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "relative": {
@@ -54914,6 +55652,7 @@
                                       },
                                       "wrap": {
                                         "description": "Text wrapping configuration",
+                                        "additionalProperties": false,
                                         "type": "object",
                                         "properties": {
                                           "type": {
@@ -54968,6 +55707,7 @@
                                           },
                                           "margins": {
                                             "description": "Distance from text margins",
+                                            "additionalProperties": false,
                                             "type": "object",
                                             "properties": {
                                               "top": {

--- a/skills/json-to-office/assets/schemas/theme.schema.json
+++ b/skills/json-to-office/assets/schemas/theme.schema.json
@@ -147,6 +147,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -181,6 +182,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -194,6 +196,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -253,6 +256,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -287,6 +291,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -300,6 +305,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -359,6 +365,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -393,6 +400,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -406,6 +414,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -465,6 +474,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -499,6 +509,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -512,6 +523,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -677,6 +689,7 @@
             "type": "boolean"
           },
           "lineSpacing": {
+            "additionalProperties": false,
             "type": "object",
             "properties": {
               "type": {
@@ -711,6 +724,7 @@
             "required": ["type"]
           },
           "spacing": {
+            "additionalProperties": false,
             "type": "object",
             "properties": {
               "before": {
@@ -724,6 +738,7 @@
             }
           },
           "characterSpacing": {
+            "additionalProperties": false,
             "type": "object",
             "properties": {
               "type": {
@@ -1338,6 +1353,7 @@
           },
           "indent": {
             "description": "Indentation configuration",
+            "additionalProperties": false,
             "type": "object",
             "properties": {
               "left": {
@@ -1405,6 +1421,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -1439,6 +1456,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -1452,6 +1470,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -2066,6 +2085,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -2130,6 +2150,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -2164,6 +2185,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -2177,6 +2199,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -2791,6 +2814,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -2855,6 +2879,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -2889,6 +2914,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -2902,6 +2928,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -3516,6 +3543,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -3580,6 +3608,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -3614,6 +3643,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -3627,6 +3657,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -4241,6 +4272,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -4305,6 +4337,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -4339,6 +4372,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -4352,6 +4386,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -4966,6 +5001,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -5030,6 +5066,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -5064,6 +5101,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -5077,6 +5115,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -5691,6 +5730,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -5755,6 +5795,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -5789,6 +5830,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -5802,6 +5844,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -6416,6 +6459,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -6480,6 +6524,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -6514,6 +6559,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -6527,6 +6573,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -7141,6 +7188,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -7205,6 +7253,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -7239,6 +7288,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -7252,6 +7302,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -7866,6 +7917,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -7930,6 +7982,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -7964,6 +8017,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -7977,6 +8031,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -8686,6 +8741,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -8750,6 +8806,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -8784,6 +8841,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -8797,6 +8855,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -9506,6 +9565,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -9570,6 +9630,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -9604,6 +9665,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -9617,6 +9679,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -10326,6 +10389,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -10390,6 +10454,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -10424,6 +10489,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -10437,6 +10503,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -11146,6 +11213,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -11210,6 +11278,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -11244,6 +11313,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -11257,6 +11327,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -11966,6 +12037,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -12030,6 +12102,7 @@
               "type": "boolean"
             },
             "lineSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -12064,6 +12137,7 @@
               "required": ["type"]
             },
             "spacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "before": {
@@ -12077,6 +12151,7 @@
               }
             },
             "characterSpacing": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "type": {
@@ -12786,6 +12861,7 @@
             },
             "indent": {
               "description": "Indentation configuration",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "left": {
@@ -12886,6 +12962,7 @@
                   "type": "boolean"
                 },
                 "lineSpacing": {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "type": {
@@ -12920,6 +12997,7 @@
                   "required": ["type"]
                 },
                 "spacing": {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "before": {
@@ -12933,6 +13011,7 @@
                   }
                 },
                 "characterSpacing": {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "type": {
@@ -13001,6 +13080,7 @@
                 },
                 {
                   "description": "Line spacing configuration",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "type": {
@@ -13109,6 +13189,7 @@
                   "type": "boolean"
                 },
                 "lineSpacing": {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "type": {
@@ -13143,6 +13224,7 @@
                   "required": ["type"]
                 },
                 "spacing": {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "before": {
@@ -13156,6 +13238,7 @@
                   }
                 },
                 "characterSpacing": {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "type": {
@@ -13232,10 +13315,12 @@
             },
             "floating": {
               "description": "Floating text frame properties",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "horizontalPosition": {
                   "description": "Horizontal positioning (use either align or offset, not both)",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "relative": {
@@ -13297,6 +13382,7 @@
                 },
                 "verticalPosition": {
                   "description": "Vertical positioning (use either align or offset, not both)",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "relative": {
@@ -13358,6 +13444,7 @@
                 },
                 "wrap": {
                   "description": "Text wrapping configuration",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "type": {
@@ -13538,10 +13625,12 @@
             },
             "floating": {
               "description": "Floating element properties",
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "horizontalPosition": {
                   "description": "Horizontal positioning (use either align or offset, not both)",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "relative": {
@@ -13611,6 +13700,7 @@
                 },
                 "verticalPosition": {
                   "description": "Vertical positioning (use either align or offset, not both)",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "relative": {
@@ -13680,6 +13770,7 @@
                 },
                 "wrap": {
                   "description": "Text wrapping configuration",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "type": {
@@ -13734,6 +13825,7 @@
                     },
                     "margins": {
                       "description": "Distance from text margins",
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "top": {
@@ -13944,6 +14036,7 @@
         },
         "table": {
           "description": "Table component props with column-based structure",
+          "additionalProperties": false,
           "type": "object",
           "properties": {
             "borderColor": {
@@ -13953,6 +14046,7 @@
                   "type": "string"
                 },
                 {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "bottom": {
@@ -13983,6 +14077,7 @@
                   "type": "number"
                 },
                 {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "bottom": {
@@ -14017,6 +14112,7 @@
                 },
                 {
                   "description": "Selectively hide specific borders",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "bottom": {
@@ -14048,6 +14144,7 @@
               ]
             },
             "cellDefaults": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "color": {
@@ -14099,6 +14196,7 @@
                   ]
                 },
                 "font": {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "family": {
@@ -14137,6 +14235,7 @@
                       "type": "string"
                     },
                     {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "bottom": {
@@ -14167,6 +14266,7 @@
                       "type": "number"
                     },
                     {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "bottom": {
@@ -14201,6 +14301,7 @@
                       "type": "number"
                     },
                     {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "bottom": {
@@ -14235,6 +14336,7 @@
               }
             },
             "headerCellDefaults": {
+              "additionalProperties": false,
               "type": "object",
               "properties": {
                 "color": {
@@ -14286,6 +14388,7 @@
                   ]
                 },
                 "font": {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "family": {
@@ -14324,6 +14427,7 @@
                       "type": "string"
                     },
                     {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "bottom": {
@@ -14354,6 +14458,7 @@
                       "type": "number"
                     },
                     {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "bottom": {
@@ -14388,6 +14493,7 @@
                       "type": "number"
                     },
                     {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "bottom": {
@@ -14432,6 +14538,7 @@
               "minItems": 1,
               "type": "array",
               "items": {
+                "additionalProperties": false,
                 "type": "object",
                 "properties": {
                   "width": {
@@ -14449,6 +14556,7 @@
                     ]
                   },
                   "cellDefaults": {
+                    "additionalProperties": false,
                     "type": "object",
                     "properties": {
                       "color": {
@@ -14500,6 +14608,7 @@
                         ]
                       },
                       "font": {
+                        "additionalProperties": false,
                         "type": "object",
                         "properties": {
                           "family": {
@@ -14538,6 +14647,7 @@
                             "type": "string"
                           },
                           {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "bottom": {
@@ -14568,6 +14678,7 @@
                             "type": "number"
                           },
                           {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "bottom": {
@@ -14602,6 +14713,7 @@
                             "type": "number"
                           },
                           {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "bottom": {
@@ -14636,6 +14748,7 @@
                     }
                   },
                   "header": {
+                    "additionalProperties": false,
                     "type": "object",
                     "properties": {
                       "color": {
@@ -14687,6 +14800,7 @@
                         ]
                       },
                       "font": {
+                        "additionalProperties": false,
                         "type": "object",
                         "properties": {
                           "family": {
@@ -14725,6 +14839,7 @@
                             "type": "string"
                           },
                           {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "bottom": {
@@ -14755,6 +14870,7 @@
                             "type": "number"
                           },
                           {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "bottom": {
@@ -14789,6 +14905,7 @@
                             "type": "number"
                           },
                           {
+                            "additionalProperties": false,
                             "type": "object",
                             "properties": {
                               "bottom": {
@@ -14835,6 +14952,7 @@
                   "cells": {
                     "type": "array",
                     "items": {
+                      "additionalProperties": false,
                       "type": "object",
                       "properties": {
                         "color": {
@@ -14886,6 +15004,7 @@
                           ]
                         },
                         "font": {
+                          "additionalProperties": false,
                           "type": "object",
                           "properties": {
                             "family": {
@@ -14924,6 +15043,7 @@
                               "type": "string"
                             },
                             {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "bottom": {
@@ -14954,6 +15074,7 @@
                               "type": "number"
                             },
                             {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "bottom": {
@@ -14988,6 +15109,7 @@
                               "type": "number"
                             },
                             {
+                              "additionalProperties": false,
                               "type": "object",
                               "properties": {
                                 "bottom": {
@@ -15286,6 +15408,7 @@
                     "type": "string"
                   },
                   {
+                    "additionalProperties": false,
                     "type": "object",
                     "properties": {
                       "text": {
@@ -15296,6 +15419,57 @@
                         "maximum": 8,
                         "description": "Nesting level for this item",
                         "type": "number"
+                      },
+                      "revision": {
+                        "description": "Tracked-change data: renders the component text as native Word revisions (accept/reject in Word)",
+                        "additionalProperties": false,
+                        "type": "object",
+                        "properties": {
+                          "author": {
+                            "description": "Revision author shown in Word (default: \"json-to-office\")",
+                            "type": "string"
+                          },
+                          "date": {
+                            "format": "date-time",
+                            "description": "Revision timestamp (ISO 8601). Defaults to the Unix epoch for deterministic output",
+                            "type": "string"
+                          },
+                          "segments": {
+                            "minItems": 1,
+                            "description": "Ordered text segments; concatenating equal+insert segments yields the new text, equal+delete the old text",
+                            "type": "array",
+                            "items": {
+                              "description": "A contiguous run of text sharing one revision state",
+                              "additionalProperties": false,
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "description": "Segment kind: 'equal' renders as normal text, 'insert' as a tracked insertion, 'delete' as a tracked deletion",
+                                  "anyOf": [
+                                    {
+                                      "const": "equal",
+                                      "type": "string"
+                                    },
+                                    {
+                                      "const": "insert",
+                                      "type": "string"
+                                    },
+                                    {
+                                      "const": "delete",
+                                      "type": "string"
+                                    }
+                                  ]
+                                },
+                                "text": {
+                                  "description": "Literal text of this segment (rendered without markdown)",
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["type", "text"]
+                            }
+                          }
+                        },
+                        "required": ["segments"]
                       }
                     },
                     "required": ["text"]
@@ -15314,6 +15488,7 @@
               "type": "array",
               "items": {
                 "description": "Configuration for a single list level",
+                "additionalProperties": false,
                 "type": "object",
                 "properties": {
                   "level": {
@@ -15598,6 +15773,7 @@
                   },
                   "indent": {
                     "description": "Indentation configuration",
+                    "additionalProperties": false,
                     "type": "object",
                     "properties": {
                       "left": {
@@ -15937,6 +16113,7 @@
                 },
                 {
                   "description": "Indentation configuration",
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "left": {


### PR DESCRIPTION
## Summary

Closes a correctness gap where the object/buffer generation path accepted malformed input and emitted a **silently-wrong** document. A typo'd prop like `lineSpacing: { name: 'single' }` (should be `{ type: 'single' }`) was quietly discarded, so the property went missing with no error — the playground rejected it, but `generateBuffer` did not.

Generation now runs the **same validation the playground already performs** and reports the error instead of producing corrupt output. Behavior is opt-out-able, so this lands as a fix with escape hatches rather than a hard break.

## What changed

- **Validate on generation, default on.** `generateDocumentFromJson` / `generateBufferFromJson` validate both string and object input and throw `JsonValidationError` on invalid documents. The plugin generator (`createDocumentGenerator().generate/generateBuffer/generateFile`) validates plugin-aware (standard + registered custom components) and throws `ComponentValidationError`. Opt out with `validation: { enabled: false }`.
- **Clearer messages for typo'd keys.** Component prop objects now reject unknown properties, so a misspelled key surfaces as `Unexpected property "<key>"` instead of being ignored. Highcharts `options` stays an open passthrough by design.
- **`allowUnknownFields` opt-out.** `validation: { allowUnknownFields: true }` strips unknown properties instead of rejecting them — a one-line migration aid. Required and typed fields are still enforced.
- **Single source of truth.** Runtime validation is driven through the same TypeBox-derived validator that backs the playground, so the public JSON Schema and the runtime check can't drift.

## Bugs fixed along the way

- The plugin generator **computed validation and discarded the result** — it never actually reported anything.
- `generator.validate()` **always returned `{ valid: true }`** (it relied on a throw that never happened).
- The plugin path **mistakenly rejected registered custom components** (validated structure against the standard schema). Now plugin-aware, so valid custom-component docs pass while standard-component typos inside them are still caught.

## Migration

Documents that previously generated with silently-dropped or unknown props will now throw by default. To keep the prior behavior:

- `validation: { allowUnknownFields: true }` — strip unknown keys
- `validation: { enabled: false }` — skip validation entirely

## Testing

- New: `core/__tests__/generation-validation.test.ts` and `plugin/__tests__/plugin-validation.test.ts` (15 tests) covering the repro, strict nested keys, `allowUnknownFields`, `enabled: false`, plugin custom-component pass/fail, and the `validate()` regression.
- Updated 5 pre-existing fixtures that encoded the silent-drop bug (root `title`, `headers`/`rows` table shape).
- `pnpm build`, full `test`, `typecheck`, `lint` all green; committed JSON schemas regenerated.

## Note

The typed in-memory `generateDocument(obj)` path **without** `$schema` stays unvalidated — it's the low-level entry for already-typed `ReportComponentDefinition`. All JSON/buffer entry points (what was reported) validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * JSON editor now collapses long string values (>200 chars) into clickable chips for improved readability; click to expand/collapse.

* **Improvements**
  * Document generation now validates JSON input by default, catching errors before processing instead of producing corrupt output.
  * Enhanced error messages for invalid component properties and unknown fields.
  * Added validation configuration options to allow bypassing strict validation when needed (`allowUnknownFields`, `validation.enabled`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->