### PR TITLE
fix(playground): expand collapsed long-string sentinels for render and clipboard

### DIFF
--- a/.changeset/collapse-sentinel-leak-render.md
+++ b/.changeset/collapse-sentinel-leak-render.md
@@ -1,0 +1,11 @@
+---
+'@json-to-office/jto': patch
+---
+
+fix(playground): expand collapsed long-string sentinels before preview/build
+
+The long-string collapser rewrites the Monaco model text, replacing a value's hidden middle with a `§jtoc:<id>§` sentinel that only `toStorageValue()` restores. The save path called it, but the Run/preview path (`preview:flushAndBuild`) read `editor.getValue()` raw at three points, leaking sentinels into the rendered document (and persisting them back into the store).
+
+The per-editor `toStorageValue` reconstructor is now exposed on the editor refs store and applied to every live-text read feeding `saveDocument`, `updateTheme`, and `buildDocument`.
+
+Copy and cut were leaking the sentinel too — the hidden `§jtoc:<id>§` is real model text, so a selection crossing a collapsed chip put the sentinel on the clipboard. `copy`/`cut` are now intercepted in the capture phase and the clipboard is rewritten with the reconstructed value (cut also deletes the selection).

--- a/packages/jto/src/client/components/json-editor/editor-monaco-json.tsx
+++ b/packages/jto/src/client/components/json-editor/editor-monaco-json.tsx
@@ -107,8 +107,9 @@ function EditorMonacoJson({
     editorRef.current = editor;
     monacoRef.current = monaco;
 
-    // Register editor in the refs store
-    registerEditor(name, editor, monaco);
+    // Register editor in the refs store. Pass the sentinel reconstructor so any
+    // consumer reading live text (preview/build) expands collapsed strings.
+    registerEditor(name, editor, monaco, toStorageValue);
     setActiveEditor(name);
 
     // Ensure the model's language is set to JSON for schema validation

--- a/packages/jto/src/client/components/playground/editor.tsx
+++ b/packages/jto/src/client/components/playground/editor.tsx
@@ -833,7 +833,9 @@ function EditorComponent() {
         const hasPendingDiff =
           documentsStore.getState().pendingDiffs[editorRef.documentName];
         if (!hasPendingDiff) {
-          const liveText = editorRef.editor.getValue();
+          const liveText = editorRef.toStorageValue(
+            editorRef.editor.getValue()
+          );
           documentsStore
             .getState()
             .saveDocument(editorRef.documentName, liveText);
@@ -848,7 +850,7 @@ function EditorComponent() {
         if (allDtypes[doc.name] === 'application/json+theme') {
           const ref = useEditorRefsStore.getState().getEditor(doc.name);
           if (ref) {
-            const liveText = ref.editor.getValue();
+            const liveText = ref.toStorageValue(ref.editor.getValue());
             const existing = themesStore.getState().customThemes[doc.name];
             if (!existing || existing.content !== liveText) {
               themesStore.getState().updateTheme(doc.name, liveText);
@@ -899,7 +901,7 @@ function EditorComponent() {
           const doc = pending
             ? { ...freshDoc, text: pending.modified }
             : ref
-              ? { ...freshDoc, text: ref.editor.getValue() }
+              ? { ...freshDoc, text: ref.toStorageValue(ref.editor.getValue()) }
               : freshDoc;
           getDocumentVersionRef.current(doc.name);
           // Bypass cache only when a theme was updated during this flush

--- a/packages/jto/src/client/lib/monaco-collapse-strings.ts
+++ b/packages/jto/src/client/lib/monaco-collapse-strings.ts
@@ -216,6 +216,17 @@ export function installLongStringCollapser(
   const makeSentinel = (id: number) =>
     `${SENTINEL_PREFIX}${id}${SENTINEL_SUFFIX}`;
 
+  /** Expand any collapsed sentinels in `text` back to their original middles. */
+  function reconstruct(text: string): string {
+    if (tracked.size === 0) return text;
+    let out = text;
+    for (const t of tracked.values()) {
+      if (t.expanded) continue; // already full text in the model
+      out = out.split(makeSentinel(t.id)).join(t.middle);
+    }
+    return out;
+  }
+
   function collapsedDecoration(
     middleLen: number
   ): editor.IModelDecorationOptions {
@@ -403,6 +414,42 @@ export function installLongStringCollapser(
     })
   );
 
+  // Copy/cut must yield the REAL value, not the hidden `§jtoc:<id>§` sentinel
+  // (it lives in the model text — CSS only hides it). Intercept in the capture
+  // phase so we run before Monaco's own clipboard handler, then fully take over
+  // (set the reconstructed text, and for cut delete the selection ourselves).
+  const handleClipboard = (e: ClipboardEvent) => {
+    if (tracked.size === 0) return;
+    const model = editorInstance.getModel();
+    const selection = editorInstance.getSelection();
+    if (!model || !selection || selection.isEmpty()) return;
+    const selected = model.getValueInRange(selection);
+    if (!selected.includes(SENTINEL_PREFIX)) return;
+    const reconstructed = reconstruct(selected);
+    if (reconstructed === selected) return;
+    e.clipboardData?.setData('text/plain', reconstructed);
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    if (e.type === 'cut') {
+      // Real content change — leave `applying` unset so the edit is persisted.
+      editorInstance.executeEdits('jto-collapse-cut', [
+        { range: selection, text: '' },
+      ]);
+    }
+  };
+
+  const domNode = editorInstance.getDomNode();
+  if (domNode) {
+    domNode.addEventListener('copy', handleClipboard, true);
+    domNode.addEventListener('cut', handleClipboard, true);
+    disposables.push({
+      dispose() {
+        domNode.removeEventListener('copy', handleClipboard, true);
+        domNode.removeEventListener('cut', handleClipboard, true);
+      },
+    });
+  }
+
   return {
     recollapse() {
       const model = editorInstance.getModel();
@@ -458,13 +505,7 @@ export function installLongStringCollapser(
     },
 
     toStorageValue(modelText: string): string {
-      if (tracked.size === 0) return modelText;
-      let out = modelText;
-      for (const t of tracked.values()) {
-        if (t.expanded) continue; // already full text in the model
-        out = out.split(makeSentinel(t.id)).join(t.middle);
-      }
-      return out;
+      return reconstruct(modelText);
     },
 
     isApplyingEdits() {

--- a/packages/jto/src/client/store/editor-refs-store.ts
+++ b/packages/jto/src/client/store/editor-refs-store.ts
@@ -11,6 +11,13 @@ export interface EditorReference {
   editor: MonacoEditorType.IStandaloneCodeEditor;
   monaco: Monaco;
   documentName: string;
+  /**
+   * Reconstruct the full document text from the live model text, expanding any
+   * collapsed long-string sentinels (`§jtoc:<id>§`) back to their real values.
+   * Any consumer that reads `editor.getValue()` for persistence or rendering
+   * MUST pipe it through this, or sentinels leak into the output.
+   */
+  toStorageValue: (modelText: string) => string;
 }
 
 interface EditorRefsState {
@@ -22,7 +29,8 @@ interface EditorRefsActions {
   registerEditor: (
     documentName: string,
     editor: MonacoEditorType.IStandaloneCodeEditor,
-    monaco: Monaco
+    monaco: Monaco,
+    toStorageValue?: (modelText: string) => string
   ) => void;
   unregisterEditor: (documentName: string) => void;
   setActiveEditor: (documentName: string | null) => void;
@@ -36,10 +44,15 @@ export const useEditorRefsStore = create<EditorRefsStore>((set, get) => ({
   editors: new Map(),
   activeEditorName: null,
 
-  registerEditor: (documentName, editor, monaco) => {
+  registerEditor: (documentName, editor, monaco, toStorageValue) => {
     set((state) => {
       const newEditors = new Map(state.editors);
-      newEditors.set(documentName, { editor, monaco, documentName });
+      newEditors.set(documentName, {
+        editor,
+        monaco,
+        documentName,
+        toStorageValue: toStorageValue ?? ((text) => text),
+      });
       return { editors: newEditors };
     });
   },


### PR DESCRIPTION
## Problem

The long-string collapser rewrites the Monaco model text, swapping a value's hidden middle for a `§jtoc:<id>§` sentinel that only `toStorageValue()` restores. Two consumers read the model text raw and leaked the sentinel into output:

- **Preview/build** — `preview:flushAndBuild` read `editor.getValue()` at three points, feeding sentinels into `saveDocument`, `updateTheme`, and `buildDocument`. Result: `§jtoc:104§` rendered straight into the generated document (and got persisted back into the store).
- **Copy/cut** — the sentinel is real model text (CSS only hides it), so a selection crossing a collapsed chip put the literal `§jtoc:<id>§` on the clipboard.

## Fix

- Expose the per-editor `toStorageValue` reconstructor on the editor refs store and apply it to every live-text read feeding `saveDocument` / `updateTheme` / `buildDocument`.
- Intercept `copy`/`cut` on the editor DOM node in the capture phase (before Monaco's own clipboard handler) and rewrite the clipboard with the reconstructed value; cut also deletes the selection.
- Refactor `toStorageValue` to share a single `reconstruct()` helper.

## Notes

- Includes a `@json-to-office/jto` patch changeset.

## Verification

- `tsc --noEmit` passes; pre-commit eslint/prettier clean.
- Manual check suggested: collapse a long string → Run → confirm real text renders (not `§jtoc:…§`); select-all + copy/paste and cut a collapsed value → confirm full value on clipboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display artifacts appearing in rendered long strings within the playground.
  * Fixed unwanted characters being persisted to storage when saving long strings.
  * Fixed copy and cut operations including incorrect characters from collapsed strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->