### PR TITLE
refactor(docx): extract shared line-run builder (closes #137)

### DIFF
--- a/.changeset/shared-line-run-builder.md
+++ b/.changeset/shared-line-run-builder.md
@@ -1,0 +1,5 @@
+---
+'@json-to-office/core-docx': patch
+---
+
+Extract the duplicated tab-splitting line-run builder shared by the plain-text and placeholder paths into `buildRunCommonProps` / `buildTextRuns` (textParser), so run-level properties can no longer drift between the two paths. No behavior change; parity now pinned by tests for every run-level prop.

--- a/packages/core-docx/src/__tests__/character-spacing.test.ts
+++ b/packages/core-docx/src/__tests__/character-spacing.test.ts
@@ -91,3 +91,94 @@ describe('font.characterSpacing (w:spacing)', () => {
     expect(await documentXml(buf)).toMatch(/<w:spacing w:val="30"/);
   });
 });
+
+/**
+ * The plain-text and placeholder paths now share one run builder
+ * (buildRunCommonProps / buildTextRuns in textParser). This suite pins the
+ * invariant that builder exists to guarantee: every run-level property
+ * renders identically whether or not the text contains a placeholder.
+ */
+describe('run-property parity between plain and placeholder paths', () => {
+  const cases: Array<{
+    label: string;
+    props: Record<string, unknown>;
+    pattern: RegExp;
+  }> = [
+    {
+      label: 'font family (w:rFonts)',
+      props: { font: { family: 'Courier New' } },
+      pattern: /<w:rFonts [^>]*w:ascii="Courier New"/,
+    },
+    {
+      label: 'font size (w:sz)',
+      props: { font: { size: 13 } },
+      pattern: /<w:sz w:val="26"/,
+    },
+    {
+      label: 'color (w:color)',
+      props: { font: { color: 'FF6600' } },
+      pattern: /<w:color w:val="FF6600"/,
+    },
+    {
+      label: 'bold (w:b)',
+      props: { font: { bold: true } },
+      pattern: /<w:b\/>/,
+    },
+    {
+      label: 'italic (w:i)',
+      props: { font: { italic: true } },
+      pattern: /<w:i\/>/,
+    },
+    {
+      label: 'underline (w:u)',
+      props: { font: { underline: true } },
+      pattern: /<w:u w:val="single"/,
+    },
+    {
+      label: 'scale (w:w)',
+      props: { font: { scale: 150 } },
+      pattern: /<w:w w:val="150"/,
+    },
+    {
+      label: 'characterSpacing (w:spacing)',
+      props: {
+        font: { characterSpacing: { type: 'expanded', value: 30 } },
+      },
+      pattern: /<w:spacing w:val="30"/,
+    },
+    {
+      label: 'language (w:lang)',
+      props: { language: 'fr-FR' },
+      pattern: /<w:lang [^>]*w:val="fr-FR"/,
+    },
+    {
+      label: 'noProof (w:noProof)',
+      props: { noProof: true },
+      pattern: /<w:noProof\/>/,
+    },
+  ];
+
+  async function renderParagraph(
+    text: string,
+    props: Record<string, unknown>
+  ): Promise<string> {
+    const buf = await generateBufferFromJson({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [{ name: 'paragraph', props: { text, ...props } }],
+    } as never);
+    return documentXml(buf);
+  }
+
+  for (const { label, props, pattern } of cases) {
+    it(`forwards ${label} on both paths`, async () => {
+      const plain = await renderParagraph('Alpha beta gamma.', props);
+      const withPlaceholder = await renderParagraph(
+        'Alpha {DATE} gamma.',
+        props
+      );
+      expect(plain).toMatch(pattern);
+      expect(withPlaceholder).toMatch(pattern);
+    });
+  }
+});

