### PR TITLE
fix(docx): validate standard nodes emitted by custom render()

### DIFF
--- a/.changeset/validate-render-output.md
+++ b/.changeset/validate-render-output.md
@@ -1,0 +1,9 @@
+---
+'@json-to-office/core-docx': patch
+---
+
+fix(docx): validate standard nodes emitted by a custom component's render()
+
+Generation validation (default on) only validated the input document, before component expansion. A standard component emitted by a custom component's `render()` was never schema-checked, so a document could generate "successfully" while its `standardDefinition` failed standard-schema validation (e.g. when pasted into the playground).
+
+Each `render()`'s emitted tree is now validated at the boundary with the same gate authored standard components pass through, and the error names the emitting component (`custom component '<name>' emitted invalid output — …`). Honors `validation.enabled` and `validation.allowUnknownFields` like the rest of the pipeline.

--- a/packages/core-docx/src/plugin/__tests__/infer-component-definition.test.ts
+++ b/packages/core-docx/src/plugin/__tests__/infer-component-definition.test.ts
@@ -318,7 +318,7 @@ describe('createComponent with TComponentDefinition type parameter', () => {
           render: async ({ props }) => [
             {
               name: 'statistic',
-              props: { value: String(props.value), label: props.label },
+              props: { number: String(props.value), description: props.label },
             },
           ],
         },

--- a/packages/core-docx/src/plugin/__tests__/plugin-validation.test.ts
+++ b/packages/core-docx/src/plugin/__tests__/plugin-validation.test.ts
@@ -141,3 +141,72 @@ describe('plugin generation validation', () => {
     expect(buffer.length).toBeGreaterThan(0);
   });
 });
