### PR TITLE
fix: gate shipped JSON assets on the schema, drop silent theme fallbacks

### DIFF
--- a/.changeset/theme-validation-gate.md
+++ b/.changeset/theme-validation-gate.md
@@ -1,0 +1,24 @@
+---
+'@json-to-office/shared-docx': minor
+'@json-to-office/core-docx': minor
+'@json-to-office/jto-cli': minor
+'@json-to-office/jto': minor
+---
+
+fix: gate every shipped JSON asset on the schema, and stop themes failing silently
+
+CI validated `examples/` and nothing else, so anything outside it drifted unchecked: all five bundled DOCX themes had shipped `componentDefaults.table` props the schema rejects (fixed by hand in the previous release, with nothing to stop it recurring), and the playground's "new theme" scaffold was born with 28 validation errors. This adds the missing gate and removes the fallbacks that hid the failures.
+
+**`pnpm validate:assets` validates every shipped asset, and CI runs it.** Every `*.docx.json`, `*.pptx.json`, `*.docx.theme.json` and `*.pptx.theme.json` under `packages/` and `examples/` — bundled themes, document templates, playground decks — plus every full document sample in `docs/**/*.md`. Docs snippets that are deliberately invalid opt out with `<!-- jto-validate: skip -- reason -->` on the line above the fence; a theme snippet opts in with `<!-- jto-validate: docx-theme -->`. Skipped samples are listed in the output rather than passing quietly.
+
+**`createMinimalTheme()` moved to `@json-to-office/shared-docx` and is now schema-valid.** It sat next to the parser in `core-docx` and emitted colours without the `#` prefix that `HexColorSchema` requires, so the one helper meant to produce a valid starting theme produced an invalid one. It now lives beside `ThemeConfigSchema`, returns `Static<typeof ThemeConfigSchema>` so a new required property breaks the build, and takes an optional name: `createMinimalTheme('house-style')` sets both `name` and a title-cased `displayName`. `core-docx` re-exports it, so `import { createMinimalTheme } from '@json-to-office/core-docx'` is unchanged.
+
+**The playground scaffolds new DOCX themes from it.** Creating a theme used to write a hardcoded literal with 5 colours, 2 font roles and no metadata — 28 errors the moment the editor opened it. New themes are now valid on creation. PPTX scaffolding is unchanged; it already matched its schema.
+
+**A failed template copy no longer falls back to the scaffold.** If `/api/discovery/…/content` failed or had not resolved, the create dialog wrote the default scaffold with only a `console.error`, producing a file named after the template you picked and containing none of it. It now reports the failure and leaves the dialog open. Switching templates also clears the previous one's content, so submitting mid-fetch can no longer write the theme you just navigated away from.
+
+**`apex` and `devportal` are statically imported like the other three themes.** They existed only via a filesystem scan of `dist/`, so which themes were available depended on build state: a stale `dist` served the old broken copies, and a missing one degraded to `minimal` without a word. The scan remains for genuinely external themes, but now validates before registering instead of trusting whatever it reads.
+
+**An unresolvable theme name warns instead of silently rendering as `minimal`.** `props.theme` is an unconstrained string and unknown names fell back to `minimal` with no signal — a typo, or a `--theme-path` file whose internal `name` differs from its filename, produced a plausible document in the wrong theme. Generation now emits a `theme_not_found` warning naming what was requested and what is available, and the CLI prints it. The fallback itself is unchanged: a bad name still renders rather than failing. `validateTheme` also stops casting unregistered theme names straight through, and rejects them with the list of valid names.
+
+The CLI now forwards structured generation warnings from the DOCX pipeline to the terminal generally, not just this one — they were collected and dropped before.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ jobs:
             node packages/jto-cli/dist/cli.js pptx validate "$file" --strict --quiet
           done
 
+      - name: Validate shipped assets and docs samples
+        shell: bash
+        run: pnpm validate:assets
+
       - name: Check generated schemas against smoke examples
         shell: bash
         run: |

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -10,6 +10,8 @@ A document is a tree of **modules**. Each module contains **base components** â€
 
 Every node has the same shape: a `name`, a `props` object, and optionally `children`:
 
