### PR TITLE
fix(docx): honor lineSpacing and spacing on header/footer paragraphs

### DIFF
--- a/.changeset/header-footer-linespacing.md
+++ b/.changeset/header-footer-linespacing.md
@@ -1,0 +1,9 @@
+---
+'@json-to-office/core-docx': patch
+---
+
+fix(docx): honor lineSpacing and spacing on header/footer paragraphs
+
+Paragraph modules in a section `header`/`footer` were rendered by a separate, minimal code path that only read font (family/size/bold/italic/color), text, and alignment. Any `font.lineSpacing` or paragraph `spacing` (before/after) set on a header/footer paragraph was silently dropped — it never reached the emitted OOXML.
+
+Header/footer paragraphs now render through the same `createText` primitive as body paragraphs, so they honor `lineSpacing`, `spacing`, and the full font set (also `underline`, `boldColor`, `fontWeight`). Run-level font/size/color resolution against the theme's Normal style is preserved, so existing documents render unchanged unless they set these previously-ignored properties. Markdown link syntax in header/footer text is now parsed into hyperlinks, matching body paragraphs.

--- a/packages/core-docx/src/__tests__/header-footer-spacing.test.ts
+++ b/packages/core-docx/src/__tests__/header-footer-spacing.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression: paragraph `lineSpacing` and `spacing` (before/after) must reach
+ * section header/footer paragraphs. These props used to be silently dropped
+ * because the header/footer renderer hand-built paragraphs instead of using the
+ * shared text primitive. See renderHeaderFooterComponents in core/render.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { generateBufferFromJson } from '../core/generator';
+
+/** Concatenate every zip part whose name matches `re` (e.g. all header*.xml). */
+async function readParts(buf: Buffer, re: RegExp): Promise<string> {
+  const zip = await JSZip.loadAsync(buf);
+  const parts = await Promise.all(zip.file(re).map((f) => f.async('string')));
+  if (parts.length === 0) throw new Error(`no parts matched ${re}`);
+  return parts.join('\n');
+}
+
+describe('header/footer paragraph spacing', () => {
+  it('applies lineSpacing and spacing to a section header paragraph', async () => {
+    const buf = await generateBufferFromJson({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          props: {
+            header: [
+              {
+                name: 'paragraph',
+                props: {
+                  text: 'Header text',
+                  font: { lineSpacing: { type: 'double' } }, // 480 twips, auto
+                  spacing: { before: 8, after: 10 }, // 160 / 200 twips
+                },
+              },
+            ],
+          },
+          children: [{ name: 'paragraph', props: { text: 'Body' } }],
+        },
+      ],
+    } as any);
+
+    const headerXml = await readParts(buf, /word\/header\d+\.xml/);
+    // Sanity: we are reading the right part.
+    expect(headerXml).toContain('Header text');
+    // lineSpacing: double -> w:line="480" w:lineRule="auto"
+    expect(headerXml).toMatch(/w:line="480"/);
+    expect(headerXml).toMatch(/w:lineRule="auto"/);
+    // spacing before/after (points -> twips, *20)
+    expect(headerXml).toMatch(/w:before="160"/);
+    expect(headerXml).toMatch(/w:after="200"/);
+  });
+
+  it('applies lineSpacing to a section footer paragraph', async () => {
+    const buf = await generateBufferFromJson({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          props: {
+            footer: [
+              {
+                name: 'paragraph',
+                props: {
+                  text: 'Footer text',
+                  font: { lineSpacing: { type: 'exactly', value: 18 } }, // 360 twips, exact
+                },
+              },
+            ],
+          },
+          children: [{ name: 'paragraph', props: { text: 'Body' } }],
+        },
+      ],
+    } as any);
+
+    const footerXml = await readParts(buf, /word\/footer\d+\.xml/);
+    expect(footerXml).toContain('Footer text');
+    // lineSpacing: exactly 18pt -> w:line="360" w:lineRule="exact"
+    expect(footerXml).toMatch(/w:line="360"/);
+    expect(footerXml).toMatch(/w:lineRule="exact"/);
+  });
+});

--- a/packages/core-docx/src/core/render.ts
+++ b/packages/core-docx/src/core/render.ts
@@ -47,8 +47,6 @@ import {
 } from '../types';
 import { ThemeConfig } from '../styles';
 import { createWordStyles } from '../styles/themeToDocxAdapter';
-import { parseTextWithDecorators } from '../utils/textParser';
-import { resolveColor } from '../styles/utils/colorUtils';
 import { resolveFontFamily } from '../styles/utils/styleHelpers';
 import { getPageSetup } from '../styles/utils/layoutUtils';
 import { ProcessedDocument, createRenderContext } from './structure';
@@ -73,7 +71,11 @@ import {
   renderVisualComponent,
   renderTextBoxComponent,
 } from '../components';
