### PR TITLE
fix(themes): doc-named built-in beats constructor theme object (closes #141)

### DIFF
--- a/.changeset/doc-named-builtin-theme-precedence.md
+++ b/.changeset/doc-named-builtin-theme-precedence.md
@@ -1,0 +1,6 @@
+---
+'@json-to-office/core-docx': minor
+'@json-to-office/core-pptx': minor
+---
+
+Plugin builders: a document explicitly naming a known built-in theme now gets that built-in, instead of being shadowed by the constructor `theme` object. The constructor object still applies when the document names no theme or names something nothing recognizes (unknown-name fallback preserved). customThemes entries keep top precedence. Same contract in DOCX and PPTX.

--- a/packages/core-docx/src/__tests__/pipeline-parity.test.ts
+++ b/packages/core-docx/src/__tests__/pipeline-parity.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from 'vitest';
 import JSZip from 'jszip';
 import { generateBufferFromJson, generateDocument } from '../core/generator';
 import { createDocumentGenerator } from './../plugin/createDocumentGenerator';
+import { corporateTheme } from '../templates/themes';
 
 /**
  * Both parts matter: run/paragraph colors land in document.xml, while theme
@@ -135,5 +136,62 @@ describe('root props defaulting', () => {
         children: [],
       } as never)
     ).rejects.toThrow(/props` is null/);
+  });
+});
+
+describe('constructor theme precedence (#141)', () => {
+  // Plugin-only semantics (core has no constructor-theme input), pinned here
+  // so a change is a conscious decision: a document explicitly naming a known
+  // built-in gets it; the constructor `theme` object fills in when the doc
+  // names nothing or names something nothing recognizes. Mirrors the PPTX
+  // pins in core-pptx/src/__tests__/pipeline-parity.test.ts.
+  //
+  // Signal: corporate's heading font is Georgia; minimal has no Georgia
+  // anywhere, so its presence in styles.xml marks which theme rendered.
+  const ctorTheme = () =>
+    structuredClone(corporateTheme) as unknown as Parameters<
+      typeof createDocumentGenerator
+    >[0]['theme'];
+
+  const headingDoc = (theme?: string) => ({
+    name: 'docx',
+    props: theme === undefined ? {} : { theme },
+    children: [{ name: 'heading', props: { text: 'H', level: 1 } }],
+  });
+
+  async function stylesXml(doc: unknown, options: Record<string, unknown>) {
+    const result = await createDocumentGenerator(options).generateBuffer(
+      doc as never
+    );
+    return (await parts(result.buffer)).styles;
+  }
+
+  it('a doc-named built-in beats the constructor theme object', async () => {
+    const styles = await stylesXml(headingDoc('minimal'), {
+      theme: ctorTheme(),
+    });
+    expect(styles).not.toContain('Georgia');
+  });
+
+  it('constructor theme object applies when the doc names no theme', async () => {
+    const styles = await stylesXml(headingDoc(), { theme: ctorTheme() });
+    expect(styles).toContain('Georgia');
+  });
+
+  it('constructor theme object fills in for a doc-named unknown theme', async () => {
+    // resolveBuiltInTheme never misses (it falls back to minimal), so without
+    // this rule an unknown name would silently render minimal instead of the
+    // app's theme.
+    const styles = await stylesXml(headingDoc('wiseair'), {
+      theme: ctorTheme(),
+    });
+    expect(styles).toContain('Georgia');
+  });
+
+  it('a customThemes entry sharing a built-in name still wins', async () => {
+    const styles = await stylesXml(headingDoc('minimal'), {
+      customThemes: { minimal: ctorTheme() },
+    });
+    expect(styles).toContain('Georgia');
   });
 });

--- a/packages/core-docx/src/core/generationContext.ts
+++ b/packages/core-docx/src/core/generationContext.ts
@@ -29,12 +29,16 @@ export interface ThemeContextOptions {
   warnings?: GenerationWarning[];
   /**
    * Theme lookup for the base `props.theme` name. The plugin builder passes
-   * its own (customThemes → constructor-supplied theme → built-in); omit it to
-   * use customThemes → built-in.
+   * its own (customThemes → doc-named built-in → constructor-supplied theme →
+   * built-in); omit it to use customThemes → built-in. `authored` is true when
+   * the name came from the document's own `props.theme` (not the 'minimal'
+   * fallback), so the lookup can honor an explicitly doc-named built-in
+   * without the constructor theme being shadowed for unnamed docs (#141).
    */
   resolveNamedTheme?: (
     name: string,
-    warnings?: GenerationWarning[]
+    warnings: GenerationWarning[] | undefined,
+    authored: boolean
   ) => ThemeConfig;
 }
 
