### PR TITLE
fix(docx): deep-validate props in nested containers, header/footer, and table cells

### DIFF
--- a/.changeset/cli-deep-validation-parity.md
+++ b/.changeset/cli-deep-validation-parity.md
@@ -1,0 +1,11 @@
+---
+'@json-to-office/shared-docx': patch
+---
+
+fix(docx): validate component props in every nested container and in header/footer regions
+
+The CLI/library document validator (`validate.jsonDocument` / `validate.document`) only re-validated the root's direct children and one level of `section` children. Component props nested inside `text-box`/`columns` children (any depth) and inside section `header`/`footer` regions — which the section schema types loosely as an array of `Type.Any()` (or the `'linkToPrevious'` literal) — were never deep-checked. As a result a document could pass `jto docx validate` (even `--strict`) while still violating the schema (e.g. `boldColor` placed inside `font`, `font.size` above the 72 pt cap, a scalar `characterSpacing`), whereas the in-editor (Monaco) validator — which runs the generated JSON Schema over the whole tree — flagged all of them.
+
+The deep validator now walks the entire component tree: every container's shared `children` field to any depth, the `header`/`footer` paragraph regions under `props`, and the component content nested inside `table` cells and column headers. A non-array `children` on any nested container (`section`/`columns`/`text-box`) is now reported at its own path too — previously only a `section`'s was, so a deeper malformed subtree could slip through as valid. `header`/`footer` entries are also checked for component structure (not just props), matching the editor's whole-tree schema, which resolves those regions to the component union even though the static section schema types them as `Type.Any()`. No schema or rule changed — only validation coverage.
+
+This closes the table-cell gap as well: the static cell-content schema types cell `props` as `additionalProperties: true`, so a capped prop deep in a `table` cell (e.g. `font.size` over the cap) used to pass the CLI while the editor's recursive schema rejected it; the walk now re-validates each cell/header content component against its real schema, to any nesting depth (e.g. a table inside a table cell). `list` props (including item formatting) were already covered by the list's own props schema. The CLI and the playground now report the same errors at the same paths.

--- a/packages/shared-docx/src/__tests__/document-validator.test.ts
+++ b/packages/shared-docx/src/__tests__/document-validator.test.ts
@@ -210,3 +210,456 @@ describe('image source mutual exclusivity', () => {
     );
   });
 });
