### PR TITLE
refactor(pptx): pass resolved theme into processPresentation by value

### DIFF
--- a/.changeset/pptx-theme-by-value.md
+++ b/.changeset/pptx-theme-by-value.md
@@ -1,0 +1,18 @@
+---
+'@json-to-office/core-pptx': patch
+---
+
+Hand the resolved theme to `processPresentation` by value.
+
+`processPresentation` used to re-resolve the theme a third time, by name,
+from `props.theme` — which forced both generation prologues to rewrite
+`props.theme` to a scoped synthetic name and inject the resolved theme
+into `customThemes` under it, and to flatten inline theme objects into
+generated named entries. `GenerationOptions.theme` now carries the
+resolved theme directly; the rewrite/injection dance is deleted and a
+document with an inline theme round-trips with `props.theme` exactly as
+authored. The name/inline lookup remains as the fallback for direct
+`processPresentation` callers.
+
+Render-neutral: all 3 stock templates (inline themes) byte-identical via
+both entry points.

--- a/packages/core-pptx/src/__tests__/pipeline-parity.test.ts
+++ b/packages/core-pptx/src/__tests__/pipeline-parity.test.ts
@@ -104,6 +104,43 @@ describe('generateBufferFromJson vs createPresentationGenerator', () => {
   });
 });
 