@@ -89,9 +93,14 @@ export function resolveThemeContext(
   const document =
     documentIn.props === undefined ? { ...documentIn, props: {} } : documentIn;
 
-  const baseThemeName = document.props.theme || 'minimal';
+  const authoredThemeName = document.props.theme || undefined;
+  const baseThemeName = authoredThemeName ?? 'minimal';
   let theme = resolveNamedTheme
-    ? resolveNamedTheme(baseThemeName, warnings)
+    ? resolveNamedTheme(
+        baseThemeName,
+        warnings,
+        authoredThemeName !== undefined
+      )
     : defaultNamedThemeLookup(baseThemeName, customThemes, warnings);
 
   // In-document partial theme, merged before the export-mode pre-pass so a

--- a/packages/core-docx/src/plugin/createDocumentGenerator.ts
+++ b/packages/core-docx/src/plugin/createDocumentGenerator.ts
@@ -3,6 +3,7 @@ import type { CustomComponent } from './createComponent';
 import type { ComponentDefinition, ReportComponentDefinition } from '../types';
 import { type ThemeConfig } from '../styles';
 import { resolveBuiltInTheme } from '../styles/theme-resolver';
+import { hasTheme } from '../templates/themes';
 import { resolveThemeContext } from '../core/generationContext';
 import type { GenerationWarning } from '@json-to-office/shared-docx';
 import type { ServicesConfig, FontRuntimeOpts } from '@json-to-office/shared';
@@ -91,11 +92,21 @@ function createBuilderImpl<
   const componentMap = new Map(state.components.map((c) => [c.name, c]));
 
   /**
-   * Resolve theme for a document: customThemes → built-in → constructor fallback
+   * Resolve theme for a document: customThemes → doc-named built-in →
+   * constructor theme → built-in resolver fallback.
+   *
+   * A document explicitly naming a known built-in gets it; the constructor
+   * `theme` object fills in when the document names nothing or names
+   * something nothing recognizes (#141). The `authored` guard on the
+   * built-in step matters twice over: the unauthored 'minimal' fallback
+   * must not shadow the constructor theme, and an authored UNKNOWN name
+   * must still reach the constructor theme rather than silently rendering
+   * the resolver's minimal fallback.
    */
   function resolveDocumentTheme(
     themeName: string,
-    warnings?: GenerationWarning[]
+    warnings: GenerationWarning[] | undefined,
+    authored: boolean
   ): ThemeConfig {
     if (state.customThemes) {
       if (state.customThemes[themeName]) {
@@ -107,6 +118,12 @@ function createBuilderImpl<
       if (key) {
         return state.customThemes[key];
       }
+    }
+    if (authored && hasTheme(themeName)) {
+      return resolveBuiltInTheme(themeName, {
+        customThemes: state.customThemes,
+        warnings,
+      });
     }
     if (state.theme) {
       return state.theme;
@@ -452,8 +469,9 @@ function createBuilderImpl<
       // Initialize warnings collector
       const warnings: GenerationWarning[] = [];
 
-      // Props defaulting, theme resolution (customThemes → constructor theme →
-      // built-in), in-document overrides, export-mode pre-pass and cache-key
+      // Props defaulting, theme resolution (customThemes → doc-named
+      // built-in → constructor theme → built-in fallback, see
+      // resolveDocumentTheme), in-document overrides, export-mode pre-pass and cache-key
       // scoping — shared with the core pipeline so the two cannot drift (see
       // core/generationContext.ts). The pre-pass runs BEFORE custom-component
       // expansion so components reading `theme.fonts.*` during render see the

--- a/packages/core-pptx/src/__tests__/pipeline-parity.test.ts
+++ b/packages/core-pptx/src/__tests__/pipeline-parity.test.ts
@@ -316,9 +316,9 @@ describe('constructor default theme', () => {
 
   // Constructor OBJECT precedence — plugin-only semantics (core has no
   // constructor-theme input), pinned here so a change is a conscious decision:
-  // the object fills in for any customThemes miss, doc-named built-ins
-  // included, matching the DOCX plugin's resolveDocumentTheme. Revisited
-  // cross-format in #141.
+  // a document explicitly naming a known built-in gets it; the object fills
+  // in when the doc names nothing or names something nothing recognizes
+  // (#141), matching the DOCX plugin's resolveDocumentTheme.
   const ctorObject = {
     name: 'app-theme',
     colors: {
@@ -348,9 +348,27 @@ describe('constructor default theme', () => {
     ],
   });
 
-  it('constructor theme object beats a doc-named built-in (current contract, #141)', async () => {
+  it('a doc-named built-in beats the constructor theme object (#141)', async () => {
     const { buffer } = await createPresentationGenerator({
       theme: ctorObject,
+    }).generateBuffer(accentText('minimal') as never);
+    // themes.minimal accent, not the constructor object's
+    expect(await slideXml(buffer)).toContain('999999');
+  });
+
+  it('constructor theme object applies when the doc names no theme', async () => {
+    const { buffer } = await createPresentationGenerator({
+      theme: ctorObject,
+    }).generateBuffer(accentText() as never);
+    expect(await slideXml(buffer)).toContain('0FA958');
+  });
+
+  it('a customThemes entry sharing a built-in name still wins', async () => {
+    const { buffer } = await createPresentationGenerator({
+      theme: ctorObject,
+      customThemes: {
+        minimal: { ...ctorObject, name: 'minimal' },
+      },
     }).generateBuffer(accentText('minimal') as never);
     expect(await slideXml(buffer)).toContain('0FA958');
   });

--- a/packages/core-pptx/src/core/generationContext.ts
+++ b/packages/core-pptx/src/core/generationContext.ts
@@ -37,10 +37,14 @@ export interface ThemeContextOptions {
   defaultThemeName?: string;
   /**
    * Theme lookup for the base `props.theme` name. The plugin builder passes
-   * its own (customThemes → constructor theme object → built-in); omit it to
-   * use customThemes → built-in.
+   * its own (customThemes → doc-named built-in → constructor theme object →
+   * built-in); omit it to use customThemes → built-in. `authored` is true
+   * when the name came from the document's own `props.theme` (as opposed to
+   * `defaultThemeName` or the 'default' fallback), so the lookup can honor
+   * an explicitly doc-named built-in without the constructor object
+   * swallowing the default name too (#141).
    */
-  resolveNamedTheme?: (name: string) => PptxThemeConfig;
+  resolveNamedTheme?: (name: string, authored: boolean) => PptxThemeConfig;
 }
 
 export interface GenerationThemeContext {
@@ -97,15 +101,15 @@ export function resolveThemeContext(
     inlineTheme = document.props.theme as PptxThemeConfig;
   }
 
+  const authoredThemeName =
+    typeof document.props.theme === 'string' ? document.props.theme : undefined;
   const baseThemeName = inlineTheme
     ? inlineTheme.name || 'inline-theme'
-    : (document.props.theme as string | undefined) ??
-      defaultThemeName ??
-      'default';
+    : authoredThemeName ?? defaultThemeName ?? 'default';
   let theme =
     inlineTheme ??
     (resolveNamedTheme
-      ? resolveNamedTheme(baseThemeName)
+      ? resolveNamedTheme(baseThemeName, authoredThemeName !== undefined)
       : customThemes?.[baseThemeName] ?? getPptxTheme(baseThemeName));
 
   // Export-mode pre-pass: substitute rewrites non-safe families in place;

--- a/packages/core-pptx/src/plugin/createPresentationGenerator.ts
+++ b/packages/core-pptx/src/plugin/createPresentationGenerator.ts
@@ -26,7 +26,7 @@ import { validatePresentation, cleanComponentProps } from './validation';
 import { generatePluginPresentationSchema, exportPluginSchema } from './schema';
 import { processPresentation } from '../core/structure';
 import { renderPresentation } from '../core/render';
-import { getPptxTheme } from '../themes';
+import { getPptxTheme, hasPptxTheme } from '../themes';
 import type { ServicesConfig, FontRuntimeOpts } from '@json-to-office/shared';
 import { resolveDocumentFonts } from '../core/fontResolution';
 import { resolveThemeContext } from '../core/generationContext';
@@ -305,23 +305,27 @@ function createBuilderImpl<
       // `theme.fonts.*` during render sees the substituted names, not the
       // original non-safe ones.
       //
-      // Theme precedence: customThemes[name] → constructor `state.theme`
-      // object → built-in, with the lookup name taken from doc-level
-      // `props.theme` (or `defaultThemeName` when the doc names none). The
-      // constructor object fills in for ANY customThemes miss — a doc-named
-      // built-in included — matching the DOCX plugin (resolveDocumentTheme)
-      // exactly; it never shadows a customThemes entry (a doc naming
-      // "wiseair" must not render as `themes.minimal`). Whether a doc-named
-      // built-in should instead beat the constructor object is #141 — a
-      // cross-format decision, not taken here.
+      // Theme precedence: customThemes[name] → doc-named built-in →
+      // constructor `state.theme` object → built-in, with the lookup name
+      // taken from doc-level `props.theme` (or `defaultThemeName` when the
+      // doc names none). A document explicitly naming a known built-in gets
+      // it; the constructor object fills in when the doc names nothing or
+      // names something nothing recognizes (#141). The `authored` guard on
+      // the built-in step matters twice over: an unauthored default name
+      // must not shadow the constructor object, and an authored UNKNOWN name
+      // must still reach the constructor object (getPptxTheme never misses —
+      // a doc naming "wiseair" must render the app's theme, not silently
+      // fall back to default). Matches the DOCX plugin
+      // (resolveDocumentTheme) exactly.
       const context = resolveThemeContext(internalDocument, {
         customThemes: state.customThemes,
         fonts: state.fonts,
         warnings,
         defaultThemeName:
           typeof state.theme === 'string' ? state.theme : undefined,
-        resolveNamedTheme: (name) =>
+        resolveNamedTheme: (name, authored) =>
           state.customThemes?.[name] ??
+          (authored && hasPptxTheme(name) ? getPptxTheme(name) : undefined) ??
           (typeof state.theme === 'object' && state.theme !== null
             ? state.theme
             : getPptxTheme(name)),

--- a/packages/core-pptx/src/themes/defaults.ts
+++ b/packages/core-pptx/src/themes/defaults.ts
@@ -5,13 +5,13 @@
 import type { PptxThemeConfig, TextStyle, StyleName } from '../types';
 
 const DEFAULT_STYLES: Partial<Record<StyleName, TextStyle>> = {
-  title:    { fontSize: 36, bold: true, fontColor: 'text', align: 'center' },
+  title: { fontSize: 36, bold: true, fontColor: 'text', align: 'center' },
   subtitle: { fontSize: 20, italic: true, fontColor: 'text2', align: 'center' },
   heading1: { fontSize: 28, bold: true, fontColor: 'primary' },
   heading2: { fontSize: 22, bold: true, fontColor: 'primary' },
   heading3: { fontSize: 18, bold: true, fontColor: 'text' },
-  body:     { fontSize: 14 },
-  caption:  { fontSize: 10, italic: true, fontColor: 'text2' },
+  body: { fontSize: 14 },
+  caption: { fontSize: 10, italic: true, fontColor: 'text2' },
 };
 
 export const DEFAULT_PPTX_THEME: PptxThemeConfig = {
@@ -93,6 +93,15 @@ const PPTX_THEMES: Record<string, PptxThemeConfig> = {
 
 export function getPptxTheme(name: string): PptxThemeConfig {
   return PPTX_THEMES[name] || DEFAULT_PPTX_THEME;
+}
+
+/**
+ * Whether `name` is a known built-in theme. `getPptxTheme` never misses (it
+ * falls back to the default theme), so callers that need to distinguish "a
+ * real built-in" from "an unknown name" must check here first.
+ */
+export function hasPptxTheme(name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(PPTX_THEMES, name);
 }
 
 export const pptxThemes = PPTX_THEMES;

--- a/packages/core-pptx/src/themes/index.ts
+++ b/packages/core-pptx/src/themes/index.ts
@@ -1,1 +1,6 @@
-export { DEFAULT_PPTX_THEME, getPptxTheme, pptxThemes } from './defaults';
+export {
+  DEFAULT_PPTX_THEME,
+  getPptxTheme,
+  hasPptxTheme,
+  pptxThemes,
+} from './defaults';


### PR DESCRIPTION
Takes the **doc wins** reading from #141, for both formats in one PR:

**New precedence (both plugin builders):** `customThemes[name]` → doc-named **known** built-in → constructor `theme` object → built-in resolver fallback.

Implementation: `resolveThemeContext` now tells `resolveNamedTheme` whether the name was **authored** by the document (vs the `'minimal'`/`'default'`/`defaultThemeName` fallback). The built-in step only fires for authored names — this is what keeps both constraints intact:

- unnamed docs still get the constructor object (the default name must not shadow it);
- a doc naming an unknown theme (`wiseair`) still gets the constructor object, since `hasTheme` / new `hasPptxTheme` membership checks are consulted instead of the never-missing resolvers.

Also:
- pinned PPTX pipeline-parity test flipped consciously; added pins for the unnamed-doc and customThemes-shadowing cases
- mirrored DOCX pins added (they didn't exist)
- DOCX `resolveDocumentTheme` docstring fixed (it misstated its own code)

core-docx 556 ✓, core-pptx 149 ✓, all other packages ✓.