--- a/packages/core-docx/src/utils/placeholderProcessor.ts
+++ b/packages/core-docx/src/utils/placeholderProcessor.ts
@@ -8,11 +8,11 @@ import {
   PageNumber,
   ExternalHyperlink,
   InternalHyperlink,
-  Tab,
 } from 'docx';
 import {
   parseTextWithDecorators,
-  splitByNoProofWords,
+  buildRunCommonProps,
+  buildTextRuns,
   TextStyle,
 } from './textParser';
 import { normalizeUnicodeText } from './unicode';
@@ -291,71 +291,10 @@ function createTextRunsWithNewlines(
   baseStyle: TextStyle,
   noProofWords?: string[]
 ): TextRun[] {
-  const runs: TextRun[] = [];
-  const lines = text.split('\n');
-
-  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
-    const line = lines[lineIndex];
-    const needsLineBreak = lineIndex > 0;
-
-    if (line || needsLineBreak) {
-      const commonProps = {
-        font: baseStyle.font,
-        size: baseStyle.size,
-        color: baseStyle.color,
-        bold: baseStyle.bold,
-        italics: baseStyle.italics,
-        underline: baseStyle.underline,
-        ...(baseStyle.scale && { scale: baseStyle.scale }),
-        ...(baseStyle.characterSpacing && {
-          characterSpacing: baseStyle.characterSpacing,
-        }),
-        ...(baseStyle.language && { language: baseStyle.language }),
-      };
-      const wholeRunNoProof = baseStyle.noProof === true;
-      const wordsForLine = wholeRunNoProof ? undefined : noProofWords;
-
-      let firstSegment = true;
-      const lineRuns: TextRun[] = [];
-      // Tab characters become real <w:tab/> runs (see textParser) so
-      // paragraph tabStops apply.
-      const tabSegments = line.split('\t');
-      tabSegments.forEach((tabSegment, tabIndex) => {
-        if (tabIndex > 0) {
-          lineRuns.push(
-            new TextRun({
-              children: [new Tab()],
-              ...commonProps,
-              break: needsLineBreak && firstSegment ? 1 : undefined,
-            })
-          );
-          firstSegment = false;
-        }
-        if (!tabSegment && tabSegments.length > 1) return;
-        lineRuns.push(
-          ...splitByNoProofWords(
-            tabSegment,
-            (segment, matched) => {
-              const run = new TextRun({
-                text: segment,
-                ...commonProps,
-                ...((matched || baseStyle.noProof !== undefined) && {
-                  noProof: matched || wholeRunNoProof,
-                }),
-                break: needsLineBreak && firstSegment ? 1 : undefined,
-              });
-              firstSegment = false;
-              return run;
-            },
-            wordsForLine
-          )
-        );
-      });
-      runs.push(...lineRuns);
-    }
-  }
-
-  return runs;
+  return buildTextRuns(text, buildRunCommonProps(baseStyle), {
+    noProof: baseStyle.noProof,
+    noProofWords,
+  });
 }
 
 /**

--- a/packages/core-docx/src/utils/textParser.ts
+++ b/packages/core-docx/src/utils/textParser.ts
@@ -237,13 +237,99 @@ export function parseTextWithDecorators(
 }
 
 /**
- * Helper function to create TextRuns with newlines from text
+ * Run-level properties shared by every run produced for a piece of text.
+ * Single assembly point for both the plain-text and placeholder paths — a
+ * prop forwarded here reaches both, so the two cannot drift (issue #137).
  */
