### PR TITLE
fix(server): inline bundled template media as data URLs in safe mode

### DIFF
--- a/.changeset/inline-template-media.md
+++ b/.changeset/inline-template-media.md
@@ -1,0 +1,15 @@
+---
+'@json-to-office/jto': patch
+---
+
+fix(server): inline bundled template media as data URLs in safe mode
+
+Deployed playgrounds run with `OUTBOUND_SOURCE_MODE=safe`, which rejects the
+relative `media/...` paths every bundled template ships with — and docx
+`visual` components ship their JSON to the remote rasterizer, which has no
+access to those files anyway. When a request's `sourceName` matches a
+server-discovered document, its relative image references (image components,
+`{ image: { path } }` backgrounds, visual elements) are now resolved against
+the document's directory, containment-checked, and inlined as `data:` URLs
+before outbound-source validation. Arbitrary client paths stay blocked;
+development mode keeps filesystem resolution untouched.

--- a/packages/jto/src/server/routes/format.ts
+++ b/packages/jto/src/server/routes/format.ts
@@ -29,6 +29,7 @@ import {
   LibreOfficeOutputNotFoundError,
   LibreOfficeTimeoutError,
 } from '../services/libreoffice-converter.js';
+import { inlineTemplateMedia } from '../services/template-media-inliner.js';
 
 export function createFormatRouter(adapter: FormatAdapter) {
   const router = new Hono<AppEnv>();
@@ -71,6 +72,26 @@ export function createFormatRouter(adapter: FormatAdapter) {
     }
   };
 