-import { createHeaderElement, createFooterElement } from './content';
+import {
+  createText,
+  createHeaderElement,
+  createFooterElement,
+} from './content';
 import { mapFloatingOptions } from '../utils/docxImagePositioning';
 
 /**
@@ -282,37 +284,38 @@ async function renderHeaderFooterComponents(
   for (const component of activeComponents) {
     if (isParagraphComponent(component)) {
       const textComp = component as ParagraphComponentDefinition;
+      const font = textComp.props.font;
 
-      // Use theme's normal style for header/footer text since header/footer styles are removed
+      // Header/footer text has no dedicated style, so unspecified font
+      // properties resolve against the theme's Normal style.
       const normalStyle = getNormalStyle(theme);
 
-      // Create text style using theme's normal styling
-      const textStyle = {
-        font:
-          textComp.props.font?.family ||
-          resolveFontFamily(theme, normalStyle.font) ||
-          getThemeFonts(theme).body.family,
-        size:
-          ((textComp.props.font?.size ?? normalStyle.size ?? 11) as number) * 2, // Convert to half-points
-        bold: textComp.props.font?.bold ?? false,
-        italics: textComp.props.font?.italic ?? false,
-        color:
-          (textComp.props.font?.color &&
-            resolveColor(textComp.props.font.color, theme)) ||
-          (normalStyle.color && resolveColor(normalStyle.color, theme)) ||
-          getThemeColors(theme).textPrimary,
-      } as const;
-
-      // Use parseTextWithDecorators to support rich text formatting
-      const textRuns = parseTextWithDecorators(textComp.props.text, textStyle);
-
+      // Render through the shared paragraph primitive (same as body
+      // paragraphs) so headers/footers honor lineSpacing, spacing
+      // (before/after) and the full font set instead of silently dropping
+      // them. When the component omits lineSpacing/spacing, createText leaves
+      // them unset and the Normal style supplies the baseline.
       elements.push(
-        new Paragraph({
-          children: textRuns,
-          alignment: textComp.props.alignment
-            ? getAlignment(textComp.props.alignment)
-            : undefined,
+        createText(textComp.props.text, theme, themeName, {
           style: 'Normal',
+          alignment: textComp.props.alignment,
+          // Resolve explicit run styling against the Normal style, preserving
+          // prior header/footer rendering for these properties.
+          fontFamily:
+            font?.family ||
+            resolveFontFamily(theme, normalStyle.font) ||
+            getThemeFonts(theme).body.family,
+          fontSize: (font?.size ?? normalStyle.size ?? 11) as number,
+          // Pass the raw color/token; createText resolves it. Fall back to the
+          // Normal style color, then the theme's primary text color.
+          fontColor: font?.color || normalStyle.color || 'textPrimary',
+          bold: font?.bold ?? false,
+          italic: font?.italic ?? false,
+          underline: font?.underline,
+          fontWeight: (font as { fontWeight?: number } | undefined)?.fontWeight,
+          boldColor: textComp.props.boldColor,
+          spacing: textComp.props.spacing,
+          lineSpacing: font?.lineSpacing,
         })
       );
     } else if (isImageComponent(component)) {


### PR DESCRIPTION
## Problem

Paragraph modules in a section `header`/`footer` were rendered by a separate, minimal code path (`renderHeaderFooterComponents` in `core/render.ts`) that read only font (family/size/bold/italic/color), text, and alignment. Any `font.lineSpacing` or paragraph `spacing` (before/after) set on a header/footer paragraph was **silently dropped** — it never reached the emitted OOXML. The body paragraph path didn't have this gap because it routes through the shared `createText` primitive.

## Fix

Route header/footer paragraphs through that same `createText` primitive — the canonical place that already maps `lineSpacing` → OOXML, `spacing`, and the full font set. This deletes the duplicated impoverished renderer so the two paths can't drift again.

- **Visuals preserved:** kept the explicit Normal-style font/size/color resolution; pass the *raw* color/token so `createText`'s `resolveColor` works (it returns bare hex and throws on a re-fed bare hex).
- Dropped now-unused `parseTextWithDecorators` / `resolveColor` imports; added `createText`.

Verified OOXML now emits `<w:spacing w:before="160" w:after="200" w:line="480" w:lineRule="auto"/>` on header paragraphs, with run font/size/color and `<w:jc>` / `Normal` style intact.

## Behavior changes (all net-improvements over silent-drop)

Previously dropped, now honored on header/footer paragraphs: `lineSpacing`, `spacing` (before/after), `underline`, `boldColor`, `fontWeight`. Markdown link syntax (`[text](url)`) in header/footer text is now parsed into hyperlinks, matching body paragraphs.

Existing documents render unchanged unless they set one of these previously-ignored properties.

## Test

Adds `header-footer-spacing.test.ts` — unzips the generated docx and asserts the spacing/lineSpacing attributes land in `header*.xml` / `footer*.xml`. Confirmed it **fails on `main`, passes with the fix**.

`tsc --noEmit` clean; full `core-docx` suite **441 passed (38 files)**.

> Note: a stale `@json-to-office/shared-docx` `dist` (unrelated to this change) surfaces as failing plugin/validation tests + 2 tsc errors until `pnpm --filter @json-to-office/shared-docx build` is run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Header and footer paragraphs now properly honor line spacing and paragraph spacing settings.
  * Header and footer text styling now emits the full font set, including underline, bold color, and font weight.

* **New Features**
  * Markdown link syntax inside header and footer text is now parsed into hyperlinks, matching body paragraph behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->