-function createTextRunsWithNewlines(
-  text: string,
+export function buildRunCommonProps(
   baseStyle: TextStyle,
-  options: TextDecoratorOptions,
-  overrideStyle?: { bold?: boolean; italics?: boolean }
+  overrides?: { bold?: boolean; italics?: boolean; boldColor?: string }
+) {
+  const bold = overrides?.bold ?? baseStyle.bold;
+  const italics = overrides?.italics ?? baseStyle.italics;
+  return {
+    ...(baseStyle.font && { font: baseStyle.font }),
+    ...(baseStyle.size && { size: baseStyle.size }),
+    ...(baseStyle.color && {
+      color:
+        bold && overrides?.boldColor ? overrides.boldColor : baseStyle.color,
+    }),
+    ...(bold !== undefined && { bold }),
+    ...(italics !== undefined && { italics }),
+    ...(baseStyle.underline && { underline: baseStyle.underline }),
+    ...(baseStyle.scale && { scale: baseStyle.scale }),
+    ...(baseStyle.characterSpacing && {
+      characterSpacing: baseStyle.characterSpacing,
+    }),
+    ...(baseStyle.language && { language: baseStyle.language }),
+  };
+}
+
+/**
+ * Build the runs for a single line of text: split on `\t` into real
+ * `<w:tab/>` runs (a tab char inside <w:t> would be silently dropped by
+ * Word, and paragraph tabStops only apply to real tab runs), emit no-proof
+ * word runs, and attach the line break to the first emitted run only.
+ */
+function buildLineRuns(
+  line: string,
+  commonProps: ReturnType<typeof buildRunCommonProps>,
+  opts: { needsLineBreak: boolean; noProof?: boolean; noProofWords?: string[] }
+): TextRun[] {
+  const { needsLineBreak, noProof } = opts;
+  // When the whole run is already no-proof, there's nothing to single out,
+  // so skip word splitting and emit one run for the line.
+  const wholeRunNoProof = noProof === true;
+  const wordsForLine = wholeRunNoProof ? undefined : opts.noProofWords;
+
+  // The line break belongs only on the first run of the line.
+  let firstSegment = true;
+  const lineRuns: TextRun[] = [];
+  const tabSegments = line.split('\t');
+  tabSegments.forEach((tabSegment, tabIndex) => {
+    if (tabIndex > 0) {
+      lineRuns.push(
+        new TextRun({
+          children: [new Tab()],
+          ...commonProps,
+          ...(needsLineBreak && firstSegment && { break: 1 }),
+        })
+      );
+      firstSegment = false;
+    }
+    if (!tabSegment && tabSegments.length > 1) return;
+    lineRuns.push(
+      ...splitByNoProofWords(
+        tabSegment,
+        (segment, matched) => {
+          const run = new TextRun({
+            text: segment,
+            ...commonProps,
+            ...((matched || noProof !== undefined) && {
+              noProof: matched || wholeRunNoProof,
+            }),
+            ...(needsLineBreak && firstSegment && { break: 1 }),
+          });
+          firstSegment = false;
+          return run;
+        },
+        wordsForLine
+      )
+    );
+  });
+  return lineRuns;
+}
+
+/**
+ * Turn multi-line text into TextRuns: `\n` becomes a run break, `\t` a real
+ * tab run, no-proof words their own runs. Shared by the plain-text path
+ * (textParser) and the placeholder path (placeholderProcessor) so run-level
+ * properties cannot diverge between them.
+ */
+export function buildTextRuns(
+  text: string,
+  commonProps: ReturnType<typeof buildRunCommonProps>,
+  opts: { noProof?: boolean; noProofWords?: string[] } = {}
 ): TextRun[] {
   const runs: TextRun[] = [];
   const lines = text.split('\n');
@@ -252,81 +338,35 @@ function createTextRunsWithNewlines(
     const line = lines[lineIndex];
     const needsLineBreak = lineIndex > 0;
 
+    // Create runs even for empty lines if they need a break
     if (line || needsLineBreak) {
-      // Create run even for empty lines if they need a break
-      const runStyle = {
-        bold: overrideStyle?.bold ?? baseStyle.bold,
-        italics: overrideStyle?.italics ?? baseStyle.italics,
-      };
-
-      // Properties shared by every run produced for this line.
-      const commonProps = {
-        ...(baseStyle.font && { font: baseStyle.font }),
-        ...(baseStyle.size && { size: baseStyle.size }),
-        ...(baseStyle.color && {
-          color:
-            runStyle.bold && options.boldColor
-              ? options.boldColor
-              : baseStyle.color,
-        }),
-        ...(runStyle.bold !== undefined && { bold: runStyle.bold }),
-        ...(runStyle.italics !== undefined && { italics: runStyle.italics }),
-        ...(baseStyle.underline && { underline: baseStyle.underline }),
-        ...(baseStyle.scale && { scale: baseStyle.scale }),
-        ...(baseStyle.characterSpacing && {
-          characterSpacing: baseStyle.characterSpacing,
-        }),
-        ...(baseStyle.language && { language: baseStyle.language }),
-      };
-
-      // When the whole run is already no-proof, there's nothing to single out,
-      // so skip word splitting and emit one run for the line.
-      const wholeRunNoProof = baseStyle.noProof === true;
-      const wordsForLine = wholeRunNoProof ? undefined : options.noProofWords;
-
-      // The line break belongs only on the first run of the line.
-      let firstSegment = true;
-      const lineRuns: TextRun[] = [];
-      // Tab characters become real <w:tab/> runs (a tab char inside <w:t>
-      // would be silently dropped by Word), so paragraph tabStops apply.
-      const tabSegments = line.split('\t');
-      tabSegments.forEach((tabSegment, tabIndex) => {
-        if (tabIndex > 0) {
-          lineRuns.push(
-            new TextRun({
-              children: [new Tab()],
-              ...commonProps,
-              ...(needsLineBreak && firstSegment && { break: 1 }),
-            })
-          );
-          firstSegment = false;
-        }
-        if (!tabSegment && tabSegments.length > 1) return;
-        lineRuns.push(
-          ...splitByNoProofWords(
-            tabSegment,
-            (segment, matched) => {
-              const segNoProof = matched || wholeRunNoProof;
-              const run = new TextRun({
-                text: segment,
-                ...commonProps,
-                ...((matched || baseStyle.noProof !== undefined) && {
-                  noProof: segNoProof,
-                }),
-                ...(needsLineBreak && firstSegment && { break: 1 }),
-              });
-              firstSegment = false;
-              return run;
-            },
-            wordsForLine
-          )
-        );
-      });
-      runs.push(...lineRuns);
+      runs.push(
+        ...buildLineRuns(line, commonProps, { needsLineBreak, ...opts })
+      );
     }
   }
 
   return runs;
+}
+
+/**
+ * Helper function to create TextRuns with newlines from text
+ */
+function createTextRunsWithNewlines(
+  text: string,
+  baseStyle: TextStyle,
+  options: TextDecoratorOptions,
+  overrideStyle?: { bold?: boolean; italics?: boolean }
+): TextRun[] {
+  return buildTextRuns(
+    text,
+    buildRunCommonProps(baseStyle, {
+      bold: overrideStyle?.bold,
+      italics: overrideStyle?.italics,
+      boldColor: options.boldColor,
+    }),
+    { noProof: baseStyle.noProof, noProofWords: options.noProofWords }
+  );
 }
 
 /**


### PR DESCRIPTION
Extracts the duplicated line-to-runs algorithm from `textParser.ts` and `placeholderProcessor.ts` into shared `buildRunCommonProps` + `buildTextRuns` helpers (living in `textParser.ts`, which `placeholderProcessor` already imports from).

- commonProps assembly — the part that actually drifted in #136 — is now built in one place, with the textParser-only bold/italics override + `boldColor` handled via an optional overrides arg (placeholder path passes none, matching prior behavior).
- `break` emission unified to the conditional-spread form; `break: undefined` and omitted are equivalent in docx.
- `character-spacing.test.ts` extended with a table-driven parity suite asserting plain vs placeholder text renders identical run properties for every run-level prop (rFonts, sz, color, b, i, u, w, spacing, lang, noProof).

All 562 core-docx tests pass.

Closes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of text formatting in DOCX output, including fonts, colors, emphasis, underlining, scaling, character spacing, language, and proofing settings.
  * Preserved formatting when text includes placeholders, line breaks, or tabs.
* **Tests**
  * Added coverage to verify matching formatting for regular and placeholder-containing paragraphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->