+describe('substitute-mode theme delivery', () => {
+  // The resolved theme reaches processPresentation by value. Before #135 it
+  // travelled by name — rewritten `props.theme` + a scoped customThemes
+  // entry — and a miss meant slide processing silently re-resolved a fresh,
+  // pre-substitute theme. This is the regression that fails if the handover
+  // is ever wired wrong: the non-safe family must not reach the slide XML.
+  it('renders substituted families identically on both paths', async () => {
+    const inter = deck({
+      name: 'subst-parity',
+      colors: {
+        primary: '#231F20',
+        secondary: '#595959',
+        accent: '#E6E620',
+        background: '#FFFFFF',
+        text: '#000000',
+      },
+      fonts: { heading: 'Inter', body: 'Inter' },
+      defaults: { fontSize: 18, fontColor: '#000000' },
+    });
+    const fonts = { mode: 'substitute' as const };
+
+    const viaCore = await generateBufferFromJson(
+      structuredClone(inter) as never,
+      { fonts }
+    );
+    const { buffer: viaPlugin } = await createPresentationGenerator({
+      fonts,
+    }).generateBuffer(structuredClone(inter) as never);
+
+    const core = await slideXml(viaCore as Buffer);
+    const plugin = await slideXml(viaPlugin);
+    expect(core).not.toContain('typeface="Inter"');
+    expect(core).toContain('typeface="Calibri"');
+    expect(plugin).toEqual(core);
+  });
+});
+
 describe('root props defaulting', () => {
   // The PPTX validator rejects a missing root `props`, so the divergence
   // lived behind `validation: { enabled: false }`: the core path died with a

--- a/packages/core-pptx/src/core/__tests__/inline-theme.test.ts
+++ b/packages/core-pptx/src/core/__tests__/inline-theme.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { processPresentation } from '../structure';
 import { generateBufferWithWarnings } from '../generator';
+import { resolveThemeContext } from '../generationContext';
 import type { PresentationComponentDefinition } from '../../types';
 
 const inlineTheme = {
@@ -53,5 +54,29 @@ describe('inline document theme', () => {
     expect(warnings.filter((w) => String(w.code).includes('THEME'))).toEqual(
       []
     );
+  });
+});
+
+describe('generation prologue with an inline theme', () => {
+  // The theme reaches processPresentation by value, so the prologue no longer
+  // flattens the inline object into a synthetic named customThemes entry —
+  // the document round-trips with `props.theme` exactly as authored.
+  it('leaves the authored props.theme untouched, in substitute mode too', () => {
+    const context = resolveThemeContext(doc(inlineTheme), {
+      fonts: { mode: 'substitute' },
+    });
+
+    expect(context.document.props.theme).toEqual(inlineTheme);
+    expect(context.theme.colors.accent).toBe('#CC785C');
+    // Cache key still scopes by export mode and inline name.
+    expect(context.themeName).toBe('editorial#substitute');
+  });
+
+  it('leaves an authored theme name untouched', () => {
+    const context = resolveThemeContext(doc('minimal'), {});
+
+    expect(context.document.props.theme).toBe('minimal');
+    expect(context.themeName).toBe('minimal');
+    expect(context.theme.name).toBe('minimal');
   });
 });

--- a/packages/core-pptx/src/core/generationContext.ts
+++ b/packages/core-pptx/src/core/generationContext.ts
@@ -45,15 +45,20 @@ export interface ThemeContextOptions {
 
 export interface GenerationThemeContext {
   /**
-   * The document after the export-mode pre-pass rewrote font references, with
-   * `props.theme` normalized to `themeName`. `processPresentation` re-resolves
-   * the theme by name from `props.theme`, so callers must register `theme`
-   * under `themeName` in the customThemes they pass it (#135 tracks deleting
-   * this dance by handing the resolved theme over directly).
+   * The document after the export-mode pre-pass rewrote font references.
+   * `props.theme` stays as authored (name or inline object) — callers hand
+   * `theme` to `processPresentation` by value instead of round-tripping it
+   * through a name lookup (#135).
    */
   document: PresentationComponentDefinition;
   theme: PptxThemeConfig;
-  /** Cache key: base theme name + export-mode scope. */
+  /**
+   * Cache key: base theme name + export-mode scope. Nothing in PPTX consumes
+   * a theme by name after the prologue today; this is the key a future
+   * theme-keyed cache must use (a substitute-mode run rewrites the theme in
+   * place, so it must never share a slot with a custom-mode run of the same
+   * base name — the DOCX layout cache is keyed exactly this way).
+   */
   themeName: string;
 }
 
@@ -80,26 +85,23 @@ export function resolveThemeContext(
   let document =
     documentIn.props === undefined ? { ...documentIn, props: {} } : documentIn;
 
-  // An inline theme object (self-contained document) is normalized to a name
-  // plus resolved config so font-mode scoping and the name-keyed re-resolution
-  // in `processPresentation` work unchanged. The inline object wins over any
-  // customThemes entry sharing its name, on both paths.
+  // An inline theme object (self-contained document) resolves directly and
+  // wins over any customThemes entry sharing its name, on both paths. The
+  // document keeps the authored object — nothing downstream resolves the
+  // theme by name anymore.
   let inlineTheme: PptxThemeConfig | undefined;
   if (
     typeof document.props.theme === 'object' &&
     document.props.theme !== null
   ) {
     inlineTheme = document.props.theme as PptxThemeConfig;
-    document = {
-      ...document,
-      props: { ...document.props, theme: inlineTheme.name || 'inline-theme' },
-    };
   }
 
-  const baseThemeName =
-    (document.props.theme as string | undefined) ??
-    defaultThemeName ??
-    'default';
+  const baseThemeName = inlineTheme
+    ? inlineTheme.name || 'inline-theme'
+    : (document.props.theme as string | undefined) ??
+      defaultThemeName ??
+      'default';
   let theme =
     inlineTheme ??
     (resolveNamedTheme
@@ -119,21 +121,9 @@ export function resolveThemeContext(
     });
   }
 
-  // Scope the cache key by mode so a theme-name-keyed cache can't leak a
-  // custom-mode run into a substitute-mode slot (or vice versa), then
-  // normalize `props.theme` to it: `processPresentation` resolves the theme
-  // from `props.theme`, so the name the document carries must be the name the
-  // caller registers the resolved theme under. Normalizing whenever the value
-  // differs — not only when mode scoping applies — is what keeps a
-  // constructor-supplied default theme name from being silently dropped
-  // between font resolution and slide processing.
-  const themeName = scopedThemeName(baseThemeName, fonts?.mode);
-  if (document.props.theme !== themeName) {
-    document = {
-      ...document,
-      props: { ...document.props, theme: themeName },
-    };
-  }
-
-  return { document, theme, themeName };
+  return {
+    document,
+    theme,
+    themeName: scopedThemeName(baseThemeName, fonts?.mode),
+  };
 }

--- a/packages/core-pptx/src/core/generator.ts
+++ b/packages/core-pptx/src/core/generator.ts
@@ -41,6 +41,12 @@ export interface GenerationValidationOptions {
  */
 export interface GenerationOptions extends PresentationPackagingOptions {
   customThemes?: Record<string, PptxThemeConfig>;
+  /**
+   * Fully resolved theme, set by the generation prologue after the
+   * export-mode pre-pass. Wins over the `props.theme` name/inline lookup in
+   * `processPresentation` — omit it (direct callers) to fall back to that.
+   */
+  theme?: PptxThemeConfig;
   services?: ServicesConfig;
   fonts?: FontRuntimeOpts;
   validation?: GenerationValidationOptions;
@@ -200,15 +206,11 @@ export async function generateBufferWithWarnings(
     warnings,
     options?.fonts
   );
-  // processPresentation re-resolves the theme from `props.theme` (normalized
-  // to context.themeName), so the resolved theme is registered under that
-  // name for it to find.
+  // processPresentation takes the resolved theme by value — the document's
+  // `props.theme` stays as authored and is not consulted again.
   const effectiveOptions: GenerationOptions = {
     ...options,
-    customThemes: {
-      ...(options?.customThemes ?? {}),
-      [context.themeName]: context.theme,
-    },
+    theme: context.theme,
   };
   // Gradient/pattern fills render as sentinel solid fills during generation;
   // packagePresentationBuffer splices the real fill XML in afterwards.

--- a/packages/core-pptx/src/core/structure.ts
+++ b/packages/core-pptx/src/core/structure.ts
@@ -59,13 +59,17 @@ export function processPresentation(
 ): ProcessedPresentation {
   const { props, children = [] } = document;
 
-  // `theme` is a name to resolve, or an inline theme config object embedded in
-  // the document itself (self-contained documents-as-data).
+  // The generation prologue hands the resolved theme over directly — after
+  // the export-mode pre-pass, so a name lookup here would resurrect
+  // pre-substitute font families. The `props.theme` resolution below (a name,
+  // or an inline theme config object embedded in the document itself —
+  // self-contained documents-as-data) is the fallback for direct callers.
   const baseTheme =
-    typeof props.theme === 'object' && props.theme !== null
+    options?.theme ??
+    (typeof props.theme === 'object' && props.theme !== null
       ? (props.theme as PptxThemeConfig)
       : options?.customThemes?.[props.theme ?? 'default'] ??
-        getPptxTheme(props.theme ?? 'default');
+        getPptxTheme(props.theme ?? 'default'));
 
   // Merge presentation-level componentDefaults on top of theme-level ones
   const presDefaults = props.componentDefaults;

--- a/packages/core-pptx/src/plugin/createPresentationGenerator.ts
+++ b/packages/core-pptx/src/plugin/createPresentationGenerator.ts
@@ -413,17 +413,11 @@ function createBuilderImpl<
       // and this path silently resolved by runtime precedence.
       assertNoContentConflicts(processedDocument);
 
-      // processPresentation re-resolves the theme from `props.theme`
-      // (normalized to context.themeName); inject the post-substitute theme
-      // under that name so substitute-mode rewrites survive into slide
-      // processing instead of being overwritten by a fresh `getPptxTheme()`
-      // lookup.
-      const effectiveCustomThemes = {
-        ...(state.customThemes ?? {}),
-        [context.themeName]: resolvedTheme,
-      };
+      // processPresentation takes the resolved (post-substitute) theme by
+      // value — the document's `props.theme` stays as authored and is not
+      // consulted again.
       const processed = processPresentation(processedDocument, {
-        customThemes: effectiveCustomThemes,
+        theme: resolvedTheme,
         services: state.services,
       });
       const pendingFills: PendingXmlFill[] = [];


### PR DESCRIPTION
Implements #135. **Stacked on #139** — do not merge first; retarget to `main` once #139 lands.

## What

`processPresentation` re-resolved the theme a third time, by name, from `props.theme` (`core/structure.ts`). That lookup was why both prologues had to rewrite `props.theme` to a scoped synthetic name, inject the resolved theme into `customThemes` under it, and flatten inline theme objects into generated named entries. Export-mode correctness rode on the injection winning the lookup.

Now `GenerationOptions.theme` carries the fully resolved (post-substitute) theme into `processPresentation` directly:

- The `props.theme` rewrite and the scoped `customThemes` injection are deleted from the context and both call sites.
- Inline theme objects are no longer flattened — **a document with an inline theme round-trips with `props.theme` exactly as authored** (the font collector and the substitute rewriter both special-case `theme.fonts.*` symmetrically, so the object riding in the doc changes nothing about font resolution).
- The name/inline lookup in `processPresentation` stays as the fallback for direct callers.
- The `componentDefaults` merge stays in `processPresentation` (document-level concern).

## Open questions from the issue — decisions

- **`scopedThemeName` fate**: kept as the context's returned `themeName` — a dormant, documented cache key. Nothing in PPTX consumes a theme by name after the prologue today, but a future theme-keyed cache must scope by export mode (substitute rewrites the theme in place), and DOCX's layout cache is keyed exactly this way. Keeping the `{document, theme, themeName}` return shape identical across the two format contexts is the point of the mirror.
- **Inline theme**: authored object end-to-end. No synthetic `inline-theme` / `name#substitute` strings anywhere in the document.

## Verification

- `pipeline-parity.test.ts`: new substitute-mode regression — non-safe family (`Inter`) in an inline theme must not reach slide XML (`Calibri` must), identical on both paths. This is the case that fails if the theme handover is ever wired wrong; it was previously protected only by the injection.
- `inline-theme.test.ts`: context now asserted to leave `props.theme` untouched (object, substitute mode included; name case too), with the cache key still scoping (`editorial#substitute`). Direct `processPresentation` fallback tests unchanged.
- All #134 parity cases still green (7/7), full `core-pptx` suite 19 files / 145 tests green, workspace build + test green.
- Render-neutrality: 3 stock templates — **all of which use inline themes**, so they exercise exactly the changed path — generated via both entry points, byte-identical vs the `main` baseline (6/6), warning counts unchanged.

Closes #135