+  // In safe mode, relative media of a server-discovered document is inlined
+  // as data URLs so bundled templates pass source validation and survive the
+  // trip to the remote rasterizer. Development mode keeps filesystem
+  // resolution (and the path-keyed visual cache) untouched.
+  const inlineDiscoveredMedia = async (
+    jsonDefinition: unknown,
+    baseDir: string | undefined
+  ): Promise<unknown> => {
+    if (
+      baseDir === undefined ||
+      config.outboundSources.mode === 'development'
+    ) {
+      return jsonDefinition;
+    }
+    return inlineTemplateMedia(jsonDefinition, baseDir, {
+      maxFileBytes: config.requestLimits.maxFileSize,
+      maxTotalBytes: config.requestLimits.maxBodySize,
+    });
+  };
+
   const contentTypeMw = async (c: any, next: () => Promise<void>) => {
     const contentType = c.req.header('content-type');
     if (!contentType || !contentType.includes('application/json')) {
@@ -101,7 +122,16 @@ export function createFormatRouter(adapter: FormatAdapter) {
       const requestId = c.get('requestId');
 
       try {
-        assertRequestSources(jsonDefinition, 'jsonDefinition');
+        // Resolve the trusted sourceName -> baseDir mapping first so bundled
+        // template media can be inlined as data URLs before safe-mode source
+        // validation (which rejects relative paths from HTTP clients).
+        const baseDir = await resolveSourceBaseDir(options);
+        const effectiveDefinition = await inlineDiscoveredMedia(
+          jsonDefinition,
+          baseDir
+        );
+
+        assertRequestSources(effectiveDefinition, 'jsonDefinition');
         assertRequestSources(customThemes, 'customThemes');
         assertRequestSources(options, 'options');
 
@@ -127,8 +157,6 @@ export function createFormatRouter(adapter: FormatAdapter) {
           sanitizedFonts = rawFonts;
         }
 
-        const baseDir = await resolveSourceBaseDir(options);
-
         // `baseDir` selects the directory local media paths resolve against —
         // never accept it from the HTTP client. Only the server-side
         // sourceName mapping above may set it.
@@ -136,7 +164,7 @@ export function createFormatRouter(adapter: FormatAdapter) {
         delete clientOptions.baseDir;
 
         const result = await generatorService.generate({
-          jsonDefinition,
+          jsonDefinition: effectiveDefinition,
           customThemes,
           options: {
             ...clientOptions,
@@ -471,16 +499,20 @@ export function createFormatRouter(adapter: FormatAdapter) {
       }>(c, 'json');
 
       try {
-        assertRequestSources(jsonDefinition, 'jsonDefinition');
-        assertRequestSources(customThemes, 'customThemes');
-        assertRequestSources(options, 'options');
-
         // Same server-side sourceName -> baseDir mapping as /generate, so
         // previews resolve relative asset paths the way downloads do (#142).
         const baseDir = await resolveSourceBaseDir(options);
+        const effectiveDefinition = await inlineDiscoveredMedia(
+          jsonDefinition,
+          baseDir
+        );
+
+        assertRequestSources(effectiveDefinition, 'jsonDefinition');
+        assertRequestSources(customThemes, 'customThemes');
+        assertRequestSources(options, 'options');
 
         const generated = await generatorService.generate({
-          jsonDefinition,
+          jsonDefinition: effectiveDefinition,
           customThemes,
           options: {
             bypassCache: true,

--- a/packages/jto/src/server/services/__tests__/template-media-inliner.test.ts
+++ b/packages/jto/src/server/services/__tests__/template-media-inliner.test.ts
@@ -116,6 +116,31 @@ describe('inlineTemplateMedia', () => {
     expect(result.children[1].props.path).toBe('media/big.png');
   });
 
+  it('charges equivalent path spellings of one file only once', async () => {
+    const doc = {
+      children: [
+        { name: 'image', props: { path: 'media/logo.png' } },
+        { name: 'image', props: { path: 'media/./logo.png' } },
+      ],
+    };
+    const result = (await inlineTemplateMedia(doc, baseDir, {
+      maxTotalBytes: PNG_BYTES.length,
+    })) as typeof doc;
+    expect(result.children[0].props.path).toBe(PNG_DATA_URL);
+    expect(result.children[1].props.path).toBe(PNG_DATA_URL);
+  });
+
+  it('parses string definitions and inlines their media', async () => {
+    const doc = JSON.stringify({
+      children: [{ name: 'image', props: { path: 'media/logo.png' } }],
+    });
+    const result = (await inlineTemplateMedia(doc, baseDir)) as any;
+    expect(typeof result).toBe('object');
+    expect(result.children[0].props.path).toBe(PNG_DATA_URL);
+    // malformed strings pass through for structural validation
+    expect(await inlineTemplateMedia('{oops', baseDir)).toBe('{oops');
+  });
+
   it('reuses cached data for repeated references without double-charging', async () => {
     const doc = {
       children: [

--- a/packages/jto/src/server/services/__tests__/template-media-inliner.test.ts
+++ b/packages/jto/src/server/services/__tests__/template-media-inliner.test.ts
@@ -1,0 +1,132 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { inlineTemplateMedia } from '../template-media-inliner';
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const PNG_DATA_URL = `data:image/png;base64,${PNG_BYTES.toString('base64')}`;
+
+let baseDir: string;
+
+beforeAll(async () => {
+  baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jto-inline-'));
+  await fs.mkdir(path.join(baseDir, 'media'), { recursive: true });
+  await fs.writeFile(path.join(baseDir, 'media', 'logo.png'), PNG_BYTES);
+  await fs.writeFile(path.join(baseDir, 'media', 'big.png'), PNG_BYTES);
+  await fs.writeFile(path.join(baseDir, 'media', 'notes.txt'), 'not an image');
+});
+
+afterAll(async () => {
+  await fs.rm(baseDir, { recursive: true, force: true });
+});
+
+describe('inlineTemplateMedia', () => {
+  it('inlines relative image component paths as data URLs', async () => {
+    const doc = {
+      children: [{ name: 'image', props: { path: 'media/logo.png' } }],
+    };
+    const result = (await inlineTemplateMedia(doc, baseDir)) as typeof doc;
+    expect(result.children[0].props.path).toBe(PNG_DATA_URL);
+    // input untouched
+    expect(doc.children[0].props.path).toBe('media/logo.png');
+  });
+
+  it('inlines background { image: { path } } objects', async () => {
+    const doc = {
+      props: { background: { image: { path: 'media/logo.png' } } },
+    };
+    const result = (await inlineTemplateMedia(doc, baseDir)) as typeof doc;
+    expect(result.props.background.image.path).toBe(PNG_DATA_URL);
+  });
+
+  it('inlines image elements nested in visual components', async () => {
+    const doc = {
+      children: [
+        {
+          name: 'visual',
+          props: {
+            elements: [
+              { name: 'shape', props: { type: 'rect' } },
+              { name: 'image', props: { path: 'media/logo.png' } },
+            ],
+          },
+        },
+      ],
+    };
+    const result = (await inlineTemplateMedia(doc, baseDir)) as any;
+    expect(result.children[0].props.elements[1].props.path).toBe(PNG_DATA_URL);
+  });
+
+  it('leaves URLs, data URLs, and absolute paths untouched', async () => {
+    const doc = {
+      children: [
+        { name: 'image', props: { path: 'https://example.com/a.png' } },
+        { name: 'image', props: { path: PNG_DATA_URL } },
+        { name: 'image', props: { path: '/etc/passwd' } },
+      ],
+    };
+    const result = (await inlineTemplateMedia(doc, baseDir)) as typeof doc;
+    expect(result.children.map((c) => c.props.path)).toEqual(
+      doc.children.map((c) => c.props.path)
+    );
+  });
+
+  it('does not inline paths escaping baseDir or missing files', async () => {
+    const escape = path.join('..', path.basename(baseDir), 'media', 'logo.png');
+    const doc = {
+      children: [
+        { name: 'image', props: { path: '../outside.png' } },
+        { name: 'image', props: { path: 'media/missing.png' } },
+        { name: 'image', props: { path: 'media/../../oops.png' } },
+        { name: 'image', props: { path: escape } },
+      ],
+    };
+    const result = (await inlineTemplateMedia(doc, baseDir)) as typeof doc;
+    expect(result.children[0].props.path).toBe('../outside.png');
+    expect(result.children[1].props.path).toBe('media/missing.png');
+    expect(result.children[2].props.path).toBe('media/../../oops.png');
+  });
+
+  it('skips non-image extensions and files over the per-file cap', async () => {
+    const doc = {
+      children: [
+        { name: 'image', props: { path: 'media/notes.txt' } },
+        { name: 'image', props: { path: 'media/big.png' } },
+      ],
+    };
+    const result = (await inlineTemplateMedia(doc, baseDir, {
+      maxFileBytes: 4,
+    })) as typeof doc;
+    expect(result.children[0].props.path).toBe('media/notes.txt');
+    expect(result.children[1].props.path).toBe('media/big.png');
+  });
+
+  it('stops inlining once the total budget is exhausted', async () => {
+    const doc = {
+      children: [
+        { name: 'image', props: { path: 'media/logo.png' } },
+        { name: 'image', props: { path: 'media/big.png' } },
+      ],
+    };
+    const result = (await inlineTemplateMedia(doc, baseDir, {
+      maxTotalBytes: PNG_BYTES.length,
+    })) as typeof doc;
+    expect(result.children[0].props.path).toBe(PNG_DATA_URL);
+    expect(result.children[1].props.path).toBe('media/big.png');
+  });
+
+  it('reuses cached data for repeated references without double-charging', async () => {
+    const doc = {
+      children: [
+        { name: 'image', props: { path: 'media/logo.png' } },
+        { name: 'image', props: { path: 'media/logo.png' } },
+      ],
+    };
+    const result = (await inlineTemplateMedia(doc, baseDir, {
+      maxTotalBytes: PNG_BYTES.length,
+    })) as typeof doc;
+    expect(result.children[0].props.path).toBe(PNG_DATA_URL);
+    expect(result.children[1].props.path).toBe(PNG_DATA_URL);
+  });
+});

--- a/packages/jto/src/server/services/template-media-inliner.ts
+++ b/packages/jto/src/server/services/template-media-inliner.ts
@@ -60,12 +60,15 @@ async function toDataUrl(
   baseDir: string,
   state: InlineState
 ): Promise<string | null> {
-  const cached = state.cache.get(source);
-  if (cached !== undefined) return cached;
-
+  // Key the cache by canonical path so equivalent spellings of the same file
+  // (`media/logo.png` vs `media/./logo.png`) share one budget charge.
+  let cacheKey = source;
   let result: string | null = null;
   try {
     const resolved = await fs.realpath(path.resolve(baseDir, source));
+    cacheKey = resolved;
+    const cached = state.cache.get(cacheKey);
+    if (cached !== undefined) return cached;
     const contained =
       resolved === state.baseDirReal ||
       resolved.startsWith(state.baseDirReal + path.sep);
@@ -88,7 +91,7 @@ async function toDataUrl(
     // Missing or unreadable file: leave the reference for the policy layer,
     // whose error message names the offending JSON path.
   }
-  state.cache.set(source, result);
+  state.cache.set(cacheKey, result);
   return result;
 }
 
@@ -145,6 +148,16 @@ export async function inlineTemplateMedia(
   baseDir: string,
   options: InlineTemplateMediaOptions = {}
 ): Promise<unknown> {
+  // The generation schema also accepts a JSON string definition; parse it so
+  // its media inlines too (the generator accepts either form downstream).
+  if (typeof jsonDefinition === 'string') {
+    try {
+      jsonDefinition = JSON.parse(jsonDefinition);
+    } catch {
+      // Structural validation owns malformed JSON reporting.
+      return jsonDefinition;
+    }
+  }
   if (!jsonDefinition || typeof jsonDefinition !== 'object') {
     return jsonDefinition;
   }

--- a/packages/jto/src/server/services/template-media-inliner.ts
+++ b/packages/jto/src/server/services/template-media-inliner.ts
@@ -1,0 +1,168 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Inline relative media references of a server-discovered document as data
+ * URLs, so bundled templates survive safe-mode outbound-source validation and
+ * remote rasterization (which runs on a host without the template's files).
+ *
+ * Only relative paths that canonicalize inside `baseDir` are inlined; anything
+ * else (absolute paths, URLs, data URLs, `..` escapes, missing or oversized
+ * files) is left untouched for the outbound-source policy to judge.
+ */
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.tiff': 'image/tiff',
+  '.tif': 'image/tiff',
+};
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isInlineCandidate(source: string): boolean {
+  if (!source || source.includes('\0')) return false;
+  if (source.startsWith('data:')) return false;
+  if (path.isAbsolute(source)) return false;
+  try {
+    new URL(source);
+    return false; // absolute URL — policy handles it
+  } catch {
+    return true;
+  }
+}
+
+export interface InlineTemplateMediaOptions {
+  /** Per-file size cap in bytes; larger files are left as-is. */
+  maxFileBytes?: number;
+  /** Total inlined bytes cap; once exceeded, remaining files are left as-is. */
+  maxTotalBytes?: number;
+}
+
+interface InlineState {
+  baseDirReal: string;
+  maxFileBytes: number;
+  totalBudget: number;
+  cache: Map<string, string | null>;
+}
+
+async function toDataUrl(
+  source: string,
+  baseDir: string,
+  state: InlineState
+): Promise<string | null> {
+  const cached = state.cache.get(source);
+  if (cached !== undefined) return cached;
+
+  let result: string | null = null;
+  try {
+    const resolved = await fs.realpath(path.resolve(baseDir, source));
+    const contained =
+      resolved === state.baseDirReal ||
+      resolved.startsWith(state.baseDirReal + path.sep);
+    if (contained) {
+      const mime = MIME_BY_EXTENSION[path.extname(resolved).toLowerCase()];
+      if (mime) {
+        const stat = await fs.stat(resolved);
+        if (
+          stat.isFile() &&
+          stat.size <= state.maxFileBytes &&
+          stat.size <= state.totalBudget
+        ) {
+          const buffer = await fs.readFile(resolved);
+          state.totalBudget -= buffer.length;
+          result = `data:${mime};base64,${buffer.toString('base64')}`;
+        }
+      }
+    }
+  } catch {
+    // Missing or unreadable file: leave the reference for the policy layer,
+    // whose error message names the offending JSON path.
+  }
+  state.cache.set(source, result);
+  return result;
+}
+
+async function visit(
+  value: unknown,
+  containerKey: string | undefined,
+  baseDir: string,
+  state: InlineState,
+  seen: WeakSet<object>
+): Promise<void> {
+  if (!value || typeof value !== 'object' || seen.has(value)) return;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      await visit(entry, containerKey, baseDir, state, seen);
+    }
+    return;
+  }
+
+  const record = value as JsonRecord;
+
+  // Image components: { name: 'image', props: { path } }.
+  const componentName =
+    typeof record.name === 'string' ? record.name.toLowerCase() : undefined;
+  const props = isRecord(record.props) ? record.props : undefined;
+  if (
+    componentName === 'image' &&
+    props &&
+    typeof props.path === 'string' &&
+    isInlineCandidate(props.path)
+  ) {
+    const inlined = await toDataUrl(props.path, baseDir, state);
+    if (inlined !== null) props.path = inlined;
+  }
+
+  // Canvas/slide backgrounds: plain { image: { path } } objects.
+  if (
+    containerKey === 'image' &&
+    typeof record.path === 'string' &&
+    isInlineCandidate(record.path)
+  ) {
+    const inlined = await toDataUrl(record.path, baseDir, state);
+    if (inlined !== null) record.path = inlined;
+  }
+
+  for (const [key, child] of Object.entries(record)) {
+    await visit(child, key, baseDir, state, seen);
+  }
+}
+
+export async function inlineTemplateMedia(
+  jsonDefinition: unknown,
+  baseDir: string,
+  options: InlineTemplateMediaOptions = {}
+): Promise<unknown> {
+  if (!jsonDefinition || typeof jsonDefinition !== 'object') {
+    return jsonDefinition;
+  }
+
+  let baseDirReal: string;
+  try {
+    baseDirReal = await fs.realpath(baseDir);
+  } catch {
+    return jsonDefinition;
+  }
+
+  const clone = structuredClone(jsonDefinition);
+  const state: InlineState = {
+    baseDirReal,
+    maxFileBytes: options.maxFileBytes ?? 10 * 1024 * 1024,
+    totalBudget: options.maxTotalBytes ?? 32 * 1024 * 1024,
+    cache: new Map(),
+  };
+  await visit(clone, undefined, baseDir, state, new WeakSet());
+  return clone;
+}


### PR DESCRIPTION
## Problem
Deployed playgrounds run with `OUTBOUND_SOURCE_MODE=safe`, which rejects the relative `media/...` paths every bundled template ships with (`Unsafe outbound source ... local and relative file paths are disabled for HTTP requests`). Even with a policy exception, docx `visual` components ship their JSON to the remote jto-render-server, which has no access to those files.

## Fix
When a request's `sourceName` matches a **server-discovered** document (#142's trusted mapping — never client `baseDir`), its relative image refs (image components, `{ image: { path } }` backgrounds, visual elements) are resolved against the document's directory, `realpath`-containment-checked, mime/size-capped, and inlined as `data:` URLs **before** outbound-source validation. Applied to `/generate` and `/preview/libreoffice-from-json`.

- Arbitrary client paths stay blocked: no `sourceName` → 400; `../` escapes and absolute paths → left untouched → 400 as before.
- Development mode unchanged (filesystem resolution, path-keyed visual cache).
- Caps from existing config: `MAX_FILE_SIZE` per file, `MAX_REQUEST_BODY_SIZE` total; per-request dedupe cache.

## Verified
- 8 new inliner tests; full jto suite 152/152, typecheck + lint clean.
- Live safe-mode server (`NODE_ENV=production`, prod allowlist): `modern-annual-report-3` → 200, 2.4MB docx, 25 media entries; `minimalist-pitch-deck` (pptx) → 200.
- Negative cases: no `sourceName` → 400; `../../etc/hosts` and `/etc/hosts` with valid `sourceName` → 400.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server-generated documents can now safely embed eligible template images and backgrounds directly into the output.
  * Relative media is validated for location and size before embedding; unsafe, missing, unsupported, or oversized files remain unchanged.
  * Preview and generation workflows now support consistent template-media handling.

* **Bug Fixes**
  * Improved protection against path traversal and unauthorized client-provided file access.
  * Repeated media references are handled efficiently without redundant processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->