+
+// A custom component whose render() emits a standard `statistic` node. The
+// emitted props are parameterised so each test can make them valid or invalid.
+// These nodes never exist in the input document, so the pre-expansion gate
+// cannot see them — only the render-boundary check does.
+function statBoxComponent(emittedProps: Record<string, unknown>) {
+  return createComponent({
+    name: 'stat-box',
+    versions: {
+      '1.0.0': createVersion({
+        propsSchema: Type.Object({}, { additionalProperties: false }),
+        description: 'Emits a standard statistic',
+        render: async (): Promise<ComponentDefinition[]> => [
+          { name: 'statistic', props: emittedProps },
+        ],
+      }),
+    },
+  });
+}
+
+describe('plugin render-output validation', () => {
+  it('throws when a custom render() emits an invalid standard component', async () => {
+    // `statistic` requires `number`/`description`; emit a bad extra prop instead.
+    const gen = createDocumentGenerator({ theme: testTheme }).addComponent(
+      statBoxComponent({ number: '42', description: 'Users', color: 'text' })
+    );
+    await expect(
+      gen.generateBuffer(docWith([{ name: 'stat-box', props: {} }]) as any)
+    ).rejects.toBeInstanceOf(ComponentValidationError);
+  });
+
+  it('attributes the error to the emitting component', async () => {
+    const gen = createDocumentGenerator({ theme: testTheme }).addComponent(
+      statBoxComponent({ number: '42', description: 'Users', color: 'text' })
+    );
+    try {
+      await gen.generateBuffer(
+        docWith([{ name: 'stat-box', props: {} }]) as any
+      );
+      throw new Error('expected generation to throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ComponentValidationError);
+      expect((e as ComponentValidationError).message).toContain(
+        "custom component 'stat-box' emitted invalid output"
+      );
+    }
+  });
+
+  it('accepts a custom render() that emits a valid standard component', async () => {
+    const gen = createDocumentGenerator({ theme: testTheme }).addComponent(
+      statBoxComponent({ number: '42', description: 'Active Users' })
+    );
+    const { buffer } = await gen.generateBuffer(
+      docWith([{ name: 'stat-box', props: {} }]) as any
+    );
+    expect(buffer.length).toBeGreaterThan(0);
+  });
+
+  it('validation.enabled=false lets invalid render output through', async () => {
+    const gen = createDocumentGenerator({ theme: testTheme }).addComponent(
+      statBoxComponent({ number: '42', description: 'Users', color: 'text' })
+    );
+    const { buffer } = await gen.generateBuffer(
+      docWith([{ name: 'stat-box', props: {} }]) as any,
+      { validation: { enabled: false } }
+    );
+    expect(buffer.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core-docx/src/plugin/createDocumentGenerator.ts
+++ b/packages/core-docx/src/plugin/createDocumentGenerator.ts
@@ -117,6 +117,9 @@ function createBuilderImpl<
     preserveSet: ReadonlySet<string> | undefined,
     warningsCollector: GenerationWarning[],
     resolvedTheme: ThemeConfig,
+    validateEmitted:
+      | ((emitted: ComponentDefinition[], componentLabel: string) => void)
+      | undefined,
     depth = 0
   ): Promise<{
     standard: ComponentDefinition[];
@@ -183,6 +186,7 @@ function createBuilderImpl<
               preserveSet,
               warningsCollector,
               resolvedTheme,
+              validateEmitted,
               depth + 1
             );
             nestedChildren = nested.standard;
@@ -218,12 +222,22 @@ function createBuilderImpl<
             Array.isArray(result) ? result : [result]
           ) as ComponentDefinition[];
 
+          // Validate the standard tree this render() emitted, applying the same
+          // schema gate authored standard components pass through up front. The
+          // pre-expansion pass never saw these nodes, so without this an invalid
+          // prop produced by a plugin would ride through into standardDefinition
+          // and only surface when that output is validated separately.
+          if (validateEmitted) {
+            validateEmitted(resultComponents, versionLabel);
+          }
+
           // Recursively process the result in case it contains more custom components
           const processedResult = await processDocumentComponents(
             resultComponents,
             preserveSet,
             warningsCollector,
             resolvedTheme,
+            validateEmitted,
             depth + 1
           );
           standardOut.push(...processedResult.standard);
@@ -266,6 +280,7 @@ function createBuilderImpl<
             preserveSet,
             warningsCollector,
             resolvedTheme,
+            validateEmitted,
             depth + 1
           );
           standardOut.push({
@@ -381,6 +396,34 @@ function createBuilderImpl<
         }
       }
 
+      // Re-apply the same gate to the tree each custom component's render()
+      // emits. The pre-expansion pass above only saw authored nodes, so a
+      // standard component produced by a plugin would otherwise reach
+      // standardDefinition unchecked. We validate the emitted nodes in their
+      // pre-normalization form — exactly how authored nodes are validated —
+      // by reusing the already-validated document props as a wrapper, so the
+      // only new errors come from the emitted children. Undefined when
+      // validation is disabled, which short-circuits the boundary check.
+      const validateEmitted =
+        vOpts.enabled === false
+          ? undefined
+          : (emitted: ComponentDefinition[], componentLabel: string) => {
+              const result = validateDocument(
+                { ...internalDocument, children: emitted },
+                state.components as unknown as CustomComponent<TSchema>[],
+                { allowUnknownFields: vOpts.allowUnknownFields }
+              );
+              if (!result.valid) {
+                throw new ComponentValidationError(
+                  (result.errors ?? []).map((e) => ({
+                    path: e.path ?? '',
+                    message: `custom component '${componentLabel}' emitted invalid output — ${e.message}`,
+                  })),
+                  emitted
+                );
+              }
+            };
+
       // Resolve theme per-document: customThemes → built-in → constructor fallback
       const baseThemeName = internalDocument.props.theme || 'minimal';
       const docTheme = resolveDocumentTheme(baseThemeName);
@@ -416,7 +459,8 @@ function createBuilderImpl<
         mode.doc.children || [],
         preserveSet,
         warnings,
-        modedTheme
+        modedTheme,
+        validateEmitted
       );
 
       // Create a new document definition with processed components


### PR DESCRIPTION
## Problem

Generation validation (default-on since 0.17.0) only validates the **input** document, *before* component expansion. A standard component emitted by a custom component's `render()` is never schema-validated. Result: a document generates "successfully" while its `standardDefinition` fails standard-schema validation (e.g. when pasted into the playground).

Identical node, two outcomes:
- standard `table` authored directly in input → caught by the pre-expansion gate.
- the same `table` emitted by a custom `render()` → never validated.

Reported against `@json-to-office/core-docx@0.17.0`.

## Fix

`generate()` builds a `validateEmitted` closure and threads it through every `processDocumentComponents` recursion. After each custom `render()` produces its node array, the emitted tree is validated **at the boundary** — before recursion/normalization, in the same pre-normalization form authored nodes are validated in.

- **Throws** `ComponentValidationError` instead of emitting an invalid `standardDefinition`.
- **Attributes** the failure: `custom component '<name>' emitted invalid output — <detail>`.
- Honors `validation.enabled` and `validation.allowUnknownFields` like the rest of the pipeline.

Reuses the existing plugin `validateDocument` with `{ ...internalDocument, children: emitted }` — the already-validated doc props act as the wrapper, so the only new errors come from the emitted children.

## Tests

- 4 new cases in `plugin-validation.test.ts`: throws on invalid render output, attributes to the emitting component, accepts valid render output, and `enabled:false` escape hatch.
- Fixed `infer-component-definition.test.ts`, which was asserting the old buggy pass-through (a custom `stats` component emitting a standard `statistic` with `value`/`label` instead of the required `number`/`description`).
- Full suite: **439 core-docx tests pass; typecheck clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DOCX generation validation to validate output from custom components, ensuring consistency with standard validation rules. Error messages now indicate which custom component produced invalid output.

* **Tests**
  * Added test coverage for custom component output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->