+<!-- jto-validate: skip -- illustrates a custom plugin component (kpi-card) that is not in the base registry -->
+
 ```json
 {
   "name": "docx",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "turbo dev --ui tui --output-logs=errors-only",
     "build": "turbo build generate:schemas --output-logs=errors-only --log-order=grouped",
     "generate:schemas": "tsx scripts/generate-schemas.ts",
+    "validate:assets": "tsx scripts/validate-shipped-assets.ts",
     "test": "turbo test --output-logs=errors-only --log-order=grouped",
     "lint": "turbo lint --output-logs=errors-only --log-order=grouped",
     "typecheck": "turbo typecheck --output-logs=errors-only --log-order=grouped",

--- a/packages/core-docx/src/core/generator.ts
+++ b/packages/core-docx/src/core/generator.ts
@@ -11,7 +11,8 @@ import {
   ReportComponentDefinition,
   isReportComponent,
 } from '../types';
-import { getThemeWithFallback, ThemeConfig } from '../styles';
+import { ThemeConfig } from '../styles';
+import { resolveBuiltInTheme } from '../styles/theme-resolver';
 import type { ServicesConfig, FontRuntimeOpts } from '@json-to-office/shared';
 import { processDocument } from './structure';
 import { applyLayout } from './layout';
@@ -175,11 +176,11 @@ async function generateDocumentWithCustomThemes(
       if (matchingThemeKey) {
         theme = customThemes[matchingThemeKey];
       } else {
-        theme = getThemeWithFallback(themeName);
+        theme = resolveBuiltInTheme(themeName, { customThemes, warnings });
       }
     }
   } else {
-    theme = getThemeWithFallback(themeName);
+    theme = resolveBuiltInTheme(themeName, { warnings });
   }
 
   // Export-mode pre-pass: substitute (default) rewrites non-safe families

--- a/packages/core-docx/src/plugin/createDocumentGenerator.ts
+++ b/packages/core-docx/src/plugin/createDocumentGenerator.ts
@@ -1,7 +1,8 @@
 import type { TSchema } from '@sinclair/typebox';
 import type { CustomComponent } from './createComponent';
 import type { ComponentDefinition, ReportComponentDefinition } from '../types';
-import { type ThemeConfig, getThemeWithFallback } from '../styles';
+import { type ThemeConfig } from '../styles';
+import { resolveBuiltInTheme } from '../styles/theme-resolver';
 import type { GenerationWarning } from '@json-to-office/shared-docx';
 import type { ServicesConfig, FontRuntimeOpts } from '@json-to-office/shared';
 import { applyExportMode, scopedThemeName } from '@json-to-office/shared';
@@ -92,7 +93,10 @@ function createBuilderImpl<
   /**
    * Resolve theme for a document: customThemes → built-in → constructor fallback
    */
-  function resolveDocumentTheme(themeName: string): ThemeConfig {
+  function resolveDocumentTheme(
+    themeName: string,
+    warnings?: GenerationWarning[]
+  ): ThemeConfig {
     if (state.customThemes) {
       if (state.customThemes[themeName]) {
         return state.customThemes[themeName];
@@ -107,7 +111,10 @@ function createBuilderImpl<
     if (state.theme) {
       return state.theme;
     }
-    return getThemeWithFallback(themeName);
+    return resolveBuiltInTheme(themeName, {
+      customThemes: state.customThemes,
+      warnings,
+    });
   }
 
   /**
@@ -442,12 +449,12 @@ function createBuilderImpl<
               }
             };
 
-      // Resolve theme per-document: customThemes → built-in → constructor fallback
-      const baseThemeName = internalDocument.props.theme || 'minimal';
-      const docTheme = resolveDocumentTheme(baseThemeName);
-
       // Initialize warnings collector
       const warnings: GenerationWarning[] = [];
+
+      // Resolve theme per-document: customThemes → built-in → constructor fallback
+      const baseThemeName = internalDocument.props.theme || 'minimal';
+      const docTheme = resolveDocumentTheme(baseThemeName, warnings);
 
       // Export-mode pre-pass runs BEFORE custom-component expansion so
       // components that read `theme.fonts.*` during render see the

--- a/packages/core-docx/src/styles/__tests__/theme-resolver.test.ts
+++ b/packages/core-docx/src/styles/__tests__/theme-resolver.test.ts
@@ -1,54 +1,45 @@
 import { describe, it, expect } from 'vitest';
-import { resolveTheme } from '../theme-resolver';
-import type { ThemeConfig } from '../index';
+import type { GenerationWarning } from '@json-to-office/shared';
+import { resolveBuiltInTheme } from '../theme-resolver';
 
 describe('styles/theme-resolver', () => {
-  describe('resolveTheme', () => {
-    it('should resolve theme by name', () => {
-      const theme = resolveTheme('minimal');
-      expect(theme).toBeDefined();
-      expect(theme).toHaveProperty('colors');
+  describe('resolveBuiltInTheme', () => {
+    it('resolves a built-in theme by name without warning', () => {
+      const warnings: GenerationWarning[] = [];
+      const theme = resolveBuiltInTheme('minimal', { warnings });
+
+      expect(theme.name).toBe('minimal');
+      expect(warnings).toEqual([]);
     });
 
-    it('should return minimal theme for unknown name', () => {
-      const theme = resolveTheme('non-existent');
-      expect(theme).toBeDefined();
-      expect(theme).toHaveProperty('colors');
+    it('warns when the name does not resolve, and still falls back', () => {
+      const warnings: GenerationWarning[] = [];
+      const theme = resolveBuiltInTheme('non-existent', { warnings });
+
+      // The fallback stays — a bad name must not fail an otherwise valid render.
+      expect(theme.name).toBe('minimal');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatchObject({
+        component: 'theme',
+        severity: 'warning',
+        context: { code: 'theme_not_found', requested: 'non-existent' },
+      });
+      expect(warnings[0].message).toContain('non-existent');
+      expect(warnings[0].message).toContain('minimal');
     });
 
-    it('should handle undefined theme name', () => {
-      const theme = resolveTheme(undefined);
-      expect(theme).toBeDefined();
-      expect(theme).toHaveProperty('colors');
+    it('lists custom theme names as available in the warning', () => {
+      const warnings: GenerationWarning[] = [];
+      resolveBuiltInTheme('typo', {
+        customThemes: { 'house-style': {} as never },
+        warnings,
+      });
+
+      expect(warnings[0].context?.available).toContain('house-style');
     });
 
-    it('should return theme object as-is', () => {
-      const customTheme: ThemeConfig = {
-        colors: {
-          primary: '#FF0000',
-          secondary: '#00FF00',
-          text: '#000000',
-          background: '#FFFFFF',
-        },
-        fonts: {
-          heading: 'Arial',
-          body: 'Calibri',
-        },
-      };
-
-      const resolved = resolveTheme(customTheme);
-      expect(resolved).toEqual(customTheme);
-    });
-
-    it('should handle partial theme objects', () => {
-      const partialTheme: ThemeConfig = {
-        colors: {
-          primary: '#123456',
-        },
-      };
-
-      const resolved = resolveTheme(partialTheme);
-      expect(resolved.colors?.primary).toBe('#123456');
+    it('does not require a warnings sink', () => {
+      expect(() => resolveBuiltInTheme('non-existent')).not.toThrow();
     });
   });
 });

--- a/packages/core-docx/src/styles/theme-resolver.ts
+++ b/packages/core-docx/src/styles/theme-resolver.ts
@@ -1,24 +1,39 @@
+import type { GenerationWarning } from '@json-to-office/shared';
 import type { ThemeConfig } from './index';
-import { getTheme } from '../templates/themes';
+import {
+  getThemeNames,
+  getThemeWithFallback,
+  hasTheme,
+} from '../templates/themes';
 
 /**
- * Resolve a theme by merging with defaults
+ * Resolve a built-in theme by name, reporting a miss instead of swallowing it.
+ *
+ * `getThemeWithFallback` renders an unknown name as `minimal`, which used to be
+ * invisible: a typo, or a `--theme-path` file whose internal `name` differs
+ * from its filename, produced a plausible-looking document styled by the wrong
+ * theme. The fallback is kept — a bad name should not fail a render — but it
+ * now surfaces as a warning naming what was asked for and what is available.
  */
-export function resolveTheme(theme?: ThemeConfig | string): ThemeConfig {
-  if (typeof theme === 'string') {
-    const resolvedTheme = getTheme(theme);
-    if (resolvedTheme) {
-      return resolvedTheme as ThemeConfig;
-    }
-    // Fallback to minimal theme if default doesn't exist
-    return getTheme('minimal') as ThemeConfig;
+export function resolveBuiltInTheme(
+  themeName: string,
+  options: {
+    customThemes?: { [key: string]: ThemeConfig };
+    warnings?: GenerationWarning[];
+  } = {}
+): ThemeConfig {
+  if (!hasTheme(themeName)) {
+    const available = [
+      ...getThemeNames(),
+      ...Object.keys(options.customThemes ?? {}),
+    ].sort();
+    options.warnings?.push({
+      component: 'theme',
+      message: `Theme "${themeName}" not found; falling back to "minimal". Available themes: ${available.join(', ')}.`,
+      severity: 'warning',
+      context: { code: 'theme_not_found', requested: themeName, available },
+    });
   }
 
-  if (theme) {
-    // Return theme as-is, assuming it's complete
-    return theme;
-  }
-
-  // Return minimal theme as default
-  return getTheme('minimal') as ThemeConfig;
+  return getThemeWithFallback(themeName);
 }

--- a/packages/core-docx/src/styles/theme-validator.ts
+++ b/packages/core-docx/src/styles/theme-validator.ts
@@ -1,5 +1,6 @@
 import type { ThemeConfig } from './index';
 import { validateTheme as validateThemeUnified } from '@json-to-office/shared-docx/validation/unified';
+import { hasTheme, getThemeNames } from '../templates/themes';
 
 /**
  * Validate a theme configuration
@@ -13,7 +14,14 @@ export function validateTheme(
   }
 
   if (typeof theme === 'string') {
-    // Theme name - will be resolved later
+    // Theme name: resolved later, but check it exists now. Casting an
+    // unregistered name straight through is what let a typo reach the
+    // renderer and silently come back as `minimal`.
+    if (!hasTheme(theme)) {
+      throw new Error(
+        `Unknown theme "${theme}". Available themes: ${getThemeNames().sort().join(', ')}.`
+      );
+    }
     return theme as unknown as ThemeConfig;
   }
 

--- a/packages/core-docx/src/templates/themes/index.ts
+++ b/packages/core-docx/src/templates/themes/index.ts
@@ -6,13 +6,22 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import type { ThemeConfigJson } from '@json-to-office/shared-docx';
+import {
+  isValidThemeConfig,
+  type ThemeConfigJson,
+} from '@json-to-office/shared-docx';
 import { ensureThemeDefaults } from '../../themes/defaults';
 
-// Import theme JSON files directly
+// Import theme JSON files directly. Every bundled theme is imported here, so
+// which themes exist is decided by code, not by whether `dist/` happens to be
+// built and fresh — `apex` and `devportal` used to be reachable only through
+// the filesystem scan below, which meant a stale build silently served the old
+// copy and a missing one degraded to `minimal`.
 import minimalThemeJson from './minimal.docx.theme.json';
 import corporateThemeJson from './corporate.docx.theme.json';
 import modernThemeJson from './modern.docx.theme.json';
+import apexThemeJson from './apex.docx.theme.json';
+import devportalThemeJson from './devportal.docx.theme.json';
 
 /**
  * Registry of available themes loaded from JSON files
@@ -29,6 +38,8 @@ function loadThemesFromJson(): Record<string, ThemeConfigJson> {
     minimal: ensureThemeDefaults(minimalThemeJson as ThemeConfigJson),
     corporate: ensureThemeDefaults(corporateThemeJson as ThemeConfigJson),
     modern: ensureThemeDefaults(modernThemeJson as ThemeConfigJson),
+    apex: ensureThemeDefaults(apexThemeJson as ThemeConfigJson),
+    devportal: ensureThemeDefaults(devportalThemeJson as ThemeConfigJson),
   };
 
   // Also try to load from file system for runtime additions (if available)
@@ -46,9 +57,22 @@ function loadThemesFromJson(): Record<string, ThemeConfigJson> {
       for (const themeName of themeFiles) {
         if (!themes[themeName]) {
           try {
-            const filePath = path.join(themesDir, `${themeName}.docx.theme.json`);
+            const filePath = path.join(
+              themesDir,
+              `${themeName}.docx.theme.json`
+            );
             const content = fs.readFileSync(filePath, 'utf8');
             const parsedTheme = JSON.parse(content);
+            // Check before registering. A theme that reaches the registry is
+            // never validated again, so an invalid one here renders wrong
+            // rather than failing — the drift that hid dead `componentDefaults`
+            // props across five themes for as long as they shipped.
+            if (!isValidThemeConfig(parsedTheme)) {
+              console.warn(
+                `Skipping theme ${themeName}: does not match the theme schema.`
+              );
+              continue;
+            }
             themes[themeName] = ensureThemeDefaults(parsedTheme);
           } catch (error) {
             console.warn(

--- a/packages/core-docx/src/themes/__tests__/bundled-themes.test.ts
+++ b/packages/core-docx/src/themes/__tests__/bundled-themes.test.ts
@@ -9,6 +9,8 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { validateThemeJson, formatValidationErrors } from '../json/validator';
+import { createMinimalTheme } from '../json';
+import { getTheme, getThemeNames } from '../../templates/themes';
 
 const themesDir = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -33,5 +35,45 @@ describe('bundled docx themes', () => {
     const errors = result.success ? [] : formatValidationErrors(result.error!);
     expect(errors).toEqual([]);
     expect(result.success).toBe(true);
+  });
+});
+
+/**
+ * The files above are one thing; what `getTheme()` hands the renderer is
+ * another. Built-ins are loaded with a raw JSON import cast to
+ * `ThemeConfigJson` and then backfilled by `ensureThemeDefaults`, so neither
+ * `tsc` nor the parser ever sees them. This walks the registry itself.
+ */
+describe('built-in theme registry', () => {
+  const registeredNames = getThemeNames();
+
+  it('registers the statically imported themes', () => {
+    expect(registeredNames).toEqual(
+      expect.arrayContaining(['minimal', 'corporate', 'modern'])
+    );
+  });
+
+  it.each(registeredNames)('getTheme(%s) returns a valid theme', (name) => {
+    const result = validateThemeJson(JSON.stringify(getTheme(name)));
+
+    const errors = result.success ? [] : formatValidationErrors(result.error!);
+    expect(errors).toEqual([]);
+  });
+});
+
+describe('createMinimalTheme', () => {
+  it('scaffolds a theme that is valid on creation', () => {
+    const result = validateThemeJson(JSON.stringify(createMinimalTheme()));
+
+    const errors = result.success ? [] : formatValidationErrors(result.error!);
+    expect(errors).toEqual([]);
+  });
+
+  it('carries the requested name through to name and displayName', () => {
+    const theme = createMinimalTheme('house-style');
+
+    expect(theme.name).toBe('house-style');
+    expect(theme.displayName).toBe('House Style');
+    expect(validateThemeJson(JSON.stringify(theme)).success).toBe(true);
   });
 });

--- a/packages/core-docx/src/themes/json/index.ts
+++ b/packages/core-docx/src/themes/json/index.ts
@@ -3,6 +3,12 @@ export {
   ThemeConfigSchema,
   type ThemeConfigJson,
   isValidThemeConfig,
+  /**
+   * Create a minimal theme template for users to start with.
+   * Defined in shared-docx next to `ThemeConfigSchema` so every consumer
+   * (CLI, playground) scaffolds from one schema-checked source.
+   */
+  createMinimalTheme,
 } from '@json-to-office/shared-docx';
 export { ThemeParser, ThemeValidationError, ThemeParseError } from './parser';
 export {
@@ -81,60 +87,4 @@ export function exportThemeToJson(
  */
 export function validateThemeJsonString(jsonString: string) {
   return themeParser.validate(jsonString);
-}
-
-/**
- * Create a minimal theme template for users to start with
- * @returns ThemeConfig - Basic theme with required properties
- */
-export function createMinimalTheme(): ThemeConfigJson {
-  return {
-    name: 'minimal-theme',
-    displayName: 'Minimal Theme',
-    description: 'A minimal theme with basic styling',
-    version: '1.0.0',
-    colors: {
-      primary: '2563EB',
-      secondary: '64748B',
-      accent: 'F8FAFC',
-      text: '334155',
-      background: 'FFFFFF',
-      border: '334155',
-      textPrimary: '334155',
-      textSecondary: '64748B',
-      textMuted: '94A3B8',
-      borderPrimary: '334155',
-      borderSecondary: '64748B',
-      backgroundPrimary: 'FFFFFF',
-      backgroundSecondary: 'F8FAFC',
-    },
-    fonts: {
-      heading: { family: 'Arial', size: 14 },
-      body: { family: 'Arial', size: 11 },
-      mono: { family: 'Courier New', size: 10 },
-      light: { family: 'Arial', size: 10 },
-    },
-    page: {
-      size: 'A4',
-      margins: {
-        top: 1440,
-        bottom: 1440,
-        left: 1440,
-        right: 1440,
-        header: 720,
-        footer: 720,
-        gutter: 0,
-      },
-    },
-    styles: {
-      normal: {
-        font: 'body',
-        size: 11,
-        color: '334155',
-        alignment: 'left',
-        lineSpacing: { type: 'multiple', value: 1.15 },
-        spacing: { after: 8 },
-      },
-    },
-  };
 }

--- a/packages/jto-cli/src/format-adapter.ts
+++ b/packages/jto-cli/src/format-adapter.ts
@@ -5,11 +5,22 @@ import type {
   ServicesConfig,
   FontRuntimeOpts,
   PptxRasterizer,
+  GenerationWarning,
 } from '@json-to-office/shared';
 import { validatePresentationDocument } from '@json-to-office/shared-pptx';
 import { validate as validateDocx } from '@json-to-office/shared-docx';
 import { createLibreOfficePptxRasterizer } from './pptx-rasterizer.js';
 import { emitDiagnostic } from './services/diagnostics.js';
+
+/** Forward structured warnings collected during generation to the terminal. */
+function emitGenerationWarnings(warnings: GenerationWarning[]): void {
+  for (const warning of warnings) {
+    emitDiagnostic(
+      `${warning.component}: ${warning.message}`,
+      warning.severity === 'info' ? 'info' : 'warning'
+    );
+  }
+}
 
 const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 function safeThemeKey(name: string | undefined): string {
@@ -205,7 +216,11 @@ export class DocxFormatAdapter implements FormatAdapter {
       resolved.customThemes
     );
     const services = buildDocxServices();
-    return await core.generateBufferFromJson(docDefinition as any, {
+    // Collect rather than swallow: without a sink, core warnings (an
+    // unresolvable `props.theme` among them) never reach the terminal and the
+    // render just comes back looking subtly wrong.
+    const warnings: GenerationWarning[] = [];
+    const buffer = await core.generateBufferFromJson(docDefinition as any, {
       customThemes,
       services,
       fonts: options.fonts,
@@ -214,7 +229,10 @@ export class DocxFormatAdapter implements FormatAdapter {
       },
       deterministic: options.deterministic,
       generatedAt: options.generatedAt,
+      warnings,
     });
+    emitGenerationWarnings(warnings);
+    return buffer;
   }
 
   async createGenerator(
@@ -241,7 +259,8 @@ export class DocxFormatAdapter implements FormatAdapter {
             typeof document === 'string' ? JSON.parse(document) : document;
           const { document: docDefinition, customThemes: themes } =
             withRequestedTheme(parsed, requestedTheme, customThemes);
-          return await core.generateBufferFromJson(docDefinition, {
+          const warnings: GenerationWarning[] = [];
+          const buffer = await core.generateBufferFromJson(docDefinition, {
             customThemes: themes,
             services,
             fonts: options.fonts,
@@ -250,7 +269,10 @@ export class DocxFormatAdapter implements FormatAdapter {
             },
             deterministic: options.deterministic,
             generatedAt: options.generatedAt,
+            warnings,
           });
+          emitGenerationWarnings(warnings);
+          return buffer;
         },
         hasPlugins: false,
         pluginNames: [],
@@ -296,6 +318,7 @@ export class DocxFormatAdapter implements FormatAdapter {
           deterministic: options.deterministic,
           generatedAt: options.generatedAt,
         });
+        emitGenerationWarnings(result.warnings ?? []);
         return result.buffer;
       },
       getStandardComponentsDefinition: generator.getStandardComponentsDefinition

--- a/packages/jto/src/client/components/playground/document-form-dialog-content.tsx
+++ b/packages/jto/src/client/components/playground/document-form-dialog-content.tsx
@@ -31,6 +31,7 @@ import {
 import { useDocumentsStore } from '../../store/documents-store-provider';
 import { useThemesStore } from '../../store/themes-store-provider';
 import { useChatStore } from '../../store/chat-store-provider';
+import { useToast } from '../ui/use-toast';
 import type { Mode } from '../../lib/types';
 import type { DocumentMetadata, ThemeMetadata } from '../../hooks/useDiscovery';
 import {
@@ -40,6 +41,7 @@ import {
   type DocumentFormData,
 } from '../../lib/validation';
 import { FORMAT } from '../../lib/env';
+import { createMinimalTheme } from '@json-to-office/shared-docx';
 
 const getLabels = (isTheme?: boolean) => ({
   create: {
@@ -97,6 +99,13 @@ function DocumentFormDialogContent({
   const [selectedItemContent, setSelectedItemContent] = useState<string | null>(
     null
   );
+  // Tracks the template copy independently of its content: a null
+  // `selectedItemContent` means "start from scratch" when idle, but "the copy
+  // failed" when errored — the two must not both fall back to the scaffold.
+  const [templateStatus, setTemplateStatus] = useState<
+    'idle' | 'loading' | 'error'
+  >('idle');
+  const { toast } = useToast();
   const labels = getLabels(isTheme);
   const {
     documents,
@@ -192,6 +201,11 @@ function DocumentFormDialogContent({
     ) {
       const item = itemsByPath.get(selectedPath);
       if (item) {
+        // Drop the previous template's content up front: while this fetch is
+        // in flight the selection no longer matches what we hold.
+        setSelectedItemContent(null);
+        setTemplateStatus('loading');
+        let cancelled = false;
         fetch(
           `/api/discovery/${isTheme ? 'themes' : 'documents'}/${encodeURIComponent(item.name)}/content`
         )
@@ -202,20 +216,24 @@ function DocumentFormDialogContent({
             return res.text();
           })
           .then((content) => {
-            try {
-              const parsed = JSON.parse(content);
-              setSelectedItemContent(JSON.stringify(parsed, null, 2));
-            } catch (e) {
-              console.error('Invalid JSON content received:', e);
-              setSelectedItemContent(null);
-            }
+            if (cancelled) return;
+            // Throws on malformed JSON, handled below like any fetch failure.
+            const parsed = JSON.parse(content);
+            setSelectedItemContent(JSON.stringify(parsed, null, 2));
+            setTemplateStatus('idle');
           })
           .catch((error) => {
-            console.error('Failed to fetch content:', error);
+            if (cancelled) return;
+            console.error('Failed to copy template:', error);
             setSelectedItemContent(null);
+            setTemplateStatus('error');
           });
+        return () => {
+          cancelled = true;
+        };
       }
     }
+    setTemplateStatus('idle');
   }, [selectedPath, mode, itemsByPath, isTheme]);
 
   // reset form
@@ -223,6 +241,7 @@ function DocumentFormDialogContent({
     if (shouldReset) {
       form.reset();
       setSelectedItemContent(null);
+      setTemplateStatus('idle');
       setSelectedPath(defaultTemplatePath);
     }
   }, [form, shouldReset]);
@@ -240,6 +259,26 @@ function DocumentFormDialogContent({
         let content: string;
         let finalName = name as string;
 
+        // A template was picked but its content never arrived. Creating the
+        // file anyway would produce something named after the template and
+        // containing none of it, so stop instead of falling back.
+        const templatePicked =
+          Boolean(selectedPath) && selectedPath !== EMPTY_TEMPLATE_VALUE;
+        if (templatePicked && selectedItemContent === null) {
+          toast({
+            title:
+              templateStatus === 'loading'
+                ? 'Template still loading'
+                : `Could not copy ${selectedItem?.name ?? 'the selected template'}`,
+            description:
+              templateStatus === 'loading'
+                ? 'Wait for the template to finish loading, then try again.'
+                : 'Pick another template, or create an empty one instead.',
+            variant: 'destructive',
+          });
+          return;
+        }
+
         if (isTheme) {
           // Use discovered theme content or create format-specific default
           const themeName = finalName
@@ -248,21 +287,9 @@ function DocumentFormDialogContent({
             .replace(/\s+/g, '-');
           const defaultTheme =
             FORMAT === 'docx'
-              ? {
-                  name: themeName,
-                  colors: {
-                    primary: '#2563EB',
-                    secondary: '#64748B',
-                    accent: '#F8FAFC',
-                    background: '#FFFFFF',
-                    text: '#334155',
-                  },
-                  fonts: {
-                    heading: { family: 'Calibri', size: 28 },
-                    body: { family: 'Calibri', size: 11 },
-                  },
-                  page: { size: 'A4' },
-                }
+              ? // Scaffolded from shared-docx so a new theme is schema-valid on
+                // creation instead of opening with validation errors.
+                createMinimalTheme(themeName)
               : {
                   name: themeName,
                   colors: {

--- a/packages/shared-docx/src/index.ts
+++ b/packages/shared-docx/src/index.ts
@@ -93,7 +93,11 @@ export type {
 // Docx-specific: Theme schemas
 // ============================================================================
 
-export { ThemeConfigSchema, isValidThemeConfig } from './schemas/theme';
+export {
+  ThemeConfigSchema,
+  isValidThemeConfig,
+  createMinimalTheme,
+} from './schemas/theme';
 
 export type {
   ThemeConfigJson,

--- a/packages/shared-docx/src/schemas/theme.ts
+++ b/packages/shared-docx/src/schemas/theme.ts
@@ -462,3 +462,80 @@ import { Value } from '@sinclair/typebox/value';
 export function isValidThemeConfig(data: unknown): data is ThemeConfigJson {
   return Value.Check(ThemeConfigSchema, data);
 }
+
+// ============================================================================
+// Minimal Theme Scaffold
+// ============================================================================
+
+/**
+ * Build a schema-complete theme to start from.
+ *
+ * Lives next to `ThemeConfigSchema` on purpose: the return type is the schema's
+ * `Static` type, so a required property added to the schema breaks the build
+ * here instead of shipping a scaffold that only fails at validation time.
+ * Colour patterns are runtime-only, so `theme-scaffold.test.ts` validates the
+ * result against the schema as well.
+ *
+ * Browser-safe (no Node built-ins), so the playground can scaffold new themes
+ * from the same source as the CLI.
+ *
+ * @param name - Theme identifier; defaults to `minimal-theme`
+ */
+export function createMinimalTheme(
+  name: string = 'minimal-theme'
+): ThemeConfigJson {
+  return {
+    name,
+    displayName:
+      name
+        .split(/[-_\s]+/)
+        .filter(Boolean)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ') || name,
+    description: 'A minimal theme with basic styling',
+    version: '1.0.0',
+    colors: {
+      primary: '#2563EB',
+      secondary: '#64748B',
+      accent: '#F8FAFC',
+      text: '#334155',
+      background: '#FFFFFF',
+      border: '#E2E8F0',
+      textPrimary: '#334155',
+      textSecondary: '#64748B',
+      textMuted: '#94A3B8',
+      borderPrimary: '#CBD5E1',
+      borderSecondary: '#E2E8F0',
+      backgroundPrimary: '#FFFFFF',
+      backgroundSecondary: '#F8FAFC',
+    },
+    fonts: {
+      heading: { family: 'Arial', size: 14 },
+      body: { family: 'Arial', size: 11 },
+      mono: { family: 'Courier New', size: 10 },
+      light: { family: 'Arial', size: 10 },
+    },
+    page: {
+      size: 'A4',
+      margins: {
+        top: 1440,
+        bottom: 1440,
+        left: 1440,
+        right: 1440,
+        header: 720,
+        footer: 720,
+        gutter: 0,
+      },
+    },
+    styles: {
+      normal: {
+        font: 'body',
+        size: 11,
+        color: '#334155',
+        alignment: 'left',
+        lineSpacing: { type: 'multiple', value: 1.15 },
+        spacing: { after: 8 },
+      },
+    },
+  };
+}

--- a/scripts/validate-shipped-assets.ts
+++ b/scripts/validate-shipped-assets.ts
@@ -1,0 +1,255 @@
+/**
+ * Validate every JSON asset this repo ships, plus the full-document samples in
+ * the docs, against the current schemas.
+ *
+ * CI validated `examples/` only, so drift accumulated wherever nothing looked:
+ * all five bundled DOCX themes shipped `componentDefaults.table` props that the
+ * schema rejects and no renderer read. Built-in themes are loaded with a raw
+ * JSON import cast to `ThemeConfigJson`, so neither `tsc` nor the parser ever
+ * saw them. This is the gate that makes that impossible to repeat.
+ *
+ * Covers:
+ *   - `*.docx.json`, `*.pptx.json`, `*.docx.theme.json`, `*.pptx.theme.json`
+ *     under `packages/` and `examples/` — format and kind come from the filename.
+ *   - ```json fences in `docs/**\/*.md` that are full document samples — a
+ *     `docx`/`pptx` root with a `children` array. Fragments (a lone component,
+ *     a props object, a `$schema` line) are skipped: they are not documents and
+ *     have no schema to check against on their own.
+ *
+ * Per-fence markers, on the line before the fence:
+ *   <!-- jto-validate: skip -- reason -->   opt out (e.g. illustrates a plugin
+ *                                           component that is not in the base
+ *                                           registry)
+ *   <!-- jto-validate: docx-theme -->       validate as a theme; themes carry no
+ *   <!-- jto-validate: pptx-theme -->       format marker of their own
+ *
+ * Run: pnpm validate:assets   (requires a build — it imports from dist/)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+const ASSET_ROOTS = ['packages', 'examples'];
+const DOCS_ROOT = 'docs';
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.git', '.turbo', 'build']);
+
+type Format = 'docx' | 'pptx';
+type Kind = 'document' | 'theme';
+
+interface Target {
+  /** Repo-relative label, with `:line` for docs snippets. */
+  label: string;
+  format: Format;
+  kind: Kind;
+  json: string;
+}
+
+interface Failure {
+  label: string;
+  format: Format;
+  kind: Kind;
+  errors: string[];
+}
+
+// ----------------------------------------------------------------------------
+// Collection
+// ----------------------------------------------------------------------------
+
+function* walk(dir: string): Generator<string> {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) yield* walk(full);
+    } else if (entry.isFile()) {
+      yield full;
+    }
+  }
+}
+
+/** Filename suffix decides format and kind; anything else is not ours. */
+function classify(file: string): { format: Format; kind: Kind } | null {
+  for (const format of ['docx', 'pptx'] as const) {
+    if (file.endsWith(`.${format}.theme.json`))
+      return { format, kind: 'theme' };
+    if (file.endsWith(`.${format}.json`)) return { format, kind: 'document' };
+  }
+  return null;
+}
+
+function collectAssets(): Target[] {
+  const targets: Target[] = [];
+  for (const root of ASSET_ROOTS) {
+    for (const file of walk(path.join(ROOT, root))) {
+      const classified = classify(file);
+      if (!classified) continue;
+      targets.push({
+        label: path.relative(ROOT, file),
+        ...classified,
+        json: fs.readFileSync(file, 'utf8'),
+      });
+    }
+  }
+  return targets.sort((a, b) => a.label.localeCompare(b.label));
+}
+
+const MARKER = /<!--\s*jto-validate:\s*(skip|docx-theme|pptx-theme)\b/;
+
+function collectDocsSnippets(): { targets: Target[]; skipped: string[] } {
+  const targets: Target[] = [];
+  const skipped: string[] = [];
+
+  for (const file of walk(path.join(ROOT, DOCS_ROOT))) {
+    if (!file.endsWith('.md')) continue;
+    const rel = path.relative(ROOT, file);
+    const lines = fs.readFileSync(file, 'utf8').split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].trim() !== '```json') continue;
+
+      const open = i;
+      const close = lines.findIndex(
+        (line, index) => index > open && line.trim() === '```'
+      );
+      if (close === -1) break; // unterminated fence; nothing sane to validate
+      const body = lines.slice(open + 1, close).join('\n');
+      // Content starts on the line after the fence; lines[] is 0-indexed.
+      const label = `${rel}:${open + 2}`;
+      i = close;
+
+      // A marker within the few lines above the fence applies to it.
+      const marker = lines
+        .slice(Math.max(0, open - 3), open)
+        .join('\n')
+        .match(MARKER)?.[1];
+
+      if (marker === 'skip') {
+        skipped.push(label);
+        continue;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(body);
+      } catch {
+        // Docs contain deliberately elided JSON ("...", trailing prose).
+        // Unparseable is not a schema failure; leave it alone.
+        continue;
+      }
+
+      if (marker === 'docx-theme' || marker === 'pptx-theme') {
+        targets.push({
+          label,
+          format: marker === 'docx-theme' ? 'docx' : 'pptx',
+          kind: 'theme',
+          json: body,
+        });
+        continue;
+      }
+
+      // A full document sample: a `docx`/`pptx` root with a children array.
+      // A root without `children` is prose illustration — a `$schema` line, a
+      // `props.grid` block — and would fail on the fields it deliberately omits.
+      const root = parsed as { name?: unknown; children?: unknown } | null;
+      if (
+        (root?.name === 'docx' || root?.name === 'pptx') &&
+        Array.isArray(root.children)
+      ) {
+        targets.push({
+          label,
+          format: root.name,
+          kind: 'document',
+          json: body,
+        });
+      }
+    }
+  }
+
+  return { targets, skipped };
+}
+
+// ----------------------------------------------------------------------------
+// Validation
+// ----------------------------------------------------------------------------
+
+async function loadValidators() {
+  const [docx, pptx] = await Promise.all([
+    import(
+      pathToFileURL(path.join(ROOT, 'packages/shared-docx/dist/index.js')).href
+    ),
+    import(
+      pathToFileURL(path.join(ROOT, 'packages/shared-pptx/dist/index.js')).href
+    ),
+  ]);
+  return { docx: docx.validateStrict, pptx: pptx.validateStrict };
+}
+
+async function main() {
+  const validators = await loadValidators();
+
+  const assets = collectAssets();
+  const { targets: snippets, skipped } = collectDocsSnippets();
+  const targets = [...assets, ...snippets];
+
+  if (assets.length === 0) {
+    console.error('No shipped JSON assets found — the walk is misconfigured.');
+    process.exit(1);
+  }
+
+  const failures: Failure[] = [];
+
+  for (const target of targets) {
+    const validator = validators[target.format];
+    const result =
+      target.kind === 'theme'
+        ? validator.jsonTheme(target.json)
+        : validator.jsonDocument(target.json);
+
+    if (!result.valid) {
+      failures.push({
+        label: target.label,
+        format: target.format,
+        kind: target.kind,
+        errors: (result.errors ?? []).map(
+          (e: { path?: string; message: string }) =>
+            e.path ? `${e.path}: ${e.message}` : e.message
+        ),
+      });
+    }
+  }
+
+  console.log(
+    `Validated ${assets.length} shipped asset(s) and ${snippets.length} docs sample(s).`
+  );
+  // Say what was not checked: a silent skip reads as "covered" when it isn't.
+  if (skipped.length > 0) {
+    console.log(`Skipped ${skipped.length} marked docs sample(s):`);
+    for (const label of skipped) console.log(`  - ${label}`);
+  }
+
+  if (failures.length > 0) {
+    console.error(`\n${failures.length} file(s) failed validation:\n`);
+    for (const failure of failures) {
+      console.error(`  ${failure.label}  (${failure.format} ${failure.kind})`);
+      for (const error of failure.errors) console.error(`      ${error}`);
+      console.error('');
+    }
+    process.exit(1);
+  }
+
+  console.log('All shipped assets and docs samples are valid.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #111.

CI validated `examples/` and nothing else, so anything outside it drifted unchecked. This adds the missing gate and removes the fallbacks that hid the failures.

## The gate

`pnpm validate:assets` (`scripts/validate-shipped-assets.ts`), wired into the `conformance` job. Covers every `*.docx.json`, `*.pptx.json`, `*.docx.theme.json` and `*.pptx.theme.json` under `packages/` and `examples/` — 23 assets — plus every full document sample in `docs/**/*.md` — 20 samples.

Per-fence markers, on the line above the fence:

- `<!-- jto-validate: skip -- reason -->` — opt out. Used on the `kpi-card` sample in `docs/guide/architecture.md`, which deliberately illustrates a plugin component outside the base registry.
- `<!-- jto-validate: docx-theme -->` / `pptx-theme` — validate as a theme; themes carry no format marker of their own.

Skipped samples are listed in the output rather than passing quietly. Verified it exits 1 when `striped` is re-injected into `apex.docx.theme.json`.

## Issue #111 status

Drift 1 (bundled themes invalid) was already fixed by hand in e311268. Everything else in the issue was still live:

**Drift 2 — playground scaffold.** `document-form-dialog-content.tsx` hardcoded a literal with 5 colours, 2 font roles and no metadata: 28 validation errors the moment the editor opened it. Now scaffolds from `createMinimalTheme()`.

**Silent fallback on template copy.** If `/api/discovery/…/content` failed or hadn't resolved, the dialog wrote the scaffold with only a `console.error` — a file named after the template you picked, containing none of it. It now reports the failure and leaves the dialog open. Switching templates also clears the previous one's content, so submitting mid-fetch can't write the theme you navigated away from.

**Unresolvable theme name.** `props.theme` is an unconstrained string and unknown names fell back to `minimal` with no signal. Generation now emits a `theme_not_found` warning naming what was requested and what's available, and the CLI prints it. The fallback itself is unchanged — a bad name still renders rather than failing.

**`validateTheme` casting names through.** Now rejects unregistered names with the list of valid ones.

**Two-tier registry.** `apex` and `devportal` existed only via a filesystem scan of `dist/`, so availability depended on build state. Both are now statically imported like the other three; the scan remains for genuinely external themes but validates before registering.

## Two things beyond the issue

**`createMinimalTheme()` was itself invalid** — 10 errors, hex colours without the `#` prefix `HexColorSchema` requires. The issue's suggested fix ("reuse `createMinimalTheme()`") would have produced a still-broken scaffold. It now lives in `@json-to-office/shared-docx` beside `ThemeConfigSchema`, returns `Static<typeof ThemeConfigSchema>` so a new required property breaks the build, and takes an optional name. `core-docx` re-exports it, so existing imports are unchanged.

**`apex`/`devportal` were being served from stale `dist/`.** The new registry test caught them still carrying the old dead `componentDefaults.table` props — Drift 1 was fixed in source, but `getTheme()` reads `dist/templates/themes`. This is exactly the build-state dependency the issue flagged, and the static imports remove it.

## Tests

- `bundled-themes.test.ts` extended: walks the registry itself (what `getTheme()` hands the renderer, post-`ensureThemeDefaults`) and covers `createMinimalTheme()`.
- `theme-resolver.test.ts` rewritten for the warning behaviour. The old file tested `resolveTheme`, which nothing but that test imported.

## Verification

`build`, `typecheck`, `lint`, `test`, `docs:build`, `validate:assets` all pass.

CLI, unknown theme name:

```
theme: Theme "no-such-theme" not found; falling back to "minimal". Available themes: apex, corporate, devportal, minimal, modern.
```

Playground, in-browser: Active Themes → `+` → "house style" → Create produces a complete theme (13 colours, 4 font roles, page margins, `displayName: "House Style"`) with zero Monaco validation markers. Was 28 errors.

## Note

The CLI now forwards structured generation warnings from the DOCX pipeline to the terminal generally, not just the theme one — they were collected and dropped before. Expect previously-invisible font-resolution warnings to start appearing on `jto docx generate`.