+
+describe('deep prop validation in nested containers and regions', () => {
+  it('flags a bad font prop inside a text-box child (any depth)', () => {
+    const result = validate.document({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          props: {},
+          children: [
+            {
+              name: 'text-box',
+              props: { width: 200, height: 100 },
+              // font.size is capped at 72; deep inside a text-box this was
+              // silently accepted before the whole-tree walk.
+              children: [
+                {
+                  name: 'paragraph',
+                  props: { text: 'big', font: { size: 200 } },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(
+      (result.errors ?? []).some(
+        (e) => e.path.includes('/font/size') && /72/.test(e.message)
+      )
+    ).toBe(true);
+  });
+
+  it('flags a bad font prop inside a columns child', () => {
+    const result = validate.document({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          props: {},
+          children: [
+            {
+              name: 'columns',
+              props: { columns: 2 },
+              children: [
+                {
+                  name: 'paragraph',
+                  // characterSpacing must be an object, not a number
+                  props: { text: 'x', font: { characterSpacing: 0 } },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(
+      (result.errors ?? []).some((e) =>
+        e.path.includes('/font/characterSpacing')
+      )
+    ).toBe(true);
+  });
+
+  it('flags an unknown font property in a section header/footer region', () => {
+    const result = validate.document({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          props: {
+            // header/footer are Type.Array(Type.Any()) on the section schema,
+            // so their entries' props are only caught by the deep walk.
+            header: [
+              {
+                name: 'paragraph',
+                props: { text: 'h', font: { size: 8, boldColor: '#000000' } },
+              },
+            ],
+            footer: [
+              {
+                name: 'paragraph',
+                props: { text: 'f', font: { size: 8, boldColor: '#000000' } },
+              },
+            ],
+          },
+          children: [{ name: 'paragraph', props: { text: 'body' } }],
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    const headerHit = (result.errors ?? []).some((e) =>
+      e.path.includes('/props/header/0/props/font/boldColor')
+    );
+    const footerHit = (result.errors ?? []).some((e) =>
+      e.path.includes('/props/footer/0/props/font/boldColor')
+    );
+    expect(headerHit).toBe(true);
+    expect(footerHit).toBe(true);
+  });
+
+  it('accepts a clean deeply-nested document', () => {
+    const result = validate.document({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          props: {
+            header: [
+              { name: 'paragraph', props: { text: 'h', font: { size: 8 } } },
+            ],
+          },
+          children: [
+            {
+              name: 'text-box',
+              props: { width: 200, height: 100 },
+              children: [
+                {
+                  name: 'paragraph',
+                  props: { text: 'ok', font: { size: 12 } },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.errors ?? []).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('flags non-array children on a nested container (no silent valid)', () => {
+    const result = validate.document({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        // A nested container with a non-array `children` used to be caught by a
+        // `section`-only guard. The whole-tree walk must keep reporting it —
+        // otherwise TypeBox's stripped catch-all leaves zero errors and the
+        // document flips back to valid.
+        { name: 'section', props: {}, children: 'not-an-array' },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(
+      (result.errors ?? []).some(
+        (e) =>
+          e.path === '/children/0/children' &&
+          /must be an array/i.test(e.message)
+      )
+    ).toBe(true);
+  });
+
+  it('flags non-array children on a deeply nested container', () => {
+    const result = validate.document({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          props: {},
+          children: [
+            {
+              name: 'text-box',
+              props: { width: 200, height: 100 },
+              children: 'nope',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(
+      (result.errors ?? []).some(
+        (e) => e.path === '/children/0/children/0/children'
+      )
+    ).toBe(true);
+  });
+
+  it('reports an unknown component in a header at a well-formed /name path', () => {
+    const result = validate.document({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          // The region path carries an inner `/props` segment
+          // (`/props/header/0/props`); the unknown-component error must point at
+          // the entry's `/name`, not mangle the earlier `/props`.
+          props: { header: [{ name: 'boguscomp', props: {} }] },
+          children: [{ name: 'paragraph', props: { text: 'b' } }],
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(
+      (result.errors ?? []).some(
+        (e) =>
+          e.path === '/children/0/props/header/0/name' &&
+          /unknown component/i.test(e.message)
+      )
+    ).toBe(true);
+  });
+
+  it('flags a non-component entry in a header region (whole-tree parity)', () => {
+    const result = validate.document({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          // The static section schema types header as Type.Any(), but the
+          // editor's whole-tree schema resolves it to the component union, so a
+          // non-object entry must be reported for parity.
+          props: { header: [42] },
+          children: [{ name: 'paragraph', props: { text: 'b' } }],
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(
+      (result.errors ?? []).some(
+        (e) =>
+          e.path === '/children/0/props/header/0' &&
+          /must be an object/i.test(e.message)
+      )
+    ).toBe(true);
+  });
+
+  it('flags a footer entry missing its name (whole-tree parity)', () => {
+    const result = validate.document({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          props: { footer: [{ props: {} }] },
+          children: [{ name: 'paragraph', props: { text: 'b' } }],
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(
+      (result.errors ?? []).some(
+        (e) =>
+          e.path === '/children/0/props/footer/0/name' &&
+          /missing required field "name"/i.test(e.message)
+      )
+    ).toBe(true);
+  });
+
+  it('flags a bad prop on a component inside a table cell', () => {
+    const result = validate.document({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          props: {},
+          children: [
+            {
+              name: 'table',
+              // Cell content nests components under `props`, and the static
+              // table schema accepts any cell-content props object — so a
+              // capped prop deep in a cell was silently accepted by the CLI
+              // while the editor's recursive schema rejected it.
+              props: {
+                columns: [
+                  {
+                    cells: [
+                      {
+                        content: {
+                          name: 'paragraph',
+                          props: { text: 'x', font: { size: 200 } },
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(
+      (result.errors ?? []).some(
+        (e) =>
+          e.path ===
+            '/children/0/children/0/props/columns/0/cells/0/content/props/font/size' &&
+          /72/.test(e.message)
+      )
+    ).toBe(true);
+  });
+
+  it('flags a bad prop on a component in a table column header', () => {
+    const result = validate.document({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          props: {},
+          children: [
+            {
+              name: 'table',
+              props: {
+                columns: [
+                  {
+                    header: {
+                      content: {
+                        name: 'paragraph',
+                        props: { text: 'h', font: { boldColor: '#000000' } },
+                      },
+                    },
+                    cells: [{ content: 'plain' }],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(
+      (result.errors ?? []).some((e) =>
+        e.path.includes('/props/columns/0/header/content/props/font/boldColor')
+      )
+    ).toBe(true);
+  });
+
+  it('walks components nested in a table cell to any depth', () => {
+    const result = validate.document({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          props: {},
+          children: [
+            {
+              name: 'table',
+              props: {
+                columns: [
+                  {
+                    cells: [
+                      {
+                        // table nested inside a table cell
+                        content: {
+                          name: 'table',
+                          props: {
+                            columns: [
+                              {
+                                cells: [
+                                  {
+                                    content: {
+                                      name: 'paragraph',
+                                      props: { text: 'z', font: { size: 200 } },
+                                    },
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(
+      (result.errors ?? []).some(
+        (e) =>
+          e.path.endsWith('/content/props/font/size') && /72/.test(e.message)
+      )
+    ).toBe(true);
+  });
+
+  it('does not invent errors on clean table cell content', () => {
+    // A broken sibling forces the whole-tree walk to run; the clean table
+    // (component content, plain-string content, and a column header) must
+    // contribute zero errors.
+    const result = validate.document({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          props: {},
+          children: [
+            {
+              name: 'table',
+              props: {
+                columns: [
+                  {
+                    header: {
+                      content: {
+                        name: 'paragraph',
+                        props: { text: 'h', font: { size: 10 } },
+                      },
+                    },
+                    cells: [
+                      {
+                        content: {
+                          name: 'paragraph',
+                          props: { text: 'ok', font: { size: 12 } },
+                        },
+                      },
+                      { content: 'plain string' },
+                    ],
+                  },
+                ],
+              },
+            },
+            { name: 'paragraph', props: { text: 'b', font: { size: 999 } } },
+          ],
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    // Only the broken sibling is flagged — nothing from the clean table.
+    const tableErrors = (result.errors ?? []).filter((e) =>
+      e.path.includes('/props/columns/')
+    );
+    expect(tableErrors).toEqual([]);
+  });
+});

--- a/packages/shared-docx/src/validation/unified/deep-validator.ts
+++ b/packages/shared-docx/src/validation/unified/deep-validator.ts
@@ -147,7 +147,8 @@ export function deepValidateDocument(
     allErrors.push(...propsErrors);
   }
 
-  // Validate children array
+  // Validate the children array. The root component requires one; nested
+  // containers may legitimately omit it.
   if (!data.children) {
     allErrors.push({
       path: '/children',
@@ -160,111 +161,174 @@ export function deepValidateDocument(
       message: 'Field "children" must be an array',
       code: 'invalid_type',
     });
-  } else {
-    // Validate each child component
-    data.children.forEach((child: any, index: number) => {
-      const childPath = `/children/${index}`;
+  }
 
-      if (!child || typeof child !== 'object') {
-        allErrors.push({
+  // Deep-validate the props of every component anywhere in the tree.
+  //
+  // The earlier implementation only re-validated the root's direct children
+  // and one level of `section` children. Two whole-tree blind spots followed:
+  //   1. component props nested inside `text-box`/`columns` children — the
+  //      content of every container lives in the shared `children` field, so
+  //      anything below the first level went unchecked; and
+  //   2. the `header`/`footer` paragraph regions, which the section schema
+  //      types loosely as an array of `Type.Any()` (or the `'linkToPrevious'`
+  //      literal) — so their entries' props are never checked by the
+  //      per-section validation.
+  // The in-editor (Monaco) validator runs the generated JSON Schema over the
+  // entire document, so it flags both. This walk brings the CLI to parity.
+  walkComponentTree(data, '', opts, allErrors);
+
+  return allErrors;
+}
+
+/**
+ * Recursively validate the props of every component nested under `node`.
+ *
+ * Walks two kinds of child position to any depth:
+ *  - the `children` array — the universal container field shared by `docx`,
+ *    `section`, `columns` and `text-box` (added by the component registry), so
+ *    a bad prop inside a `text-box` or `columns` child is caught however deeply
+ *    it is nested; and
+ *  - the `header` / `footer` paragraph regions under `props` — typed only
+ *    loosely on the section schema (an array of `Type.Any()`, or the
+ *    `'linkToPrevious'` literal, which is skipped), so their entries are not
+ *    deep-checked by the parent's per-component validation.
+ *
+ * The node's own props are NOT validated here — the caller validates the root
+ * props, and every entry is validated as it is visited. `table` and `list`
+ * nest their components inside their own recursive props schemas, so those are
+ * already covered by `validateComponentProps` and are intentionally not
+ * re-walked here.
+ */
+function walkComponentTree(
+  node: any,
+  path: string,
+  opts: DeepValidateOptions,
+  errors: ValidationError[]
+): void {
+  if (!node || typeof node !== 'object') return;
+
+  // `strictStructure` controls whether a malformed entry (not an object, or
+  // missing `name`) is reported here. It is ON for positions the per-component
+  // schema leaves unchecked — the `children` array (a sibling field, never seen
+  // by props validation) and the `header`/`footer` regions (typed `Type.Any()`
+  // on the static section schema) — so the walk is their only structural
+  // checker and must match the whole-tree schema the editor runs. It is OFF for
+  // `table` cell content, whose structure the table's own props schema already
+  // validates; there the walk only adds the prop-constraint errors the loose
+  // cell-content ref misses, so reporting structure too would double-report.
+  const validateEntry = (
+    child: any,
+    childPath: string,
+    strictStructure: boolean
+  ): void => {
+    if (!child || typeof child !== 'object') {
+      if (strictStructure) {
+        errors.push({
           path: childPath,
           message: 'Component must be an object',
           code: 'invalid_type',
         });
-        return;
       }
-
-      // Check component name
-      if (!child.name) {
-        allErrors.push({
+      return;
+    }
+    if (typeof child.name !== 'string' || child.name.length === 0) {
+      if (strictStructure) {
+        errors.push({
           path: `${childPath}/name`,
           message: 'Component missing required field "name"',
           code: 'required_property',
         });
-        return;
       }
+      return;
+    }
 
-      // Registered plugin components are validated version-aware by the plugin
-      // layer; skip them here so they are neither flagged as unknown nor
-      // checked against a standard schema.
-      if (opts.knownCustomNames?.has(child.name)) {
-        return;
+    // Registered plugin components are validated version-aware by the plugin
+    // layer; skip their props and subtree so they are neither double-validated
+    // nor misreported as unknown.
+    if (opts.knownCustomNames?.has(child.name)) return;
+
+    // Validate props against the component's schema. When props is omitted,
+    // validate an empty object so the schema decides whether props are
+    // required (e.g. `section` needs none; `heading` requires text+level).
+    if (child.props != null) {
+      errors.push(
+        ...validateComponentProps(
+          child.name,
+          child.props,
+          `${childPath}/props`,
+          opts
+        )
+      );
+    } else if (child.name !== 'custom') {
+      errors.push(
+        ...validateComponentProps(child.name, {}, `${childPath}/props`, opts)
+      );
+    }
+
+    // Recurse so arbitrarily nested containers are covered.
+    walkComponentTree(child, childPath, opts, errors);
+  };
+
+  // header/footer entries are validated strictly: the static section schema
+  // types them as `Type.Any()`, so the editor's whole-tree schema (where they
+  // resolve to the component union) is stricter than the per-component check —
+  // the walk closes that gap, flagging non-component entries too. A bare
+  // `'linkToPrevious'` value is not an array, so it is skipped here.
+  for (const region of ['header', 'footer'] as const) {
+    const entries = node.props?.[region];
+    if (Array.isArray(entries)) {
+      entries.forEach((child: any, i: number) =>
+        validateEntry(child, `${path}/props/${region}/${i}`, true)
+      );
+    }
+  }
+
+  // `table` nests its cell content under `props` (not the shared `children`
+  // field), and the static table schema types that content loosely — the
+  // cell-content ref accepts any props object, just like the `Type.Any()`
+  // header/footer above. So a bad prop deep in a cell (e.g. `font.size` over the
+  // cap) slips past the per-component table check; walk each content component
+  // so its props are validated against the real schema. Structural problems
+  // with a cell are already reported by the table's own props validation, hence
+  // the lenient (`false`) entry check to avoid double-reporting.
+  if (node.name === 'table' && Array.isArray(node.props?.columns)) {
+    node.props.columns.forEach((col: any, c: number) => {
+      if (!col || typeof col !== 'object') return;
+      const base = `${path}/props/columns/${c}`;
+      const headerContent = col.header?.content;
+      if (headerContent && typeof headerContent === 'object') {
+        validateEntry(headerContent, `${base}/header/content`, false);
       }
-
-      // Validate props against the component's schema. When props is omitted,
-      // validate an empty object so the schema decides whether props are
-      // required (e.g. `section` needs none; `heading` requires text+level)
-      // rather than assuming every component requires a props field.
-      if (child.props != null) {
-        allErrors.push(
-          ...validateComponentProps(
-            child.name,
-            child.props,
-            `${childPath}/props`,
-            opts
-          )
-        );
-      } else if (child.name !== 'custom') {
-        allErrors.push(
-          ...validateComponentProps(child.name, {}, `${childPath}/props`, opts)
-        );
-      }
-
-      // Special handling for section components (recursive)
-      if (child.name === 'section' && child.children) {
-        if (!Array.isArray(child.children)) {
-          allErrors.push({
-            path: `${childPath}/children`,
-            message: 'Section children must be an array',
-            code: 'invalid_type',
-          });
-        } else {
-          // Recursively validate nested components
-          child.children.forEach((nestedChild: any, nestedIndex: number) => {
-            const nestedChildPath = `${childPath}/children/${nestedIndex}`;
-            if (!nestedChild || typeof nestedChild !== 'object') {
-              allErrors.push({
-                path: nestedChildPath,
-                message: 'Nested component must be an object',
-                code: 'invalid_type',
-              });
-              return;
-            }
-
-            if (!nestedChild.name) {
-              allErrors.push({
-                path: `${nestedChildPath}/name`,
-                message: 'Nested component missing required field "name"',
-                code: 'required_property',
-              });
-            } else if (opts.knownCustomNames?.has(nestedChild.name)) {
-              // Registered plugin component — validated separately.
-            } else if (nestedChild.props != null) {
-              allErrors.push(
-                ...validateComponentProps(
-                  nestedChild.name,
-                  nestedChild.props,
-                  `${nestedChildPath}/props`,
-                  opts
-                )
-              );
-            } else if (nestedChild.name !== 'custom') {
-              allErrors.push(
-                ...validateComponentProps(
-                  nestedChild.name,
-                  {},
-                  `${nestedChildPath}/props`,
-                  opts
-                )
-              );
-            }
-          });
-        }
+      if (Array.isArray(col.cells)) {
+        col.cells.forEach((cell: any, r: number) => {
+          const content = cell?.content;
+          if (content && typeof content === 'object') {
+            validateEntry(content, `${base}/cells/${r}/content`, false);
+          }
+        });
       }
     });
   }
 
-  return allErrors;
+  if (Array.isArray(node.children)) {
+    node.children.forEach((child: any, i: number) =>
+      validateEntry(child, `${path}/children/${i}`, true)
+    );
+  } else if (node.children != null && path !== '') {
+    // `children` is present but not an array on a nested container. The root's
+    // `children` is already checked by deepValidateDocument (skipped here via
+    // `path !== ''` so it is not reported twice); this branch covers every
+    // deeper container (`section`/`columns`/`text-box`) the old one-level walk
+    // never reached. Without it a malformed subtree slips through as valid:
+    // TypeBox reports only a generic catch-all (which we strip), so an empty
+    // error set would otherwise flip the document back to `valid`.
+    errors.push({
+      path: `${path}/children`,
+      message: 'Field "children" must be an array',
+      code: 'invalid_type',
+    });
+  }
 }
 
 /**
@@ -281,9 +345,11 @@ function validateComponentProps(
   // Get the schema for this component
   const schema = COMPONENT_SCHEMAS[componentName];
   if (!schema) {
-    // Unknown component type
+    // Unknown component type. `basePath` always ends in `/props`; anchor the
+    // swap to the end so a nested region path like `…/props/header/0/props`
+    // becomes `…/props/header/0/name` rather than mangling an earlier `/props`.
     errors.push({
-      path: basePath.replace('/props', '/name'),
+      path: basePath.replace(/\/props$/, '/name'),
       message: `Unknown component "${componentName}"`,
       code: 'unknown_component',
     });


### PR DESCRIPTION
## Summary

Brings the CLI/library document validator (`validate.document` / `validate.jsonDocument`) to parity with the in-editor (Monaco) whole-tree schema. Previously the deep validator only re-checked the root's direct children and one level of `section` children, so component props could violate the schema yet pass `jto docx validate` (even `--strict`) while the editor flagged them.

The deep validator now walks the **entire** component tree:

- **Nested container children at any depth** — props inside `text-box`/`columns` children (the shared `children` field), however deeply nested.
- **`header`/`footer` regions** — typed loosely as `Type.Any()` on the static section schema, so their entries were never deep-checked. Now both their **props** and their **component structure** (non-object / missing `name`) are validated, matching the editor schema, which resolves these regions to the component union.
- **`table` cell + column-header content** — cells nest components under `props`, and the static cell-content schema accepts any props object (`additionalProperties: true`), so a capped prop deep in a cell (e.g. `font.size` over 72) slipped past. The walk now re-validates each cell/header content component against its real schema, to any depth (e.g. a table nested inside a table cell). Lenient on structure there to avoid double-reporting what the table's own props schema already covers.
- **Non-array `children` on any nested container** (`section`/`columns`/`text-box`) — previously only a `section`'s was reported, so a deeper malformed subtree could slip through as `valid`.

Also fixes a **path bug**: the unknown-component error used `basePath.replace('/props', '/name')`, which hit the *first* `/props` — for region entries (`…/props/header/0/props`) this produced a path pointing nowhere. Now anchored to the trailing segment.

No schema or rule changed — only validation coverage. `list` props were already covered by the list's own props schema.

## Tests

`packages/shared-docx`: 81/81 pass, typecheck clean. Added 7 tests covering nested-container/header/footer/table-cell coverage, the path fix, recursion depth, and a no-false-positives guard on clean table content.

## Notes / judgment calls

- The table traversal is keyed on `node.name === 'table'` and the known cell/column shape — same coupling the `header`/`footer` handling already has. A generic "validate any `{name,props}` in props" pass was rejected because it would false-positive on configs that legitimately carry `name` fields (e.g. Highcharts series).
- header/footer entry structure is now strict (matches the editor); valid documents are unaffected since valid entries are always components, and `'linkToPrevious'` (a non-array value) is skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded document validator to comprehensively check deeply nested components throughout the entire document tree, including nested containers, table cells, and header/footer regions.
  * Improved error reporting to display validation issues at accurate nested paths.
  * CLI and playground validation now align with editor error detection.

* **Tests**
  * Added comprehensive test coverage for deep validation of nested structures and component properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->