### PR TITLE
feat(render): batch per-document visual rasterization

### DIFF
--- a/.changeset/batch-visual-rasterization.md
+++ b/.changeset/batch-visual-rasterization.md
@@ -1,0 +1,47 @@
+---
+'@json-to-office/shared': minor
+'@json-to-office/core-docx': minor
+'@json-to-office/jto-cli': minor
+'@json-to-office/jto': minor
+---
+
+feat: coalesce per-document visual rasterization into batched calls (#153)
+
+A docx render used to rasterize each `visual` component with its own
+`/rasterize` round trip and its own LibreOffice launch — ~25 sequential
+calls for the bundled annual-report templates, which starved the render
+server's rate limit (#152).
+
+Rendering now runs a per-document pre-pass that collects every enabled
+visual, dedupes identical ones, and rasterizes them together. A batch is N
+independent single-slide decks converted in ONE soffice launch (the launch
+is the amortized cost): each slide keeps its own PDF/PNG, its own size and
+dpi — so nothing is grouped and no page↔visual index mapping exists — and
+its cache key is identical to the single-slide path, so batch and single
+share the disk cache.
+
+- `shared`: `PptxRasterizeBatch*` types, `PptxBatchRasterizer`,
+  `PptxServiceConfig.renderBatch`, `MAX_RASTERIZE_BATCH_SLIDES`.
+- `jto-cli`: `createLibreOfficePptxBatchRasterizer()`; single and batch
+  share one engine with per-slide results, and a slide whose PDF is missing
+  after a batch launch is retried once in isolation.
+- `core-docx`: `renderDocument` pre-pass seeding a keyed result map;
+  `renderVisualComponent` falls back to per-visual rasterization on any
+  miss, so old servers (404 on the batch route), transport failures, or
+  collection gaps degrade to today's behavior. `flattenVisuals` accepts
+  `rasterizeBatch`.
+- `jto`: additive `POST /rasterize/batch` on both surfaces (playground +
+  render server) with per-slide validation, source policy, and 200-with-
+  item-errors semantics; shares middleware and one rate-limit bucket with
+  `/rasterize`. Per-slide errors are stage-tagged: slide-content (`build`)
+  errors surface verbatim, tooling errors are sanitized to a generic
+  message (raw detail goes to the server log). Both routes enforce an
+  estimated pixel budget (64MP/slide, 256MP/batch).
+
+Robustness bounds: the engine runs against a wall-clock deadline (one
+batch-scaled soffice window + one pdftoppm window), isolated retries for
+missing PDFs are capped at 3, and a batch where nothing converted fails
+fast instead of retrying per slide.
+
+One document is now ~one request and ~one soffice launch, so public
+rasterize rate limits can come back down.

--- a/docs/guide/render-server.md
+++ b/docs/guide/render-server.md
@@ -55,9 +55,10 @@ See the [API reference](/reference/api) for the full options object and the [cha
 
   - `GET /health` — probes the internal Highcharts server (2 s timeout). Returns `ok` on success, otherwise `503 { status: 'degraded', ... }`. Reporting 503 while Highcharts is down keeps a load balancer from routing `/export` traffic to a half-up instance.
   - `POST /rasterize` — the pptx-slide-to-PNG endpoint (rate-limited to 30 requests / 15 min in production).
+  - `POST /rasterize/batch` — up to 32 independent slides per request, one LibreOffice launch, per-slide results; shares `/rasterize`'s rate limiter, limits, and auth. This is what lets one document ≈ one request.
   - `POST /export` — the Highcharts Export Server protocol, proxied to the internal upstream after strict validation. Only base64 PNG exports are accepted (`type: "png"`, `b64: true`), unknown top-level fields are rejected, and the effective raster size is capped.
 
-  There is no catch-all proxy: any other path returns `404`, and a wrong method on `/export` or `/rasterize` returns `405`. Upstream `Set-Cookie` headers are stripped from responses.
+  There is no catch-all proxy: any other path returns `404`, and a wrong method on `/export`, `/rasterize`, or `/rasterize/batch` returns `405`. Upstream `Set-Cookie` headers are stripped from responses.
 
 - A **Highcharts Export Server** (`highcharts-export-server@5.1.0`, Puppeteer + Chromium) runs internally on `127.0.0.1:7801` and is never exposed directly.
 
@@ -162,6 +163,36 @@ Contract details, enforced by a handler shared between the render server and the
 - The presentation is checked against the [outbound source policy](#environment-variables-front-server) before rendering, so local file paths and non-allowlisted hosts fail with `400` rather than being fetched.
 - Errors: missing binaries map to `503`, invalid presentations to `400`, everything else to `500`.
 
+### POST /rasterize/batch
+
+One document usually carries many visuals, so the batch endpoint rasterizes up to **32 independent slides per request** — one LibreOffice launch instead of one per visual. Each slide is a complete single-slide presentation with its own optional `dpi` (slides are never merged, so sizes and themes may differ freely):
+
+```json
+POST /rasterize/batch
+Content-Type: application/json
+
+{
+  "slides": [
+    { "presentation": { "name": "pptx", "...": "..." }, "dpi": 120 },
+    { "presentation": { "name": "pptx", "...": "..." } }
+  ]
+}
+```
+
+```json
+200 OK
+{
+  "results": [
+    { "ok": true, "base64DataUri": "data:image/png;base64,...", "width": 480, "height": 240 },
+    { "ok": false, "error": "Top-level component must be a pptx component" }
+  ]
+}
+```
+
+`results` is index-aligned with `slides`. A bad slide fails **per item** (`ok: false`) without discarding its siblings: errors caused by the slide's own JSON are returned verbatim, while internal tooling failures come back as a generic `Slide rasterization failed` (full detail goes to the server log). Batch-level problems (validation, missing binaries) use the same `400`/`503` mapping as `/rasterize`. Both routes share one rate-limit bucket, body limit, auth, and source policy, enforce an estimated pixel budget (64 MP per slide, 256 MP per batch), and key the PNG cache per slide — identically to `/rasterize` — so mixing the two endpoints never re-renders unchanged visuals.
+
+DOCX generation uses this automatically: the renderer collects a document's visuals up front, sends them as batches, and **falls back to per-visual `/rasterize` calls if the batch endpoint is unavailable** (e.g. an older render server), so clients and servers can upgrade independently.
+
 ## Deploying the playgrounds
 
 The repo's root `Dockerfile` builds the [playground](/guide/playground) as a Docker image. The key insight: **the deployed playground is the dev server** — the container simply runs the CLI's `dev` command:
@@ -220,7 +251,7 @@ export JTO_PPTX_RASTERIZER_URL=https://render.example.com
 
 ### In-process LibreOffice fallback
 
-When `JTO_PPTX_RASTERIZER_URL` is **not** set, the DOCX CLI wires `services.pptx.render` to an in-process rasterizer (`createLibreOfficePptxRasterizer`, also exported from `@json-to-office/jto-cli`). Its pipeline:
+When `JTO_PPTX_RASTERIZER_URL` is **not** set, the DOCX CLI wires `services.pptx.render` and `services.pptx.renderBatch` to in-process rasterizers (`createLibreOfficePptxRasterizer` / `createLibreOfficePptxBatchRasterizer`, both exported from `@json-to-office/jto-cli`). A document's visuals are collected up front and batch-rasterized — one `soffice` launch converts every cache-missing slide, each as its own single-slide deck. The per-slide pipeline:
 
 1. Render the visual's slide JSON to a `.pptx` with core-pptx.
 2. `soffice --headless --convert-to pdf` with an isolated user profile (60 s timeout).

--- a/docs/guide/render-server.md
+++ b/docs/guide/render-server.md
@@ -184,12 +184,12 @@ Content-Type: application/json
 {
   "results": [
     { "ok": true, "base64DataUri": "data:image/png;base64,...", "width": 480, "height": 240 },
-    { "ok": false, "error": "Top-level component must be a pptx component" }
+    { "ok": false, "error": "Top-level component must be a pptx component", "stage": "build" }
   ]
 }
 ```
 
-`results` is index-aligned with `slides`. A bad slide fails **per item** (`ok: false`) without discarding its siblings: errors caused by the slide's own JSON are returned verbatim, while internal tooling failures come back as a generic `Slide rasterization failed` (full detail goes to the server log). Batch-level problems (validation, missing binaries) use the same `400`/`503` mapping as `/rasterize`. Both routes share one rate-limit bucket, body limit, auth, and source policy, enforce an estimated pixel budget (64 MP per slide, 256 MP per batch), and key the PNG cache per slide — identically to `/rasterize` — so mixing the two endpoints never re-renders unchanged visuals.
+`results` is index-aligned with `slides`. A bad slide fails **per item** (`ok: false`) without discarding its siblings: errors caused by the slide's own JSON (`stage: "build"`) are returned verbatim, while internal tooling failures (`stage: "convert"` or `"rasterize"`) come back as a generic `Slide rasterization failed` (full detail goes to the server log). Batch-level problems (validation, missing binaries) use the same `400`/`503` mapping as `/rasterize`. Both routes share one rate-limit bucket, body limit, auth, and source policy, enforce an estimated pixel budget (64 MP per slide, 256 MP per batch), and key the PNG cache per slide — identically to `/rasterize` — so mixing the two endpoints never re-renders unchanged visuals.
 
 DOCX generation uses this automatically: the renderer collects a document's visuals up front, sends them as batches, and **falls back to per-visual `/rasterize` calls if the batch endpoint is unavailable** (e.g. an older render server), so clients and servers can upgrade independently.
 

--- a/packages/core-docx/src/components/__tests__/visual.test.ts
+++ b/packages/core-docx/src/components/__tests__/visual.test.ts
@@ -11,7 +11,11 @@ vi.mock('../../core/content', async () => {
   };
 });
 
-import { renderVisualComponent } from '../visual';
+import {
+  renderVisualComponent,
+  visualRasterKey,
+  buildVisualPresentation,
+} from '../visual';
 import { createImage } from '../../core/content';
 
 const mockCreateImage = createImage as any;
@@ -46,13 +50,11 @@ describe('components/visual', () => {
     vi.clearAllMocks();
     mockFetch.mockResolvedValue({
       ok: true,
-      json: vi
-        .fn()
-        .mockResolvedValue({
-          base64DataUri: PNG_DATA_URI,
-          width: 1200,
-          height: 800,
-        }),
+      json: vi.fn().mockResolvedValue({
+        base64DataUri: PNG_DATA_URI,
+        width: 1200,
+        height: 800,
+      }),
     });
   });
 
@@ -61,13 +63,11 @@ describe('components/visual', () => {
   });
 
   it('rasterizes via an in-process render callback and desugars to an image', async () => {
-    const render = vi
-      .fn()
-      .mockResolvedValue({
-        base64DataUri: PNG_DATA_URI,
-        width: 1200,
-        height: 800,
-      });
+    const render = vi.fn().mockResolvedValue({
+      base64DataUri: PNG_DATA_URI,
+      width: 1200,
+      height: 800,
+    });
 
     const context = { services: { pptx: { render } } } as any;
 
@@ -95,13 +95,11 @@ describe('components/visual', () => {
   });
 
   it('builds a single-slide pptx presentation from canvas + elements', async () => {
-    const render = vi
-      .fn()
-      .mockResolvedValue({
-        base64DataUri: PNG_DATA_URI,
-        width: 10,
-        height: 10,
-      });
+    const render = vi.fn().mockResolvedValue({
+      base64DataUri: PNG_DATA_URI,
+      width: 10,
+      height: 10,
+    });
 
     await renderVisualComponent(
       visualComponent({
@@ -228,5 +226,108 @@ describe('components/visual', () => {
         TEST_THEME_NAME
       )
     ).rejects.toThrow(/services\.pptx/s);
+  });
+
+  describe('pre-rasterized results map (#153)', () => {
+    const mapKeyFor = (component: any, dpi = 200, serverUrl?: string) =>
+      visualRasterKey(buildVisualPresentation(component.props), dpi, serverUrl);
+
+    it('uses a pre-rasterized result without calling any service', async () => {
+      const render = vi.fn();
+      const component = visualComponent();
+      const context = {
+        services: { pptx: { render } },
+        visualRasterResults: new Map([
+          [
+            mapKeyFor(component),
+            { ok: true, base64DataUri: PNG_DATA_URI, width: 1200, height: 800 },
+          ],
+        ]),
+      } as any;
+
+      await renderVisualComponent(
+        component,
+        createMockTheme(),
+        TEST_THEME_NAME,
+        context
+      );
+
+      expect(render).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockCreateImage).toHaveBeenCalledWith(
+        PNG_DATA_URI,
+        expect.anything(),
+        TEST_THEME_NAME,
+        expect.objectContaining({ width: 576 })
+      );
+    });
+
+    it('throws a recorded pre-rasterization error for this visual', async () => {
+      const component = visualComponent();
+      const context = {
+        visualRasterResults: new Map([
+          [mapKeyFor(component), { ok: false, error: 'slide 3 is broken' }],
+        ]),
+      } as any;
+
+      await expect(
+        renderVisualComponent(
+          component,
+          createMockTheme(),
+          TEST_THEME_NAME,
+          context
+        )
+      ).rejects.toThrow('slide 3 is broken');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('falls back to per-visual rasterization on a map miss', async () => {
+      const component = visualComponent();
+      const context = {
+        services: { pptx: { serverUrl: 'http://localhost:9000' } },
+        visualRasterResults: new Map(), // empty — pre-pass missed this visual
+      } as any;
+
+      await renderVisualComponent(
+        component,
+        createMockTheme(),
+        TEST_THEME_NAME,
+        context
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:9000/rasterize',
+        expect.any(Object)
+      );
+    });
+
+    it('keys a serverUrl-overridden visual distinctly under an HTTP config', async () => {
+      const component = visualComponent({
+        serverUrl: 'http://prop-server:1234',
+      });
+      // Entry stored WITHOUT the override url must not be picked up.
+      const context = {
+        services: { pptx: { serverUrl: 'http://services:5555' } },
+        visualRasterResults: new Map([
+          [
+            mapKeyFor(component),
+            { ok: true, base64DataUri: PNG_DATA_URI, width: 1, height: 1 },
+          ],
+        ]),
+      } as any;
+
+      await renderVisualComponent(
+        component,
+        createMockTheme(),
+        TEST_THEME_NAME,
+        context
+      );
+
+      // Miss → rasterized against its own override server.
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://prop-server:1234/rasterize',
+        expect.any(Object)
+      );
+    });
   });
 });

--- a/packages/core-docx/src/components/visual.ts
+++ b/packages/core-docx/src/components/visual.ts
@@ -8,6 +8,7 @@
  * plain `image`.
  */
 
+import { createHash } from 'crypto';
 import { Paragraph, Table } from 'docx';
 import {
   ComponentDefinition,
@@ -28,7 +29,7 @@ import {
   type PptxRasterizeResult,
 } from '@json-to-office/shared';
 
-const DEFAULT_RASTERIZE_SERVER_URL = 'http://localhost:7802';
+export const DEFAULT_RASTERIZE_SERVER_URL = 'http://localhost:7802';
 /** 1 inch = 96 CSS pixels — used to size the embedded image at its physical canvas size. */
 const PIXELS_PER_INCH = 96;
 
@@ -107,10 +108,46 @@ export function visualToImageProps(
 }
 
 /**
+ * Identity of one visual rasterization: content + resolution + (for HTTP
+ * services) the target server. Keys the per-document pre-rasterization map
+ * (#153); the pre-pass and the render-time lookup MUST use this one function
+ * so the two sides cannot drift.
+ */
+export function visualRasterKey(
+  presentation: unknown,
+  dpi: number,
+  serverUrl?: string
+): string {
+  return createHash('sha256')
+    .update(JSON.stringify({ p: presentation, d: dpi, u: serverUrl ?? null }))
+    .digest('hex');
+}
+
+/**
+ * The serverUrl that actually differentiates a visual's rasterization. An
+ * in-process `render` callback takes precedence over any serverUrl —
+ * per-visual or config — so overrides only matter when rasterization would
+ * go over HTTP. Deliberately keyed on `render` alone (NOT `renderBatch`):
+ * per-visual fallbacks always go through `rasterizeVisualSlide`, which only
+ * consults `render`, and pre-pass inclusion must match what a fallback would
+ * actually do or the same visual could rasterize against two different
+ * services depending on cache luck.
+ */
+export function effectiveVisualServerUrl(
+  props: VisualProps,
+  serviceConfig: PptxServiceConfig | undefined
+): string | undefined {
+  if (serviceConfig?.render) return undefined;
+  return props.serverUrl;
+}
+
+/**
  * Rasterize a single-slide presentation to a PNG via the configured service.
  * An in-process `render` callback takes precedence over an HTTP `serverUrl`.
+ * Exported for the pre-rasterization pass, whose per-visual fallback must
+ * behave exactly like render-time rasterization.
  */
-async function rasterize(
+export async function rasterizeVisualSlide(
   presentation: Record<string, unknown>,
   dpi: number,
   propsServerUrl: string | undefined,
@@ -182,16 +219,35 @@ export async function renderVisualComponent(
     props.dpi ?? serviceConfig?.dpi ?? DEFAULT_VISUAL_DPI
   );
 
-  // Relative asset paths inside the visual's nested presentation must
-  // resolve against the same base directory as the docx document itself —
-  // the rasterizer runs in another process/cwd (#142).
-  const result = await rasterize(
-    presentation,
-    dpi,
-    props.serverUrl,
-    serviceConfig,
-    getBaseDir()
+  // The per-document pre-pass batch-rasterizes visuals ahead of rendering
+  // (#153). A hit uses those pixels; a recorded per-visual failure surfaces
+  // here, where the error is attributable to this component. Any miss falls
+  // through to per-visual rasterization, so the pre-pass can never make a
+  // render worse than the sequential path.
+  const preRasterized = context?.visualRasterResults?.get(
+    visualRasterKey(
+      presentation,
+      dpi,
+      effectiveVisualServerUrl(props, serviceConfig)
+    )
   );
+
+  let result: PptxRasterizeResult;
+  if (preRasterized) {
+    if (!preRasterized.ok) throw new Error(preRasterized.error);
+    result = preRasterized;
+  } else {
+    // Relative asset paths inside the visual's nested presentation must
+    // resolve against the same base directory as the docx document itself —
+    // the rasterizer runs in another process/cwd (#142).
+    result = await rasterizeVisualSlide(
+      presentation,
+      dpi,
+      props.serverUrl,
+      serviceConfig,
+      getBaseDir()
+    );
+  }
 
   // Size and placement options are derived once in visualToImageOptions (shared
   // with the flatten transform): default width = canvas physical inches; height

--- a/packages/core-docx/src/core/__tests__/flattenVisuals.test.ts
+++ b/packages/core-docx/src/core/__tests__/flattenVisuals.test.ts
@@ -179,6 +179,64 @@ describe('flattenVisuals', () => {
     expect(rasterize).not.toHaveBeenCalled();
   });
 
+  describe('rasterizeBatch (#153)', () => {
+    it('rasterizes every visual through one batch call; the single rasterizer stays idle', async () => {
+      const rasterize = fakeRasterizer();
+      const rasterizeBatch = vi.fn(async (req: any) => ({
+        results: req.slides.map(() => ({
+          ok: true,
+          base64DataUri: PNG,
+          width: 960,
+          height: 640,
+        })),
+      }));
+      const doc = {
+        name: 'docx',
+        props: {},
+        children: [
+          {
+            name: 'section',
+            props: { header: [visualNode('hdr')] },
+            children: [visualNode('a'), visualNode('b')],
+          },
+        ],
+      };
+
+      const out: any = await flattenVisuals(doc, { rasterize, rasterizeBatch });
+
+      expect(rasterizeBatch).toHaveBeenCalledOnce();
+      // All three visuals share identical props (`id` is not part of the
+      // rasterization identity), so they dedupe into a single slide.
+      expect(rasterizeBatch.mock.calls[0][0].slides).toHaveLength(1);
+      expect(rasterize).not.toHaveBeenCalled();
+      expect(out.children[0].children.map((c: any) => c.name)).toEqual([
+        'image',
+        'image',
+      ]);
+      expect(out.children[0].props.header[0].name).toBe('image');
+      expect(out.children[0].children[0].props.base64).toBe(PNG);
+    });
+
+    it('surfaces a per-slide batch error when that visual is flattened', async () => {
+      const rasterize = fakeRasterizer();
+      const rasterizeBatch = vi.fn(async () => ({
+        results: [{ ok: false, error: 'poisoned slide' }],
+      }));
+      const doc = {
+        name: 'docx',
+        props: {},
+        children: [
+          { name: 'section', props: {}, children: [visualNode('bad')] },
+        ],
+      };
+
+      await expect(
+        flattenVisuals(doc, { rasterize, rasterizeBatch })
+      ).rejects.toThrow('poisoned slide');
+      expect(rasterize).not.toHaveBeenCalled();
+    });
+  });
+
   it('clamps an out-of-range dpi before calling the rasterizer', async () => {
     const rasterize = fakeRasterizer();
     const doc = {

--- a/packages/core-docx/src/core/__tests__/prerasterizeVisuals.test.ts
+++ b/packages/core-docx/src/core/__tests__/prerasterizeVisuals.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  collectVisualProps,
+  prerasterizeVisuals,
+} from '../prerasterizeVisuals';
+import {
+  visualRasterKey,
+  buildVisualPresentation,
+} from '../../components/visual';
+import { clampVisualDpi, DEFAULT_VISUAL_DPI } from '@json-to-office/shared';
+
+const PNG = 'data:image/png;base64,AAAA';
+
+const okResult = { base64DataUri: PNG, width: 960, height: 640 };
+
+const visual = (text: string, extra: Record<string, unknown> = {}) => ({
+  name: 'visual',
+  props: {
+    canvas: { width: 6, height: 3 },
+    elements: [{ name: 'text', props: { text } }],
+    ...extra,
+  },
+});
+
+/** Map key a visual's props resolve to under in-process/default-server config. */
+const keyOf = (props: any, dpi = DEFAULT_VISUAL_DPI) =>
+  visualRasterKey(buildVisualPresentation(props), clampVisualDpi(dpi));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('collectVisualProps', () => {
+  it('finds visuals nested in children, table cells, and section headers/footers', () => {
+    const root = [
+      {
+        components: [
+          visual('top'),
+          {
+            name: 'columns',
+            props: {},
+            children: [visual('in-column')],
+          },
+          {
+            name: 'table',
+            props: {
+              columns: [
+                {
+                  header: { content: visual('in-header-cell') },
+                  cells: [{ content: visual('in-cell') }, { content: 'txt' }],
+                },
+              ],
+            },
+          },
+        ],
+        header: [visual('in-page-header')],
+        footer: 'linkToPrevious',
+      },
+    ];
+    const found = collectVisualProps(root);
+    expect(found.map((p: any) => p.elements[0].props.text)).toEqual([
+      'top',
+      'in-column',
+      'in-header-cell',
+      'in-cell',
+      'in-page-header',
+    ]);
+  });
+
+  it('prunes disabled visuals and disabled ancestor components', () => {
+    const root = [
+      {
+        components: [
+          { ...visual('off'), enabled: false },
+          {
+            name: 'section',
+            enabled: false,
+            props: {},
+            children: [visual('inside-disabled-section')],
+          },
+          visual('on'),
+        ],
+      },
+    ];
+    const found = collectVisualProps(root);
+    expect(found.map((p: any) => p.elements[0].props.text)).toEqual(['on']);
+  });
+
+  it('does not descend into a visual (pptx subtree cannot hold docx visuals)', () => {
+    const nested = visual('outer', {
+      elements: [visual('this-is-a-pptx-node-not-a-docx-visual')],
+    });
+    expect(collectVisualProps([nested])).toHaveLength(1);
+  });
+});
+
+describe('prerasterizeVisuals (in-process batch)', () => {
+  it('coalesces unique visuals into one renderBatch call and dedupes identical ones', async () => {
+    const renderBatch = vi.fn(async (req: any) => ({
+      results: req.slides.map(() => ({ ok: true, ...okResult })),
+    }));
+    const doc = [visual('a'), visual('a'), visual('b', { dpi: 300 })];
+
+    const map = await prerasterizeVisuals(
+      doc,
+      { renderBatch },
+      { baseDir: '/docs' }
+    );
+
+    expect(renderBatch).toHaveBeenCalledOnce();
+    const req = renderBatch.mock.calls[0][0];
+    expect(req.slides).toHaveLength(2); // 'a' deduped
+    expect(req.slides[1].dpi).toBe(300);
+    expect(req.baseDir).toBe('/docs');
+    expect(map.size).toBe(2);
+    expect(map.get(keyOf(doc[0].props))).toMatchObject({
+      ok: true,
+      base64DataUri: PNG,
+    });
+    expect(map.get(keyOf(doc[2].props, 300))).toMatchObject({ ok: true });
+  });
+
+  it('chunks batches above MAX_RASTERIZE_BATCH_SLIDES', async () => {
+    const renderBatch = vi.fn(async (req: any) => ({
+      results: req.slides.map(() => ({ ok: true, ...okResult })),
+    }));
+    const doc = Array.from({ length: 33 }, (_, i) => visual(`v${i}`));
+
+    const map = await prerasterizeVisuals(doc, { renderBatch });
+
+    expect(renderBatch).toHaveBeenCalledTimes(2);
+    expect(renderBatch.mock.calls[0][0].slides).toHaveLength(32);
+    expect(renderBatch.mock.calls[1][0].slides).toHaveLength(1);
+    expect(map.size).toBe(33);
+  });
+
+  it('records per-slide errors from the batch response', async () => {
+    const renderBatch = vi.fn(async () => ({
+      results: [
+        { ok: true, ...okResult },
+        { ok: false, error: 'bad slide' },
+      ],
+    }));
+    const doc = [visual('good'), visual('broken')];
+
+    const map = await prerasterizeVisuals(doc, { renderBatch });
+
+    expect(map.get(keyOf(doc[0].props))).toMatchObject({ ok: true });
+    expect(map.get(keyOf(doc[1].props))).toEqual({
+      ok: false,
+      error: 'bad slide',
+    });
+  });
+
+  it('falls back to the single rasterizer when the batch call fails', async () => {
+    const renderBatch = vi.fn(async () => {
+      throw new Error('batch exploded');
+    });
+    const render = vi.fn(async () => okResult);
+    const doc = [visual('a'), visual('b')];
+
+    const map = await prerasterizeVisuals(doc, { renderBatch, render });
+
+    expect(render).toHaveBeenCalledTimes(2);
+    expect(map.get(keyOf(doc[0].props))).toMatchObject({ ok: true });
+  });
+
+  it('falls back per-visual when the batch response is malformed (wrong length)', async () => {
+    const renderBatch = vi.fn(async () => ({
+      results: [{ ok: true, ...okResult }],
+    }));
+    const render = vi.fn(async () => okResult);
+    const doc = [visual('a'), visual('b')];
+
+    const map = await prerasterizeVisuals(doc, { renderBatch, render });
+
+    expect(render).toHaveBeenCalledTimes(2);
+    expect(map.size).toBe(2);
+  });
+
+  it('records the batch error per visual when no single rasterizer exists', async () => {
+    const renderBatch = vi.fn(async () => {
+      throw new Error('soffice missing');
+    });
+    const doc = [visual('a')];
+
+    const map = await prerasterizeVisuals(doc, { renderBatch });
+
+    expect(map.get(keyOf(doc[0].props))).toEqual({
+      ok: false,
+      error: 'soffice missing',
+    });
+  });
+
+  it('falls back to the configured HTTP server when the batch fails and no render exists', async () => {
+    const renderBatch = vi.fn(async () => {
+      throw new Error('batch exploded');
+    });
+    mockFetch.mockResolvedValue({ ok: true, json: async () => okResult });
+    const doc = [visual('a')];
+
+    const map = await prerasterizeVisuals(doc, {
+      renderBatch,
+      serverUrl: 'http://svc:9000',
+    });
+
+    // The document must keep building through the reachable HTTP service —
+    // a renderBatch failure with a configured serverUrl is not fatal.
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://svc:9000/rasterize',
+      expect.any(Object)
+    );
+    expect(map.get(keyOf(doc[0].props))).toMatchObject({ ok: true });
+  });
+
+  it('skips a malformed visual without losing batching for the rest', async () => {
+    const renderBatch = vi.fn(async (req: any) => ({
+      results: req.slides.map(() => ({ ok: true, ...okResult })),
+    }));
+    const doc = [
+      { name: 'visual', props: {} }, // no canvas — buildVisualPresentation throws
+      visual('fine'),
+    ];
+
+    const map = await prerasterizeVisuals(doc, { renderBatch });
+
+    expect(renderBatch).toHaveBeenCalledOnce();
+    expect(renderBatch.mock.calls[0][0].slides).toHaveLength(1);
+    expect(map.get(keyOf((doc[1] as any).props))).toMatchObject({ ok: true });
+  });
+});
+
+describe('prerasterizeVisuals (in-process single render)', () => {
+  it('rasterizes unique visuals through render with recorded errors per visual', async () => {
+    const render = vi
+      .fn()
+      .mockResolvedValueOnce(okResult)
+      .mockRejectedValueOnce(new Error('nope'));
+    const doc = [visual('a'), visual('b')];
+
+    const map = await prerasterizeVisuals(doc, { render });
+
+    expect(render).toHaveBeenCalledTimes(2);
+    expect(map.get(keyOf(doc[0].props))).toMatchObject({ ok: true });
+    expect(map.get(keyOf(doc[1].props))).toEqual({ ok: false, error: 'nope' });
+  });
+});
+
+describe('prerasterizeVisuals (HTTP)', () => {
+  it('POSTs one /rasterize/batch request and seeds the map', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          { ok: true, ...okResult },
+          { ok: true, ...okResult },
+        ],
+      }),
+    });
+    const doc = [visual('a'), visual('b')];
+
+    const map = await prerasterizeVisuals(doc, {
+      serverUrl: 'http://svc:9000',
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://svc:9000/rasterize/batch');
+    const body = JSON.parse(init.body);
+    expect(body.slides).toHaveLength(2);
+    expect(map.size).toBe(2);
+  });
+
+  it('falls back to per-visual /rasterize calls when the batch endpoint is missing (older server)', async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.endsWith('/rasterize/batch')) {
+        return { ok: false, status: 404, statusText: 'Not Found' };
+      }
+      return { ok: true, json: async () => okResult };
+    });
+    const doc = [visual('a'), visual('b')];
+
+    const map = await prerasterizeVisuals(doc, {
+      serverUrl: 'http://old:9000',
+    });
+
+    const urls = mockFetch.mock.calls.map((c) => c[0]);
+    expect(urls[0]).toBe('http://old:9000/rasterize/batch');
+    expect(urls.filter((u) => u === 'http://old:9000/rasterize')).toHaveLength(
+      2
+    );
+    expect(map.size).toBe(2);
+    expect(map.get(keyOf(doc[0].props))).toMatchObject({ ok: true });
+  });
+
+  it('leaves visuals with a per-visual serverUrl override to the render-time path', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [{ ok: true, ...okResult }] }),
+    });
+    const doc = [
+      visual('default-server'),
+      visual('other', { serverUrl: 'http://other:1' }),
+    ];
+
+    const map = await prerasterizeVisuals(doc, {
+      serverUrl: 'http://svc:9000',
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body).slides).toHaveLength(1);
+    expect(map.size).toBe(1);
+  });
+
+  it('returns an empty map without touching the network when there are no visuals', async () => {
+    const map = await prerasterizeVisuals(
+      [{ name: 'paragraph', props: { text: 'x' } }],
+      { serverUrl: 'http://svc:9000' }
+    );
+    expect(map.size).toBe(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core-docx/src/core/__tests__/prerasterizeVisuals.test.ts
+++ b/packages/core-docx/src/core/__tests__/prerasterizeVisuals.test.ts
@@ -95,6 +95,20 @@ describe('collectVisualProps', () => {
     });
     expect(collectVisualProps([nested])).toHaveLength(1);
   });
+
+  it('survives cyclic objects and cyclic arrays', () => {
+    const section: Record<string, unknown> = {
+      name: 'section',
+      children: [visual('in-cycle')],
+    };
+    section.owner = section;
+    const cyclicArray: unknown[] = [section];
+    cyclicArray.push(cyclicArray);
+    const found = collectVisualProps(cyclicArray);
+    expect(found.map((p: any) => p.elements[0].props.text)).toEqual([
+      'in-cycle',
+    ]);
+  });
 });
 
 describe('prerasterizeVisuals (in-process batch)', () => {

--- a/packages/core-docx/src/core/__tests__/renderVisualBatching.test.ts
+++ b/packages/core-docx/src/core/__tests__/renderVisualBatching.test.ts
@@ -1,0 +1,89 @@
+/**
+ * End-to-end guard for #153: rendering a document with several visuals must
+ * coalesce rasterization into batch calls (one per document, not one per
+ * visual), while per-visual rendering remains the fallback.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { Document } from 'docx';
+import { generateDocumentFromJson } from '../generator';
+
+// A real (decodable) 1×1 PNG so createImage can measure it.
+const VALID_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+const visual = (text: string) => ({
+  name: 'visual',
+  props: {
+    canvas: { width: 4, height: 2 },
+    elements: [{ name: 'text', props: { text, x: 1, y: 1, w: 2, h: 0.5 } }],
+  },
+});
+
+const doc = () => ({
+  name: 'docx',
+  props: { title: 'Batching' },
+  children: [
+    { name: 'paragraph', props: { text: 'intro' } },
+    visual('one'),
+    visual('two'),
+    visual('one'), // duplicate — must not rasterize twice
+  ],
+});
+
+describe('renderDocument visual batching (#153)', () => {
+  it('rasterizes all visuals in one renderBatch call instead of per visual', async () => {
+    const renderBatch = vi.fn(async (req: any) => ({
+      results: req.slides.map(() => ({
+        ok: true,
+        base64DataUri: VALID_PNG,
+        width: 1,
+        height: 1,
+      })),
+    }));
+    const render = vi.fn();
+
+    const document = await generateDocumentFromJson(doc() as any, {
+      validation: { enabled: false },
+      services: { pptx: { render, renderBatch } },
+    });
+
+    expect(document).toBeInstanceOf(Document);
+    expect(renderBatch).toHaveBeenCalledOnce();
+    expect(renderBatch.mock.calls[0][0].slides).toHaveLength(2); // deduped
+    expect(render).not.toHaveBeenCalled();
+  });
+
+  it('still renders per visual when only a single rasterizer is configured', async () => {
+    const render = vi.fn(async () => ({
+      base64DataUri: VALID_PNG,
+      width: 1,
+      height: 1,
+    }));
+
+    const document = await generateDocumentFromJson(doc() as any, {
+      validation: { enabled: false },
+      services: { pptx: { render } },
+    });
+
+    expect(document).toBeInstanceOf(Document);
+    // The pre-pass parallelizes but still dedupes: 2 unique visuals.
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails the render with the recorded error when a visual cannot rasterize', async () => {
+    const renderBatch = vi.fn(async (req: any) => ({
+      results: req.slides.map((slide: any, i: number) =>
+        i === 0
+          ? { ok: true, base64DataUri: VALID_PNG, width: 1, height: 1 }
+          : { ok: false, error: 'slide exploded' }
+      ),
+    }));
+
+    await expect(
+      generateDocumentFromJson(doc() as any, {
+        validation: { enabled: false },
+        services: { pptx: { renderBatch } },
+      })
+    ).rejects.toThrow('slide exploded');
+  });
+});

--- a/packages/core-docx/src/core/flattenVisuals.ts
+++ b/packages/core-docx/src/core/flattenVisuals.ts
@@ -18,18 +18,28 @@ import {
   clampVisualDpi,
   DEFAULT_VISUAL_DPI,
   type PptxRasterizer,
+  type PptxBatchRasterizer,
 } from '@json-to-office/shared';
 import type { VisualProps } from '@json-to-office/shared-docx';
 import {
   buildVisualPresentation,
+  visualRasterKey,
   visualToImageProps,
 } from '../components/visual';
+import { createLimiter } from '../utils/promiseLimiter';
+import { prerasterizeVisuals } from './prerasterizeVisuals';
 
 const DEFAULT_CONCURRENCY = 4;
 
 export interface FlattenVisualsOptions {
   /** Rasterizer that turns a single-slide pptx presentation into a PNG. */
   rasterize: PptxRasterizer;
+  /**
+   * Batch rasterizer (#153). When provided, all visuals are collected and
+   * rasterized together up front; `rasterize` remains the per-visual
+   * fallback for batch failures and anything the collection missed.
+   */
+  rasterizeBatch?: PptxBatchRasterizer;
   /** Default DPI applied when a `visual` does not specify one (default 200). */
   dpi?: number;
   /** Max concurrent rasterizations (default 4). */
@@ -48,29 +58,11 @@ interface FlattenCtx {
   limit: <T>(fn: () => Promise<T>) => Promise<T>;
 }
 
-/** Minimal promise pool bounding concurrent rasterizations. */
-function createLimiter(max: number): <T>(fn: () => Promise<T>) => Promise<T> {
-  let active = 0;
-  const queue: Array<() => void> = [];
-  const release = () => {
-    active--;
-    queue.shift()?.();
-  };
-  return async function limit<T>(fn: () => Promise<T>): Promise<T> {
-    if (active >= max)
-      await new Promise<void>((resolve) => queue.push(resolve));
-    active++;
-    try {
-      return await fn();
-    } finally {
-      release();
-    }
-  };
-}
-
 /**
  * Return a deep copy of `doc` with every `visual` node replaced by the `image`
- * node it rasterizes to. Visuals rasterize with bounded concurrency. A
+ * node it rasterizes to. With `rasterizeBatch`, visuals are pre-rasterized in
+ * batches and the tree walk resolves from the batch results; otherwise (and
+ * for any batch miss) visuals rasterize per-node with bounded concurrency. A
  * `visual` with `enabled: false` is left untouched (it's filtered out at render
  * anyway, so rasterizing it would be wasted work). Non-visual nodes are copied
  * structurally and otherwise unchanged.
@@ -79,8 +71,40 @@ export async function flattenVisuals<T = unknown>(
   doc: T,
   options: FlattenVisualsOptions
 ): Promise<T> {
+  let rasterize = options.rasterize;
+
+  if (options.rasterizeBatch) {
+    // The pre-pass keys results exactly like the walk below computes its
+    // requests (in-process semantics: no serverUrl), so hits are exact. A
+    // pre-pass failure must not fail the flatten — misses below rasterize
+    // per-visual exactly as they did before batching existed.
+    const preRasterized = await prerasterizeVisuals(
+      doc,
+      {
+        render: options.rasterize,
+        renderBatch: options.rasterizeBatch,
+        dpi: options.dpi,
+      },
+      { baseDir: options.baseDir, concurrency: options.concurrency }
+    ).catch(() => new Map<string, never>());
+    rasterize = async (request) => {
+      const hit = preRasterized.get(
+        visualRasterKey(request.presentation, request.dpi)
+      );
+      if (hit) {
+        if (!hit.ok) throw new Error(hit.error);
+        return {
+          base64DataUri: hit.base64DataUri,
+          width: hit.width,
+          height: hit.height,
+        };
+      }
+      return options.rasterize(request);
+    };
+  }
+
   const ctx: FlattenCtx = {
-    rasterize: options.rasterize,
+    rasterize,
     dpi: options.dpi,
     baseDir: options.baseDir,
     limit: createLimiter(

--- a/packages/core-docx/src/core/prerasterizeVisuals.ts
+++ b/packages/core-docx/src/core/prerasterizeVisuals.ts
@@ -68,12 +68,18 @@ interface VisualRasterTarget {
  */
 export function collectVisualProps(root: unknown): VisualProps[] {
   const found: VisualProps[] = [];
+  // Guards against cyclic inputs (the walk accepts arbitrary objects, not
+  // just parsed JSON); registered before the array branch so
+  // self-referential arrays are covered too.
+  const seen = new WeakSet<object>();
   const visit = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return;
+    if (seen.has(node)) return;
+    seen.add(node);
     if (Array.isArray(node)) {
       for (const item of node) visit(item);
       return;
     }
-    if (!node || typeof node !== 'object') return;
     const obj = node as Record<string, unknown>;
     // Only component-shaped nodes carry `enabled`; a disabled subtree never
     // renders (mirrors the render-time filters).

--- a/packages/core-docx/src/core/prerasterizeVisuals.ts
+++ b/packages/core-docx/src/core/prerasterizeVisuals.ts
@@ -1,0 +1,302 @@
+/**
+ * prerasterizeVisuals — per-document visual rasterization pre-pass (#153).
+ *
+ * The renderer walks components strictly in order, so each `visual` used to
+ * await its own rasterization round trip: one HTTP call + one LibreOffice
+ * launch per visual, ~25 of each for the bundled annual-report templates.
+ * This pass runs once per document before rendering: it collects every
+ * enabled visual, dedupes identical ones, and rasterizes them together —
+ * through an in-process batch rasterizer, a batched HTTP call, or (failing
+ * both) bounded-concurrency per-visual calls.
+ *
+ * Results land in a map keyed by `visualRasterKey`; `renderVisualComponent`
+ * consults the map first and falls back to per-visual rasterization on any
+ * miss. The pre-pass is therefore purely an accelerator: over-collection
+ * wastes a little work, under-collection and every failure mode degrade to
+ * the sequential status quo, never to a broken render.
+ */
+
+import {
+  clampVisualDpi,
+  DEFAULT_VISUAL_DPI,
+  MAX_RASTERIZE_BATCH_SLIDES,
+  type PptxServiceConfig,
+  type PptxRasterizeBatchResult,
+  type PptxRasterizeBatchSlideResult,
+} from '@json-to-office/shared';
+import type { VisualProps } from '@json-to-office/shared-docx';
+import {
+  buildVisualPresentation,
+  effectiveVisualServerUrl,
+  rasterizeVisualSlide,
+  visualRasterKey,
+  DEFAULT_RASTERIZE_SERVER_URL,
+} from '../components/visual';
+import { isNodeEnvironment } from '../utils/environment';
+import { createLimiter } from '../utils/promiseLimiter';
+import { resolveServiceUrl, postJsonToService } from '../utils/serviceClient';
+
+/** Bounded concurrency for per-visual fallback rasterizations. */
+const DEFAULT_FALLBACK_CONCURRENCY = 4;
+/** HTTP timeout for a batch call scales with its slide count. */
+const BATCH_TIMEOUT_BASE_MS = 30000;
+const BATCH_TIMEOUT_PER_SLIDE_MS = 10000;
+
+export interface PrerasterizeOptions {
+  /** Directory relative asset paths resolve against (#142). */
+  baseDir?: string;
+  /** Max concurrent per-visual fallback rasterizations (default 4). */
+  concurrency?: number;
+}
+
+/** One unique rasterization unit collected from the document. */
+interface VisualRasterTarget {
+  key: string;
+  presentation: Record<string, unknown>;
+  dpi: number;
+}
+
+/**
+ * Collect the props of every enabled `visual` component reachable from
+ * `root`. The walk is generic — every array element and object value is
+ * visited — so visuals nested anywhere (columns, table cells, section
+ * headers/footers, plugin containers) are found without enumerating
+ * container shapes. Disabled component subtrees are pruned: they never
+ * render, so rasterizing them is wasted work. Over-collection is harmless
+ * (an unused map entry); under-collection is harmless (render-time
+ * fallback) — which is what makes the generic walk safe.
+ */
+export function collectVisualProps(root: unknown): VisualProps[] {
+  const found: VisualProps[] = [];
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const item of node) visit(item);
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    const obj = node as Record<string, unknown>;
+    // Only component-shaped nodes carry `enabled`; a disabled subtree never
+    // renders (mirrors the render-time filters).
+    if (typeof obj.name === 'string' && obj.enabled === false) return;
+    if (obj.name === 'visual' && obj.props && typeof obj.props === 'object') {
+      found.push(obj.props as VisualProps);
+      // A visual's elements are a pptx subtree; nothing docx-renderable
+      // (and no further docx visuals) can nest inside it.
+      return;
+    }
+    for (const value of Object.values(obj)) visit(value);
+  };
+  visit(root);
+  return found;
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function* chunksOf<T>(items: T[], size: number): Generator<T[]> {
+  for (let i = 0; i < items.length; i += size) yield items.slice(i, i + size);
+}
+
+/**
+ * Validate a batch response and seed the map. All-or-nothing per chunk: any
+ * malformed entry rejects the whole chunk (returns false) so a drifted or
+ * broken server can never half-seed the map — the caller falls back to
+ * per-visual calls instead.
+ */
+function applyBatchResponse(
+  chunk: VisualRasterTarget[],
+  response: unknown,
+  map: Map<string, PptxRasterizeBatchSlideResult>
+): boolean {
+  const results = (response as PptxRasterizeBatchResult | undefined)?.results;
+  if (!Array.isArray(results) || results.length !== chunk.length) return false;
+
+  const entries: Array<[string, PptxRasterizeBatchSlideResult]> = [];
+  for (let i = 0; i < chunk.length; i++) {
+    const item = results[i] as PptxRasterizeBatchSlideResult | undefined;
+    if (
+      item &&
+      item.ok === true &&
+      typeof item.base64DataUri === 'string' &&
+      item.base64DataUri.length > 0 &&
+      typeof item.width === 'number' &&
+      typeof item.height === 'number'
+    ) {
+      entries.push([
+        chunk[i].key,
+        {
+          ok: true,
+          base64DataUri: item.base64DataUri,
+          width: item.width,
+          height: item.height,
+        },
+      ]);
+    } else if (item && item.ok === false && typeof item.error === 'string') {
+      entries.push([chunk[i].key, { ok: false, error: item.error }]);
+    } else {
+      return false;
+    }
+  }
+  for (const [key, value] of entries) map.set(key, value);
+  return true;
+}
+
+/**
+ * Batch-rasterize a document's visuals ahead of rendering. Returns a map of
+ * `visualRasterKey` → per-visual result (pixels or a recorded error). Never
+ * throws for per-visual problems; a thrown error here indicates a pre-pass
+ * bug and the caller should continue without the map.
+ */
+export async function prerasterizeVisuals(
+  root: unknown,
+  serviceConfig: PptxServiceConfig | undefined,
+  options: PrerasterizeOptions = {}
+): Promise<Map<string, PptxRasterizeBatchSlideResult>> {
+  const map = new Map<string, PptxRasterizeBatchSlideResult>();
+  // Injected in-process rasterizers are environment-agnostic; only the HTTP
+  // strategy needs Node. In a browser without callbacks the render-time path
+  // reports the environment error with full context.
+  if (
+    !isNodeEnvironment() &&
+    !serviceConfig?.renderBatch &&
+    !serviceConfig?.render
+  ) {
+    return map;
+  }
+
+  const visuals = collectVisualProps(root);
+  if (visuals.length === 0) return map;
+
+  // Dedupe identical visuals: one rasterization per unique (content, dpi).
+  const targets = new Map<string, VisualRasterTarget>();
+  for (const props of visuals) {
+    // The generic walk can reach visual-shaped nodes the renderer never
+    // touches; a malformed one must not cost the document its batching.
+    // Skipped visuals fall back to the render-time path, which reports the
+    // error only if the node actually renders.
+    try {
+      const serverUrl = effectiveVisualServerUrl(props, serviceConfig);
+      // A per-visual HTTP serverUrl override targets a different service than
+      // the batch would; leave those to the per-visual render-time path.
+      if (serverUrl !== undefined) continue;
+      const presentation = buildVisualPresentation(props);
+      const dpi = clampVisualDpi(
+        props.dpi ?? serviceConfig?.dpi ?? DEFAULT_VISUAL_DPI
+      );
+      const key = visualRasterKey(presentation, dpi, serverUrl);
+      if (!targets.has(key)) targets.set(key, { key, presentation, dpi });
+    } catch {
+      continue;
+    }
+  }
+  if (targets.size === 0) return map;
+
+  const unique = [...targets.values()];
+  const limit = createLimiter(
+    Math.max(1, options.concurrency ?? DEFAULT_FALLBACK_CONCURRENCY)
+  );
+
+  /** Per-visual fallback: exactly the render-time code path, bounded. */
+  const rasterizeIndividually = async (
+    chunk: VisualRasterTarget[]
+  ): Promise<void> => {
+    await Promise.all(
+      chunk.map((target) =>
+        limit(async () => {
+          try {
+            const result = await rasterizeVisualSlide(
+              target.presentation,
+              target.dpi,
+              undefined,
+              serviceConfig,
+              options.baseDir
+            );
+            map.set(target.key, { ok: true, ...result });
+          } catch (error) {
+            map.set(target.key, { ok: false, error: toErrorMessage(error) });
+          }
+        })
+      )
+    );
+  };
+
+  // Strategy 1: in-process batch rasterizer.
+  if (serviceConfig?.renderBatch) {
+    for (const chunk of chunksOf(unique, MAX_RASTERIZE_BATCH_SLIDES)) {
+      try {
+        const response = await serviceConfig.renderBatch({
+          slides: chunk.map((target) => ({
+            presentation: target.presentation,
+            dpi: target.dpi,
+          })),
+          ...(options.baseDir !== undefined && { baseDir: options.baseDir }),
+        });
+        if (!applyBatchResponse(chunk, response, map)) {
+          throw new Error(
+            'batch rasterizer returned a malformed result (expected index-aligned results[])'
+          );
+        }
+      } catch (error) {
+        // Any per-visual route keeps the document building: `render` first,
+        // else the configured HTTP server (rasterizeVisualSlide handles both).
+        // Only a renderBatch-with-nothing-else config records the batch-level
+        // error per visual — there is genuinely nowhere to fall back to, and
+        // inventing an HTTP call to the default localhost would replace the
+        // real error with a misleading "unreachable" one.
+        if (serviceConfig.render || serviceConfig.serverUrl) {
+          await rasterizeIndividually(chunk);
+        } else {
+          const message = toErrorMessage(error);
+          for (const target of chunk) {
+            map.set(target.key, { ok: false, error: message });
+          }
+        }
+      }
+    }
+    return map;
+  }
+
+  // Strategy 2: in-process single rasterizer — no batch surface, but the
+  // pre-pass still parallelizes what the sequential renderer could not.
+  if (serviceConfig?.render) {
+    await rasterizeIndividually(unique);
+    return map;
+  }
+
+  // Strategy 3: HTTP. Try the additive batch endpoint; ANY failure — an
+  // older server without /rasterize/batch, a transport error, a malformed
+  // response — falls back to per-visual calls (the status quo protocol).
+  const serverUrl = resolveServiceUrl(
+    undefined,
+    serviceConfig?.serverUrl,
+    DEFAULT_RASTERIZE_SERVER_URL
+  );
+  for (const chunk of chunksOf(unique, MAX_RASTERIZE_BATCH_SLIDES)) {
+    let applied = false;
+    try {
+      const response = await postJsonToService({
+        url: serverUrl,
+        path: '/rasterize/batch',
+        body: {
+          slides: chunk.map((target) => ({
+            presentation: target.presentation,
+            dpi: target.dpi,
+          })),
+          ...(options.baseDir !== undefined && { baseDir: options.baseDir }),
+        },
+        headers: serviceConfig?.headers,
+        timeoutMs:
+          BATCH_TIMEOUT_BASE_MS + BATCH_TIMEOUT_PER_SLIDE_MS * chunk.length,
+        serviceLabel: 'PPTX batch rasterization service',
+        onUnreachable: (url, cause) =>
+          `PPTX rasterization service is not reachable at ${url}. Cause: ${cause}`,
+      });
+      applied = applyBatchResponse(chunk, await response.json(), map);
+    } catch {
+      applied = false;
+    }
+    if (!applied) await rasterizeIndividually(chunk);
+  }
+  return map;
+}

--- a/packages/core-docx/src/core/render.ts
+++ b/packages/core-docx/src/core/render.ts
@@ -89,7 +89,9 @@ import { globalRevisionIdRegistry } from '../utils/revisionUtils';
 import {
   runWithGenerationDate,
   runWithBaseDir,
+  getBaseDir,
 } from '../utils/generationContext';
+import { prerasterizeVisuals } from './prerasterizeVisuals';
 
 interface RenderDocumentOptions {
   cache?: MemoryCache;
@@ -205,6 +207,27 @@ async function renderDocumentScoped(
     structure.themeName
   );
   context.services = options?.services;
+
+  // Coalesce the document's visual rasterizations into batched service calls
+  // before the (strictly sequential) component walk begins (#153). Purely an
+  // accelerator: renderVisualComponent falls back to per-visual rasterization
+  // for anything the pre-pass missed, so a pre-pass failure can slow a render
+  // but never break one.
+  try {
+    const visualRasterResults = await prerasterizeVisuals(
+      layout.sections,
+      options?.services?.pptx,
+      { baseDir: getBaseDir() }
+    );
+    if (visualRasterResults.size > 0) {
+      context.visualRasterResults = visualRasterResults;
+    }
+  } catch (error) {
+    console.warn(
+      '[core-docx] Visual pre-rasterization failed; falling back to per-visual rasterization:',
+      error instanceof Error ? error.message : error
+    );
+  }
 
   // Initialize bookmark counter for this document (scoped to renderDocument call)
   let sectionBookmarkCounter = 0;

--- a/packages/core-docx/src/types/index.ts
+++ b/packages/core-docx/src/types/index.ts
@@ -1,6 +1,9 @@
 import { ISectionOptions } from 'docx';
 import type { ThemeName } from '../styles';
-import type { ServicesConfig } from '@json-to-office/shared';
+import type {
+  ServicesConfig,
+  PptxRasterizeBatchSlideResult,
+} from '@json-to-office/shared';
 
 // Import types from shared-docx that core needs for its internal use
 import type {
@@ -219,4 +222,10 @@ export interface RenderContext {
   depth: number;
   custom?: Record<string, unknown>;
   services?: ServicesConfig;
+  /**
+   * Per-document pre-rasterized visual results, keyed by `visualRasterKey`
+   * (#153). Seeded by the renderDocument pre-pass; `renderVisualComponent`
+   * consults it first and falls back to per-visual rasterization on a miss.
+   */
+  visualRasterResults?: ReadonlyMap<string, PptxRasterizeBatchSlideResult>;
 }

--- a/packages/core-docx/src/utils/promiseLimiter.ts
+++ b/packages/core-docx/src/utils/promiseLimiter.ts
@@ -1,0 +1,27 @@
+/**
+ * Minimal promise pool bounding concurrent async operations. Shared by the
+ * visual rasterization paths (flattenVisuals, prerasterizeVisuals) to cap
+ * concurrent service calls.
+ */
+export function createLimiter(
+  max: number
+): <T>(fn: () => Promise<T>) => Promise<T> {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  const release = () => {
+    active--;
+    queue.shift()?.();
+  };
+  return async function limit<T>(fn: () => Promise<T>): Promise<T> {
+    // Re-check after waking: a caller arriving between release() and this
+    // waiter's microtask could otherwise barge past the limit.
+    while (active >= max)
+      await new Promise<void>((resolve) => queue.push(resolve));
+    active++;
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  };
+}

--- a/packages/jto-cli/src/format-adapter.ts
+++ b/packages/jto-cli/src/format-adapter.ts
@@ -5,11 +5,15 @@ import type {
   ServicesConfig,
   FontRuntimeOpts,
   PptxRasterizer,
+  PptxBatchRasterizer,
   GenerationWarning,
 } from '@json-to-office/shared';
 import { validatePresentationDocument } from '@json-to-office/shared-pptx';
 import { validate as validateDocx } from '@json-to-office/shared-docx';
-import { createLibreOfficePptxRasterizer } from './pptx-rasterizer.js';
+import {
+  createLibreOfficePptxRasterizer,
+  createLibreOfficePptxBatchRasterizer,
+} from './pptx-rasterizer.js';
 import { emitDiagnostic } from './services/diagnostics.js';
 
 /** Forward structured warnings collected during generation to the terminal. */
@@ -71,15 +75,23 @@ function buildServicesFromEnv(): ServicesConfig | undefined {
   };
 }
 
-// Lazily-constructed LibreOffice rasterizer, shared across docx generations.
-// Constructing it is cheap (no binaries touched); it only spawns LibreOffice
-// when a document actually contains a `visual` component.
+// Lazily-constructed LibreOffice rasterizers, shared across docx generations.
+// Constructing them is cheap (no binaries touched); they only spawn
+// LibreOffice when a document actually contains a `visual` component. Single
+// and batch share the same content-addressed disk cache.
 let cachedRasterizer: PptxRasterizer | undefined;
 function getPptxRasterizer(): PptxRasterizer {
   if (!cachedRasterizer) {
     cachedRasterizer = createLibreOfficePptxRasterizer();
   }
   return cachedRasterizer;
+}
+let cachedBatchRasterizer: PptxBatchRasterizer | undefined;
+function getPptxBatchRasterizer(): PptxBatchRasterizer {
+  if (!cachedBatchRasterizer) {
+    cachedBatchRasterizer = createLibreOfficePptxBatchRasterizer();
+  }
+  return cachedBatchRasterizer;
 }
 
 /**
@@ -105,7 +117,10 @@ function buildDocxServices(): ServicesConfig {
           serverUrl,
           ...(apiKey && { headers: { [apiKeyHeader]: apiKey } }),
         }
-      : { render: getPptxRasterizer() },
+      : {
+          render: getPptxRasterizer(),
+          renderBatch: getPptxBatchRasterizer(),
+        },
   };
 }
 

--- a/packages/jto-cli/src/index.ts
+++ b/packages/jto-cli/src/index.ts
@@ -10,7 +10,10 @@ export {
 } from './format-adapter.js';
 
 // PPTX rasterizer (backs docx `visual` components)
-export { createLibreOfficePptxRasterizer } from './pptx-rasterizer.js';
+export {
+  createLibreOfficePptxRasterizer,
+  createLibreOfficePptxBatchRasterizer,
+} from './pptx-rasterizer.js';
 
 // Generator factory
 export { GeneratorFactory } from './services/generator-factory.js';

--- a/packages/jto-cli/src/pptx-rasterizer.ts
+++ b/packages/jto-cli/src/pptx-rasterizer.ts
@@ -6,8 +6,20 @@
  * dimensions. Results are content-addressed and cached on disk so repeated
  * builds of an unchanged visual skip the (multi-second) LibreOffice run.
  *
- * This is injected via `services.pptx.render`; the published engine packages
- * never depend on these binaries.
+ * Single and batch rasterization share one engine (#153). A batch keeps one
+ * .pptx per slide and converts them all in a single `soffice` launch — the
+ * launch is the dominant cost, and per-file conversion keeps slides fully
+ * independent: each has its own PDF and PNG (no page↔slide index mapping),
+ * its own dpi, and a cache key identical to the single-slide path, so both
+ * paths share the same disk cache.
+ *
+ * Every engine run works against a wall-clock deadline (one batch-scaled
+ * soffice window plus one pdftoppm window) so a wedged conversion fails the
+ * remaining slides quickly instead of holding the caller — and its
+ * concurrency slot — for minutes.
+ *
+ * This is injected via `services.pptx.render` / `services.pptx.renderBatch`;
+ * the published engine packages never depend on these binaries.
  */
 
 import { execFile } from 'node:child_process';
@@ -15,13 +27,28 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import crypto from 'node:crypto';
-import type {
-  PptxRasterizer,
-  PptxRasterizeRequest,
-  PptxRasterizeResult,
+import {
+  DEFAULT_VISUAL_DPI,
+  type PptxRasterizer,
+  type PptxBatchRasterizer,
+  type PptxRasterizeRequest,
+  type PptxRasterizeResult,
+  type PptxRasterizeBatchSlideResult,
+  type PptxRasterizeFailureStage,
 } from '@json-to-office/shared';
 
 const SOFFICE_TIMEOUT_MS = 60000;
+/** Extra soffice budget per additional slide in a batch launch. */
+const SOFFICE_BATCH_EXTRA_PER_SLIDE_MS = 15000;
+/** Hard ceiling for one batch soffice launch. */
+const SOFFICE_BATCH_TIMEOUT_CAP_MS = 300000;
+/**
+ * Max isolated single-file launches after a batch launch left PDFs missing.
+ * Covers the realistic case (one poisoned slide crashed the batch; its
+ * successors are fine) without letting a broken environment turn one request
+ * into dozens of sequential 60s timeouts.
+ */
+const MAX_ISOLATED_RETRIES = 3;
 const PDFTOPPM_TIMEOUT_MS = 30000;
 const PROBE_TIMEOUT_MS = 5000;
 const MAX_BUFFER = 64 * 1024 * 1024;
@@ -171,7 +198,11 @@ async function writeCacheAtomic(
   }
 }
 
-function cacheKey(request: PptxRasterizeRequest): string {
+function cacheKey(request: {
+  presentation: unknown;
+  dpi: number;
+  baseDir?: string;
+}): string {
   return (
     crypto
       .createHash('sha256')
@@ -192,6 +223,290 @@ function toDataUri(png: Buffer): string {
   return `data:image/png;base64,${png.toString('base64')}`;
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Engine-internal result: the wire shape plus the original error object. */
+type EngineSlideResult = PptxRasterizeBatchSlideResult & { cause?: unknown };
+
+/** One unique unit of work: a slide deck plus every request index it serves. */
+interface SlideJob {
+  presentation: unknown;
+  dpi: number;
+  /** Request indexes resolved by this job (batch-internal dedup). */
+  indexes: number[];
+  cachePath: string | null;
+  pptxPath: string;
+  pdfPath: string;
+  pngPrefix: string;
+}
+
+const sofficeArgs = (
+  profileDir: string,
+  outDir: string,
+  files: string[]
+): string[] => [
+  '--headless',
+  '--norestore',
+  '--nolockcheck',
+  '--nodefault',
+  `-env:UserInstallation=file://${profileDir.replace(/\\/g, '/')}`,
+  '--convert-to',
+  'pdf:impress_pdf_Export',
+  '--outdir',
+  outDir,
+  ...files,
+];
+
+/**
+ * Rasterize N independent single-slide presentations, amortizing the soffice
+ * launch across every cache miss. Returns per-slide results (index-aligned);
+ * only environment-level failures (missing binaries) throw.
+ */
+async function rasterizeSlidesWithEngine(
+  slides: Array<{ presentation: unknown; dpi: number }>,
+  baseDir: string | undefined,
+  cacheDir: string | null
+): Promise<EngineSlideResult[]> {
+  const results: EngineSlideResult[] = new Array(slides.length);
+
+  // 1. Dedupe by content-addressed key: identical slides build, convert, and
+  //    hit the cache exactly once, then fan out to every requesting index.
+  const jobsByKey = new Map<string, SlideJob>();
+  for (let i = 0; i < slides.length; i++) {
+    const slide = slides[i];
+    const key = cacheKey({
+      presentation: slide.presentation,
+      dpi: slide.dpi,
+      baseDir,
+    });
+    const existing = jobsByKey.get(key);
+    if (existing) {
+      existing.indexes.push(i);
+    } else {
+      jobsByKey.set(key, {
+        presentation: slide.presentation,
+        dpi: slide.dpi,
+        indexes: [i],
+        cachePath: cacheDir ? path.join(cacheDir, `${key}.png`) : null,
+        pptxPath: '',
+        pdfPath: '',
+        pngPrefix: '',
+      });
+    }
+  }
+
+  const fail = (
+    job: SlideJob,
+    stage: PptxRasterizeFailureStage,
+    error: string,
+    cause?: unknown
+  ) => {
+    for (const i of job.indexes)
+      results[i] = { ok: false, error, stage, cause };
+  };
+  const succeed = (job: SlideJob, result: PptxRasterizeResult) => {
+    for (const i of job.indexes) results[i] = { ok: true, ...result };
+  };
+
+  // 2. Resolve cache hits for the unique jobs in parallel.
+  const uncached: SlideJob[] = [];
+  await Promise.all(
+    [...jobsByKey.values()].map(async (job) => {
+      if (job.cachePath) {
+        const cached = await fs.readFile(job.cachePath).catch(() => null);
+        if (cached) {
+          const size = parsePngSize(cached);
+          if (size) {
+            succeed(job, { base64DataUri: toDataUri(cached), ...size });
+            return;
+          }
+          // Corrupt/partial cache file (e.g. a killed prior render) — discard
+          // it and re-render rather than embed a broken image.
+          await fs.rm(job.cachePath, { force: true }).catch(() => {});
+        }
+      }
+      uncached.push(job);
+    })
+  );
+  if (uncached.length === 0) return results;
+
+  // 3. JSON → .pptx (in-process, pure JS). A build failure is a per-slide
+  //    content error; the remaining slides still convert.
+  const corePptx = await import('@json-to-office/core-pptx');
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jto-visual-'));
+  try {
+    const built: SlideJob[] = [];
+    for (let j = 0; j < uncached.length; j++) {
+      const job = uncached[j];
+      job.pptxPath = path.join(tempDir, `slide-${j}.pptx`);
+      job.pdfPath = path.join(tempDir, `slide-${j}.pdf`);
+      job.pngPrefix = path.join(tempDir, `slide-${j}`);
+      try {
+        const pptxBuffer = await corePptx.generateBufferFromJson(
+          job.presentation as any,
+          { baseDir }
+        );
+        await fs.writeFile(job.pptxPath, pptxBuffer);
+        built.push(job);
+      } catch (error) {
+        fail(job, 'build', errorMessage(error), error);
+      }
+    }
+    if (built.length === 0) return results;
+
+    const [soffice, pdftoppm] = await Promise.all([
+      resolveSoffice(),
+      resolvePdftoppm(),
+    ]);
+
+    // 4. .pptx → PDF: ONE soffice launch converts every deck (the launch is
+    //    the multi-second cost being amortized). The timeout scales with the
+    //    slide count so a large batch is not misread as a hang, and the whole
+    //    engine run gets a deadline of one batch window + one pdftoppm window
+    //    — bounded work no matter how conversions misbehave, sized to stay
+    //    inside the HTTP client's own batch timeout.
+    const batchTimeoutMs = Math.min(
+      SOFFICE_TIMEOUT_MS +
+        SOFFICE_BATCH_EXTRA_PER_SLIDE_MS * (built.length - 1),
+      SOFFICE_BATCH_TIMEOUT_CAP_MS
+    );
+    const deadlineAt = Date.now() + batchTimeoutMs + PDFTOPPM_TIMEOUT_MS;
+    const remainingMs = () => deadlineAt - Date.now();
+
+    let batchError: unknown;
+    try {
+      await exec(
+        soffice,
+        sofficeArgs(
+          path.join(tempDir, 'profile'),
+          tempDir,
+          built.map((job) => job.pptxPath)
+        ),
+        batchTimeoutMs
+      );
+    } catch (error) {
+      batchError = error;
+    }
+
+    // 5. Per-slide PDF check. soffice reports batch conversion coarsely (it
+    //    can skip a file or die mid-run), so the PDFs on disk are the truth.
+    //    A missing PDF gets an isolated single-file launch — salvaging slides
+    //    left unprocessed by a mid-batch crash and pinning the error on the
+    //    slide that caused it — but only within MAX_ISOLATED_RETRIES and the
+    //    deadline, and not when nothing at all converted (an environmental
+    //    failure that a retry would only repeat).
+    const converted: SlideJob[] = [];
+    const missing: SlideJob[] = [];
+    for (const job of built) {
+      ((await fileExists(job.pdfPath)) ? converted : missing).push(job);
+    }
+
+    let retriesLeft =
+      missing.length > 0 &&
+      built.length > 1 &&
+      (batchError === undefined || converted.length > 0)
+        ? MAX_ISOLATED_RETRIES
+        : 0;
+    for (const [r, job] of missing.entries()) {
+      const retryBudget = Math.min(SOFFICE_TIMEOUT_MS, remainingMs());
+      if (retriesLeft > 0 && retryBudget > 1000) {
+        retriesLeft--;
+        let retryError: unknown;
+        try {
+          await exec(
+            soffice,
+            sofficeArgs(path.join(tempDir, `profile-retry-${r}`), tempDir, [
+              job.pptxPath,
+            ]),
+            retryBudget
+          );
+        } catch (error) {
+          retryError = error;
+        }
+        if (await fileExists(job.pdfPath)) {
+          converted.push(job);
+          continue;
+        }
+        batchError ??= retryError;
+      }
+      const cause = batchError;
+      fail(
+        job,
+        'convert',
+        `LibreOffice failed to convert the slide to PDF${
+          cause ? `: ${errorMessage(cause)}` : '.'
+        }`,
+        cause
+      );
+    }
+
+    // 6. PDF → PNG at each slide's own dpi (single page, no page suffix).
+    //    pdftoppm is cheap per file; each conversion still respects the
+    //    engine deadline so a pathological PDF cannot stack 30s timeouts.
+    for (const job of converted) {
+      const budget = Math.min(PDFTOPPM_TIMEOUT_MS, remainingMs());
+      if (budget <= 1000) {
+        fail(
+          job,
+          'rasterize',
+          'Rasterization deadline exceeded before this slide could be converted to PNG.'
+        );
+        continue;
+      }
+      try {
+        await exec(
+          pdftoppm,
+          [
+            '-r',
+            String(job.dpi),
+            '-png',
+            '-singlefile',
+            job.pdfPath,
+            job.pngPrefix,
+          ],
+          budget
+        );
+        const png = await fs.readFile(`${job.pngPrefix}.png`);
+        const size = parsePngSize(png);
+        if (!size) {
+          throw new Error(
+            'Rasterization produced an invalid PNG (empty or truncated output from pdftoppm).'
+          );
+        }
+        if (job.cachePath) {
+          await writeCacheAtomic(cacheDir!, job.cachePath, png);
+        }
+        succeed(job, { base64DataUri: toDataUri(png), ...size });
+      } catch (error) {
+        fail(job, 'rasterize', errorMessage(error), error);
+      }
+    }
+
+    return results;
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function resolveCacheDir(options?: {
+  cacheDir?: string | null;
+}): string | null {
+  return options?.cacheDir === undefined
+    ? path.join(os.tmpdir(), 'jto-visual-cache')
+    : options.cacheDir;
+}
+
 /**
  * Build a LibreOffice-backed pptx rasterizer.
  *
@@ -201,88 +516,60 @@ function toDataUri(png: Buffer): string {
 export function createLibreOfficePptxRasterizer(options?: {
   cacheDir?: string | null;
 }): PptxRasterizer {
-  const cacheDir =
-    options?.cacheDir === undefined
-      ? path.join(os.tmpdir(), 'jto-visual-cache')
-      : options.cacheDir;
+  const cacheDir = resolveCacheDir(options);
 
   return async function rasterize(
     request: PptxRasterizeRequest
   ): Promise<PptxRasterizeResult> {
-    const key = cacheKey(request);
-    const cachePath = cacheDir ? path.join(cacheDir, `${key}.png`) : null;
-
-    if (cachePath) {
-      const cached = await fs.readFile(cachePath).catch(() => null);
-      if (cached) {
-        const size = parsePngSize(cached);
-        if (size) return { base64DataUri: toDataUri(cached), ...size };
-        // Corrupt/partial cache file (e.g. a killed prior render) — discard it
-        // and re-render rather than embed a broken image.
-        await fs.rm(cachePath, { force: true }).catch(() => {});
-      }
-    }
-
-    // 1. JSON → .pptx (in-process, pure JS)
-    const corePptx = await import('@json-to-office/core-pptx');
-    const pptxBuffer = await corePptx.generateBufferFromJson(
-      request.presentation as any,
-      { baseDir: request.baseDir }
+    const [result] = await rasterizeSlidesWithEngine(
+      [{ presentation: request.presentation, dpi: request.dpi }],
+      request.baseDir,
+      cacheDir
     );
-
-    const [soffice, pdftoppm] = await Promise.all([
-      resolveSoffice(),
-      resolvePdftoppm(),
-    ]);
-
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jto-visual-'));
-    try {
-      const pptxPath = path.join(tempDir, 'visual.pptx');
-      const pdfPath = path.join(tempDir, 'visual.pdf');
-      const pngPrefix = path.join(tempDir, 'visual');
-      await fs.writeFile(pptxPath, pptxBuffer);
-
-      // 2. .pptx → PDF (single slide → single page)
-      const userProfile = `file://${path.join(tempDir, 'profile').replace(/\\/g, '/')}`;
-      await exec(
-        soffice,
-        [
-          '--headless',
-          '--norestore',
-          '--nolockcheck',
-          '--nodefault',
-          `-env:UserInstallation=${userProfile}`,
-          '--convert-to',
-          'pdf:impress_pdf_Export',
-          '--outdir',
-          tempDir,
-          pptxPath,
-        ],
-        SOFFICE_TIMEOUT_MS
-      );
-
-      // 3. PDF → PNG at the requested DPI (single page, no page suffix)
-      await exec(
-        pdftoppm,
-        ['-r', String(request.dpi), '-png', '-singlefile', pdfPath, pngPrefix],
-        PDFTOPPM_TIMEOUT_MS
-      );
-
-      const png = await fs.readFile(`${pngPrefix}.png`);
-      const size = parsePngSize(png);
-      if (!size) {
-        throw new Error(
-          'Rasterization produced an invalid PNG (empty or truncated output from pdftoppm).'
-        );
-      }
-
-      if (cachePath) {
-        await writeCacheAtomic(cacheDir!, cachePath, png);
-      }
-
-      return { base64DataUri: toDataUri(png), ...size };
-    } finally {
-      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    if (!result) throw new Error('Rasterization produced no result.');
+    if (!result.ok) {
+      const error = new Error(result.error) as Error & { cause?: unknown };
+      // Preserve the original failure (exec exit code/signal, fs error) for
+      // programmatic consumers — parity with the pre-batch implementation
+      // that threw the underlying error directly.
+      if (result.cause !== undefined) error.cause = result.cause;
+      throw error;
     }
+    return {
+      base64DataUri: result.base64DataUri,
+      width: result.width,
+      height: result.height,
+    };
+  };
+}
+
+/**
+ * Build a LibreOffice-backed BATCH pptx rasterizer (#153): many independent
+ * single-slide presentations, one soffice launch, per-slide results. Shares
+ * the content-addressed disk cache with the single-slide rasterizer — the
+ * per-slide cache key is identical on both paths.
+ */
+export function createLibreOfficePptxBatchRasterizer(options?: {
+  cacheDir?: string | null;
+}): PptxBatchRasterizer {
+  const cacheDir = resolveCacheDir(options);
+
+  return async function rasterizeBatch(request) {
+    const engineResults = await rasterizeSlidesWithEngine(
+      request.slides.map((slide) => ({
+        presentation: slide.presentation,
+        dpi: slide.dpi ?? DEFAULT_VISUAL_DPI,
+      })),
+      request.baseDir,
+      cacheDir
+    );
+    // Strip the engine-internal `cause` (non-serializable) from the results.
+    return {
+      results: engineResults.map((result) =>
+        result.ok
+          ? result
+          : { ok: false, error: result.error, stage: result.stage }
+      ),
+    };
   };
 }

--- a/packages/jto-cli/src/pptx-rasterizer.ts
+++ b/packages/jto-cli/src/pptx-rasterizer.ts
@@ -374,14 +374,19 @@ async function rasterizeSlidesWithEngine(
     //    the multi-second cost being amortized). The timeout scales with the
     //    slide count so a large batch is not misread as a hang, and the whole
     //    engine run gets a deadline of one batch window + one pdftoppm window
-    //    — bounded work no matter how conversions misbehave, sized to stay
-    //    inside the HTTP client's own batch timeout.
+    //    per slide — bounded work no matter how conversions misbehave. The
+    //    PNG phase is sequential over every slide, so its share must scale
+    //    with the slide count like the soffice window does; otherwise a slow
+    //    soffice launch drains the budget and slides whose PDFs converted
+    //    fine fail spuriously. An HTTP client that gives up sooner falls
+    //    back to per-visual calls on its own.
     const batchTimeoutMs = Math.min(
       SOFFICE_TIMEOUT_MS +
         SOFFICE_BATCH_EXTRA_PER_SLIDE_MS * (built.length - 1),
       SOFFICE_BATCH_TIMEOUT_CAP_MS
     );
-    const deadlineAt = Date.now() + batchTimeoutMs + PDFTOPPM_TIMEOUT_MS;
+    const deadlineAt =
+      Date.now() + batchTimeoutMs + PDFTOPPM_TIMEOUT_MS * built.length;
     const remainingMs = () => deadlineAt - Date.now();
 
     let batchError: unknown;

--- a/packages/jto/src/__tests__/render-server.test.ts
+++ b/packages/jto/src/__tests__/render-server.test.ts
@@ -220,4 +220,133 @@ describe('standalone render server', () => {
     ).toBe(400);
     expect(rasterizer).not.toHaveBeenCalled();
   });
+
+  it('mounts /rasterize/batch with the same auth, policy, and per-slide results (#153)', async () => {
+    const batchRasterizer = vi.fn(async (req: { slides: unknown[] }) => ({
+      results: req.slides.map(() => ({
+        ok: true as const,
+        base64DataUri: 'data:image/png;base64,AA==',
+        width: 1,
+        height: 1,
+      })),
+    }));
+    const app = createRenderServerApp({
+      auth: { mode: 'required', apiKey: 'secret' },
+      sourcePolicy: { mode: 'safe', allowedHosts: [] },
+      getBatchRasterizer: () => batchRasterizer,
+    });
+    const safeSlide = { presentation: { name: 'pptx', children: [] } };
+    const unsafeSlide = {
+      presentation: {
+        name: 'pptx',
+        children: [{ name: 'image', props: { path: '/etc/passwd' } }],
+      },
+    };
+
+    // No key → 401; unsafe source in ANY slide → 400 before rasterizing.
+    expect(
+      (await post(app, '/rasterize/batch', { slides: [safeSlide] })).status
+    ).toBe(401);
+    expect(
+      (
+        await post(
+          app,
+          '/rasterize/batch',
+          { slides: [safeSlide, unsafeSlide] },
+          { 'x-api-key': 'secret' }
+        )
+      ).status
+    ).toBe(400);
+    expect(batchRasterizer).not.toHaveBeenCalled();
+
+    const ok = await post(
+      app,
+      '/rasterize/batch',
+      { slides: [safeSlide, safeSlide] },
+      { 'x-api-key': 'secret' }
+    );
+    expect(ok.status).toBe(200);
+    const body = (await ok.json()) as { results: Array<{ ok: boolean }> };
+    expect(body.results).toHaveLength(2);
+    expect(batchRasterizer).toHaveBeenCalledOnce();
+
+    // Method guard matches the other public routes.
+    const wrongMethod = await app.request('/rasterize/batch', {
+      method: 'GET',
+    });
+    expect(wrongMethod.status).toBe(405);
+  });
+
+  it('sanitizes non-build per-slide errors but preserves content errors (#153 C2)', async () => {
+    const app = createRenderServerApp({
+      auth: { mode: 'disabled' },
+      sourcePolicy: { mode: 'development', allowedHosts: [] },
+      getBatchRasterizer: () => async () => ({
+        results: [
+          {
+            ok: false as const,
+            error: 'Top-level component must be a pptx component',
+            stage: 'build' as const,
+          },
+          {
+            ok: false as const,
+            error:
+              'Command failed: /usr/bin/soffice --outdir /var/tmp/jto-visual-x1',
+            stage: 'convert' as const,
+          },
+        ],
+      }),
+    });
+
+    const res = await post(app, '/rasterize/batch', {
+      slides: [
+        { presentation: { name: 'pptx' } },
+        { presentation: { name: 'pptx' } },
+      ],
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      results: Array<{ ok: boolean; error?: string }>;
+    };
+    // Build errors are the caller's own JSON problem — surfaced verbatim.
+    expect(body.results[0].error).toBe(
+      'Top-level component must be a pptx component'
+    );
+    // Tooling errors carry host paths — replaced with a generic message.
+    expect(body.results[1].error).toBe('Slide rasterization failed');
+    expect(JSON.stringify(body)).not.toContain('/var/tmp');
+  });
+
+  it('rejects oversized raster budgets up front (400)', async () => {
+    const rasterizer = vi.fn();
+    const batchRasterizer = vi.fn();
+    const app = createRenderServerApp({
+      auth: { mode: 'disabled' },
+      sourcePolicy: { mode: 'development', allowedHosts: [] },
+      getRasterizer: () => rasterizer,
+      getBatchRasterizer: () => batchRasterizer,
+    });
+
+    // One slide over the per-slide pixel budget (100in × 60in @ 600 dpi).
+    const huge = {
+      presentation: {
+        name: 'pptx',
+        props: { slideWidth: 100, slideHeight: 60 },
+      },
+      dpi: 600,
+    };
+    expect((await post(app, '/rasterize', huge)).status).toBe(400);
+
+    // Many individually-legal slides breaching the aggregate budget.
+    const big = {
+      presentation: { name: 'pptx', props: { slideWidth: 13, slideHeight: 7 } },
+      dpi: 600,
+    };
+    const res = await post(app, '/rasterize/batch', {
+      slides: Array.from({ length: 10 }, () => big),
+    });
+    expect(res.status).toBe(400);
+    expect(rasterizer).not.toHaveBeenCalled();
+    expect(batchRasterizer).not.toHaveBeenCalled();
+  });
 });

--- a/packages/jto/src/__tests__/render-server.test.ts
+++ b/packages/jto/src/__tests__/render-server.test.ts
@@ -306,14 +306,18 @@ describe('standalone render server', () => {
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
-      results: Array<{ ok: boolean; error?: string }>;
+      results: Array<{ ok: boolean; error?: string; stage?: string }>;
     };
     // Build errors are the caller's own JSON problem — surfaced verbatim.
     expect(body.results[0].error).toBe(
       'Top-level component must be a pptx component'
     );
+    expect(body.results[0].stage).toBe('build');
     // Tooling errors carry host paths — replaced with a generic message.
     expect(body.results[1].error).toBe('Slide rasterization failed');
+    // The failure stage itself is not sensitive; clients use it to tell
+    // invalid slide input from renderer failures.
+    expect(body.results[1].stage).toBe('convert');
     expect(JSON.stringify(body)).not.toContain('/var/tmp');
   });
 

--- a/packages/jto/src/render-server.ts
+++ b/packages/jto/src/render-server.ts
@@ -7,7 +7,10 @@ import { bodyLimit } from 'hono/body-limit';
 import { HTTPException } from 'hono/http-exception';
 import { secureHeaders } from 'hono/secure-headers';
 import type { StatusCode } from 'hono/utils/http-status';
-import type { PptxRasterizer } from '@json-to-office/shared';
+import type {
+  PptxRasterizer,
+  PptxBatchRasterizer,
+} from '@json-to-office/shared';
 import { registerRasterizeRoute } from './server/rasterize-route.js';
 import { rateLimiter } from './server/middleware/hono/rate-limit.js';
 import { concurrencyLimiter } from './server/middleware/hono/concurrency-limit.js';
@@ -50,6 +53,7 @@ export interface RenderServerOptions {
   sourcePolicy?: OutboundSourcePolicy;
   fetch?: FetchImplementation;
   getRasterizer?: () => PptxRasterizer;
+  getBatchRasterizer?: () => PptxBatchRasterizer;
 }
 
 class UpstreamResponseTooLargeError extends Error {}
@@ -313,6 +317,7 @@ export function createRenderServerApp(options: RenderServerOptions = {}): Hono {
   // attempt, leaving API-key guessing unbounded.
   registerRasterizeRoute(app, {
     getRasterizer: options.getRasterizer,
+    getBatchRasterizer: options.getBatchRasterizer,
     preMiddleware: [
       rateLimiter({
         limit:
@@ -432,7 +437,7 @@ export function createRenderServerApp(options: RenderServerOptions = {}): Hono {
     }
   );
 
-  for (const route of ['/export', '/rasterize']) {
+  for (const route of ['/export', '/rasterize', '/rasterize/batch']) {
     app.all(route, (c) => {
       c.header('Allow', 'POST');
       return c.json({ success: false, error: 'Method not allowed' }, 405);

--- a/packages/jto/src/server/rasterize-route.ts
+++ b/packages/jto/src/server/rasterize-route.ts
@@ -299,8 +299,12 @@ export function registerRasterizeRoute(
           if (slide.ok) return slide;
           options.onError?.(new Error(slide.error));
           return slide.stage === 'build'
-            ? { ok: false as const, error: slide.error }
-            : { ok: false as const, error: 'Slide rasterization failed' };
+            ? { ok: false as const, error: slide.error, stage: slide.stage }
+            : {
+                ok: false as const,
+                error: 'Slide rasterization failed',
+                stage: slide.stage,
+              };
         }),
       });
     }

--- a/packages/jto/src/server/rasterize-route.ts
+++ b/packages/jto/src/server/rasterize-route.ts
@@ -1,8 +1,14 @@
 /**
- * Shared POST /rasterize route — one validated handler mounted on BOTH the
- * playground format router and the standalone jto-render-server, so the public
- * and in-app rasterize surfaces can't drift in validation, limits, or error
- * mapping. Renders a single-slide pptx presentation to a PNG.
+ * Shared POST /rasterize + /rasterize/batch routes — validated handlers
+ * mounted on BOTH the playground format router and the standalone
+ * jto-render-server, so the public and in-app rasterize surfaces can't drift
+ * in validation, limits, or error mapping.
+ *
+ * /rasterize renders one single-slide pptx presentation to a PNG.
+ * /rasterize/batch (#153) renders many independent single-slide presentations
+ * in one request — one LibreOffice launch instead of one per visual — and
+ * returns index-aligned per-slide results (200 with item errors rather than
+ * all-or-nothing).
  */
 
 import path from 'node:path';
@@ -15,9 +21,14 @@ import {
   DEFAULT_VISUAL_DPI,
   MIN_VISUAL_DPI,
   MAX_VISUAL_DPI,
+  MAX_RASTERIZE_BATCH_SLIDES,
   type PptxRasterizer,
+  type PptxBatchRasterizer,
 } from '@json-to-office/shared';
-import { createLibreOfficePptxRasterizer } from '@json-to-office/jto-cli';
+import {
+  createLibreOfficePptxRasterizer,
+  createLibreOfficePptxBatchRasterizer,
+} from '@json-to-office/jto-cli';
 import { tbValidator, getValidated } from './lib/typebox-validator.js';
 import {
   assertSafeOutboundSources,
@@ -37,14 +48,43 @@ export const RasterizeRequestSchema = Type.Object(
   { additionalProperties: false }
 );
 
+/** Body for POST /rasterize/batch: independent slides + shared baseDir. */
+export const RasterizeBatchRequestSchema = Type.Object(
+  {
+    slides: Type.Array(
+      Type.Object(
+        {
+          presentation: Type.Object({}, { additionalProperties: true }),
+          dpi: Type.Optional(
+            Type.Number({ minimum: MIN_VISUAL_DPI, maximum: MAX_VISUAL_DPI })
+          ),
+        },
+        { additionalProperties: false }
+      ),
+      { minItems: 1, maxItems: MAX_RASTERIZE_BATCH_SLIDES }
+    ),
+    baseDir: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false }
+);
+
 // One rasterizer per process — shares the on-disk content-addressed cache
-// across every /rasterize surface in the process.
+// across every /rasterize surface in the process. Single and batch factories
+// use the same default cache directory, so the two routes share hits too.
 let sharedRasterizer: PptxRasterizer | undefined;
 export function getSharedRasterizer(): PptxRasterizer {
   if (!sharedRasterizer) {
     sharedRasterizer = createLibreOfficePptxRasterizer();
   }
   return sharedRasterizer;
+}
+
+let sharedBatchRasterizer: PptxBatchRasterizer | undefined;
+export function getSharedBatchRasterizer(): PptxBatchRasterizer {
+  if (!sharedBatchRasterizer) {
+    sharedBatchRasterizer = createLibreOfficePptxBatchRasterizer();
+  }
+  return sharedBatchRasterizer;
 }
 
 const jsonOnly: MiddlewareHandler = async (c, next) => {
@@ -57,26 +97,114 @@ const jsonOnly: MiddlewareHandler = async (c, next) => {
   await next();
 };
 
+// Raster size budget. Slide dimensions are author-controlled inches and the
+// schema does not bound them, so an oversized canvas × dpi could demand an
+// enormous bitmap; with batching that multiplies by slide count. Budgets are
+// estimated up front from the declared slide size (default pptx 16:9 when
+// absent) — same philosophy as the /export pixel budget.
+const DEFAULT_SLIDE_WIDTH_IN = 13.34;
+const DEFAULT_SLIDE_HEIGHT_IN = 7.5;
+const MAX_SLIDE_PIXELS = 64_000_000;
+const MAX_BATCH_PIXELS = 256_000_000;
+
+function estimateSlidePixels(presentation: unknown, dpi: number): number {
+  const props = (presentation as { props?: Record<string, unknown> } | null)
+    ?.props;
+  const dim = (value: unknown, fallback: number): number =>
+    typeof value === 'number' && Number.isFinite(value) && value > 0
+      ? value
+      : fallback;
+  const widthIn = dim(props?.slideWidth, DEFAULT_SLIDE_WIDTH_IN);
+  const heightIn = dim(props?.slideHeight, DEFAULT_SLIDE_HEIGHT_IN);
+  return widthIn * dpi * (heightIn * dpi);
+}
+
+function assertPixelBudget(
+  slides: Array<{ presentation: unknown; dpi: number }>
+): void {
+  let total = 0;
+  for (const slide of slides) {
+    const pixels = estimateSlidePixels(slide.presentation, slide.dpi);
+    if (pixels > MAX_SLIDE_PIXELS) {
+      throw new HTTPException(400, {
+        message: 'Requested slide dimensions are too large',
+      });
+    }
+    total += pixels;
+  }
+  if (total > MAX_BATCH_PIXELS) {
+    throw new HTTPException(400, {
+      message: 'Requested batch raster size is too large',
+    });
+  }
+}
+
 /**
- * Register `POST /rasterize` on a Hono router with body-size limit, content-type
- * + schema validation (dpi clamped to [MIN,MAX]_VISUAL_DPI), the shared
- * rasterizer, and structured 400/413/503/500 error mapping.
+ * `baseDir` selects the directory local media paths resolve against. An
+ * unrestricted value would let any HTTP caller point the rasterizer at
+ * arbitrary server directories and exfiltrate readable files as rendered
+ * pixels, so it must stay inside the server's own working tree. Callers
+ * rendering documents that live elsewhere should run the server from that
+ * tree (or use an in-process rasterizer).
+ */
+function resolveSafeBaseDir(baseDir: string | undefined): string | undefined {
+  if (baseDir === undefined) return undefined;
+  const resolved = path.resolve(baseDir);
+  const cwd = process.cwd();
+  if (resolved !== cwd && !resolved.startsWith(cwd + path.sep)) {
+    throw new HTTPException(400, {
+      message: 'baseDir must be inside the server working directory',
+    });
+  }
+  return resolved;
+}
+
+/** Map rasterization failures onto stable 400/503/500 responses. */
+function toHttpException(error: unknown): HTTPException {
+  if (error instanceof HTTPException) return error;
+  if (error instanceof UnsafeOutboundSourceError) {
+    return new HTTPException(400, { message: error.message });
+  }
+  const msg =
+    error instanceof Error ? error.message.toLowerCase() : String(error);
+  if (msg.includes('not found') || msg.includes('rasterization needs')) {
+    return new HTTPException(503, { message: (error as Error).message });
+  }
+  if (msg.includes('invalid') || msg.includes('validation')) {
+    return new HTTPException(400, { message: (error as Error).message });
+  }
+  return new HTTPException(500, {
+    message: 'Internal server error during rasterization',
+  });
+}
+
+export interface RasterizeRouteOptions {
+  getRasterizer?: () => PptxRasterizer;
+  getBatchRasterizer?: () => PptxBatchRasterizer;
+  preMiddleware?: MiddlewareHandler[];
+  sourcePolicy?: OutboundSourcePolicy;
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * Register `POST /rasterize` and `POST /rasterize/batch` on a Hono router
+ * with body-size limits, content-type + schema validation (dpi clamped to
+ * [MIN,MAX]_VISUAL_DPI, batch capped at MAX_RASTERIZE_BATCH_SLIDES), the
+ * shared rasterizers, and structured 400/413/503/500 error mapping. Both
+ * routes share `preMiddleware` instances (e.g. one rate limiter), so a batch
+ * and its per-visual fallback draw from the same budget.
  *
- * @param preMiddleware - extra middleware (e.g. a rate limiter) run first.
+ * @param options.preMiddleware - extra middleware (e.g. a rate limiter) run first.
  */
 export function registerRasterizeRoute(
   router: Hono<any>,
-  options: {
-    getRasterizer?: () => PptxRasterizer;
-    preMiddleware?: MiddlewareHandler[];
-    sourcePolicy?: OutboundSourcePolicy;
-    onError?: (error: unknown) => void;
-  } = {}
+  options: RasterizeRouteOptions = {}
 ): void {
   const getRasterizer = options.getRasterizer ?? getSharedRasterizer;
+  const getBatchRasterizer =
+    options.getBatchRasterizer ?? getSharedBatchRasterizer;
 
-  router.post(
-    '/rasterize',
+  const shared: MiddlewareHandler[] = [
     ...(options.preMiddleware ?? []),
     bodyLimit({
       maxSize: 32 * 1024 * 1024,
@@ -85,6 +213,20 @@ export function registerRasterizeRoute(
       },
     }),
     jsonOnly,
+  ];
+
+  const guard = async <T>(run: () => Promise<T>): Promise<T> => {
+    try {
+      return await run();
+    } catch (error) {
+      options.onError?.(error);
+      throw toHttpException(error);
+    }
+  };
+
+  router.post(
+    '/rasterize',
+    ...shared,
     tbValidator(RasterizeRequestSchema),
     async (c) => {
       const { presentation, dpi, baseDir } = getValidated<{
@@ -92,26 +234,12 @@ export function registerRasterizeRoute(
         dpi?: number;
         baseDir?: string;
       }>(c, 'json');
+      const safeBaseDir = resolveSafeBaseDir(baseDir);
 
-      // `baseDir` selects the directory local media paths resolve against.
-      // An unrestricted value would let any HTTP caller point the rasterizer
-      // at arbitrary server directories and exfiltrate readable files as
-      // rendered pixels, so it must stay inside the server's own working
-      // tree. Callers rendering documents that live elsewhere should run the
-      // server from that tree (or use an in-process rasterizer).
-      let safeBaseDir: string | undefined;
-      if (baseDir !== undefined) {
-        const resolved = path.resolve(baseDir);
-        const cwd = process.cwd();
-        if (resolved !== cwd && !resolved.startsWith(cwd + path.sep)) {
-          throw new HTTPException(400, {
-            message: 'baseDir must be inside the server working directory',
-          });
-        }
-        safeBaseDir = resolved;
-      }
+      const effectiveDpi = clampVisualDpi(dpi ?? DEFAULT_VISUAL_DPI);
+      assertPixelBudget([{ presentation, dpi: effectiveDpi }]);
 
-      try {
+      const result = await guard(async () => {
         if (options.sourcePolicy) {
           assertSafeOutboundSources(
             presentation,
@@ -119,30 +247,62 @@ export function registerRasterizeRoute(
             'presentation'
           );
         }
-        const result = await getRasterizer()({
+        return getRasterizer()({
           presentation,
-          dpi: clampVisualDpi(dpi ?? DEFAULT_VISUAL_DPI),
+          dpi: effectiveDpi,
           baseDir: safeBaseDir,
         });
-        return c.json(result);
-      } catch (error) {
-        options.onError?.(error);
-        if (error instanceof HTTPException) throw error;
-        if (error instanceof UnsafeOutboundSourceError) {
-          throw new HTTPException(400, { message: error.message });
+      });
+      return c.json(result);
+    }
+  );
+
+  router.post(
+    '/rasterize/batch',
+    ...shared,
+    tbValidator(RasterizeBatchRequestSchema),
+    async (c) => {
+      const { slides, baseDir } = getValidated<{
+        slides: Array<{ presentation: unknown; dpi?: number }>;
+        baseDir?: string;
+      }>(c, 'json');
+      const safeBaseDir = resolveSafeBaseDir(baseDir);
+      const effectiveSlides = slides.map((slide) => ({
+        presentation: slide.presentation,
+        dpi: clampVisualDpi(slide.dpi ?? DEFAULT_VISUAL_DPI),
+      }));
+      assertPixelBudget(effectiveSlides);
+
+      const result = await guard(async () => {
+        if (options.sourcePolicy) {
+          slides.forEach((slide, index) =>
+            assertSafeOutboundSources(
+              slide.presentation,
+              options.sourcePolicy!,
+              `slides[${index}].presentation`
+            )
+          );
         }
-        const msg =
-          error instanceof Error ? error.message.toLowerCase() : String(error);
-        if (msg.includes('not found') || msg.includes('rasterization needs')) {
-          throw new HTTPException(503, { message: (error as Error).message });
-        }
-        if (msg.includes('invalid') || msg.includes('validation')) {
-          throw new HTTPException(400, { message: (error as Error).message });
-        }
-        throw new HTTPException(500, {
-          message: 'Internal server error during rasterization',
+        return getBatchRasterizer()({
+          slides: effectiveSlides,
+          baseDir: safeBaseDir,
         });
-      }
+      });
+
+      // Per-slide errors from `build` are caused by the slide's own JSON and
+      // are the caller's actionable feedback; `convert`/`rasterize` failures
+      // carry raw tool output (host paths, temp dirs), which the single route
+      // never exposes — log them, return a generic message (C2 parity with
+      // /rasterize's 500 mapping).
+      return c.json({
+        results: result.results.map((slide) => {
+          if (slide.ok) return slide;
+          options.onError?.(new Error(slide.error));
+          return slide.stage === 'build'
+            ? { ok: false as const, error: slide.error }
+            : { ok: false as const, error: 'Slide rasterization failed' };
+        }),
+      });
     }
   );
 }

--- a/packages/jto/src/server/routes/__tests__/rasterize.test.ts
+++ b/packages/jto/src/server/routes/__tests__/rasterize.test.ts
@@ -89,3 +89,82 @@ describe('/api/pptx/rasterize', () => {
     30000
   );
 });
+
+describe('/api/pptx/rasterize/batch', () => {
+  let app: Hono;
+
+  beforeAll(() => {
+    Container.initialize(new PptxFormatAdapter());
+    app = new Hono();
+    app.route('/', createFormatRouter(new PptxFormatAdapter()) as any);
+  });
+
+  it('rejects an empty slides array (400)', async () => {
+    const res = await post(app, '/rasterize/batch', { slides: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a batch above MAX_RASTERIZE_BATCH_SLIDES (400)', async () => {
+    const res = await post(app, '/rasterize/batch', {
+      slides: Array.from({ length: 33 }, () => ({ presentation: slide() })),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a slide with an out-of-range dpi (400)', async () => {
+    const res = await post(app, '/rasterize/batch', {
+      slides: [{ presentation: slide(), dpi: 5 }],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it.skipIf(!HAS_BINARIES)(
+    'rasterizes independent slides (own sizes and dpi) in order, in one request',
+    async () => {
+      const wide = {
+        ...slide(),
+        props: { slideWidth: 6, slideHeight: 3 },
+      };
+      const res = await post(app, '/rasterize/batch', {
+        slides: [
+          { presentation: slide(), dpi: 120 },
+          { presentation: wide, dpi: 96 },
+        ],
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        results: Array<
+          | { ok: true; base64DataUri: string; width: number; height: number }
+          | { ok: false; error: string }
+        >;
+      };
+      expect(body.results).toHaveLength(2);
+      const [first, second] = body.results;
+      // 4in × 2in @120dpi → 480 × 240; 6in × 3in @96dpi → 576 × 288.
+      expect(first).toMatchObject({ ok: true, width: 480, height: 240 });
+      expect(second).toMatchObject({ ok: true, width: 576, height: 288 });
+    },
+    60000
+  );
+
+  it.skipIf(!HAS_BINARIES)(
+    'reports a broken slide per-item without failing its siblings',
+    async () => {
+      const res = await post(app, '/rasterize/batch', {
+        slides: [
+          { presentation: slide(), dpi: 96 },
+          // Invalid pptx definition: the builder rejects it per-slide.
+          { presentation: { name: 'not-pptx' } },
+        ],
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        results: Array<{ ok: boolean; error?: string }>;
+      };
+      expect(body.results[0].ok).toBe(true);
+      expect(body.results[1].ok).toBe(false);
+      expect(body.results[1].error).toBeTruthy();
+    },
+    60000
+  );
+});

--- a/packages/jto/src/server/routes/format.ts
+++ b/packages/jto/src/server/routes/format.ts
@@ -698,6 +698,9 @@ export function createFormatRouter(adapter: FormatAdapter) {
       rateLimiter({
         limit: process.env.NODE_ENV === 'production' ? 10 : 1000,
         window: 15 * 60 * 1000,
+        // One bucket for /rasterize AND /rasterize/batch — without a shared
+        // namespace the default per-path key would double the budget.
+        namespace: 'rasterize',
         trustProxy: config.rateLimit.trustProxy,
       }),
     ],

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,11 +12,18 @@ export type {
   PptxRasterizeRequest,
   PptxRasterizeResult,
   PptxRasterizer,
+  PptxRasterizeBatchSlide,
+  PptxRasterizeBatchRequest,
+  PptxRasterizeBatchSlideResult,
+  PptxRasterizeBatchResult,
+  PptxRasterizeFailureStage,
+  PptxBatchRasterizer,
 } from './types/services';
 export {
   DEFAULT_VISUAL_DPI,
   MIN_VISUAL_DPI,
   MAX_VISUAL_DPI,
+  MAX_RASTERIZE_BATCH_SLIDES,
   clampVisualDpi,
 } from './types/services';
 

--- a/packages/shared/src/types/services.ts
+++ b/packages/shared/src/types/services.ts
@@ -80,6 +80,70 @@ export type PptxRasterizer = (
   request: PptxRasterizeRequest
 ) => Promise<PptxRasterizeResult>;
 
+// ============================================================================
+// Batch rasterization (#153) — one request rasterizes many independent slides.
+//
+// Each slide is a complete single-slide presentation (the exact shape a
+// single {@link PptxRasterizeRequest} carries), NOT a slide fragment of one
+// merged deck. This keeps slides independent — each may use its own canvas
+// size, theme, and dpi, so callers never need to group visuals — and lets
+// implementations key per-slide caches identically to the single-slide path.
+// ============================================================================
+
+/**
+ * Maximum slides accepted in one batch request. Shared by the HTTP surface
+ * (request validation) and clients (chunk size) so the two cannot drift.
+ * Bounds per-request work and response size the same way rate limits bound
+ * request counts.
+ */
+export const MAX_RASTERIZE_BATCH_SLIDES = 32;
+
+/** One slide in a batch: a single-slide presentation plus its resolution. */
+export interface PptxRasterizeBatchSlide {
+  /** A pptx presentation component definition ({ name: 'pptx', ... }) with one slide */
+  presentation: unknown;
+  /** Target raster resolution in dots-per-inch (absent → service default) */
+  dpi?: number;
+}
+
+/** Request handed to a batch pptx rasterizer. */
+export interface PptxRasterizeBatchRequest {
+  /** Slides to rasterize; results come back index-aligned with this array. */
+  slides: PptxRasterizeBatchSlide[];
+  /** Base directory for relative asset paths, shared by every slide (#142). */
+  baseDir?: string;
+}
+
+/**
+ * Pipeline stage a slide failed in. `build` failures are caused by the
+ * slide's own JSON (safe to surface verbatim to callers); `convert` and
+ * `rasterize` failures are environment/tooling errors whose raw messages may
+ * carry host paths — HTTP surfaces sanitize those.
+ */
+export type PptxRasterizeFailureStage = 'build' | 'convert' | 'rasterize';
+
+/**
+ * Per-slide outcome. A batch response is 200-with-item-errors rather than
+ * all-or-nothing: one bad visual must not discard its siblings' pixels.
+ */
+export type PptxRasterizeBatchSlideResult =
+  | ({ ok: true } & PptxRasterizeResult)
+  | { ok: false; error: string; stage?: PptxRasterizeFailureStage };
+
+/** Result returned by a batch pptx rasterizer. */
+export interface PptxRasterizeBatchResult {
+  /** Index-aligned with the request's `slides` (same length, same order). */
+  results: PptxRasterizeBatchSlideResult[];
+}
+
+/**
+ * In-process batch rasterizer callback. Batch-level failures (missing
+ * binaries, bad request) throw; per-slide failures land in `results`.
+ */
+export type PptxBatchRasterizer = (
+  request: PptxRasterizeBatchRequest
+) => Promise<PptxRasterizeBatchResult>;
+
 /**
  * Configuration for the pptx rasterization service backing `visual` components.
  *
@@ -93,6 +157,12 @@ export interface PptxServiceConfig {
    * Ideal for tests (no binaries) and single-process hosts.
    */
   render?: PptxRasterizer;
+  /**
+   * In-process batch rasterizer. When provided, the docx renderer coalesces a
+   * document's visuals into batch calls (#153) instead of one `render` call
+   * per visual. Like `render`, takes precedence over `serverUrl`.
+   */
+  renderBatch?: PptxBatchRasterizer;
   /**
    * HTTP rasterization service URL. The service receives
    * `{ presentation, dpi }` and returns a {@link PptxRasterizeResult}.


### PR DESCRIPTION
Closes #153

## Problem

Each `visual` component POSTed its own single-slide presentation to `/rasterize`: one HTTP round trip + one `soffice` launch per visual, strictly sequential. The bundled annual-report templates carry ~25 visuals, so one docx render ≈ 25 calls — which starved the render server's production rate limit (#152 raised it to 600 as a stopgap).

## Design

**A batch is N independent single-slide pptx files converted in ONE `soffice` launch** — not one merged multi-slide deck. `soffice --convert-to pdf` accepts multiple files per launch, so the multi-second launch cost is amortized exactly the same, while each visual keeps its own file → own PDF → own PNG. This deletes the issue's listed fragilities instead of defending against them:

- **No page↔visual index mapping exists** (1 file = 1 slide = 1 PNG) — the off-by-one class is gone.
- **No grouping by (slide size, DPI)** anywhere: `pdftoppm` runs per-PDF, so every slide keeps independent canvas size, theme, and dpi.
- **Per-slide cache keys are byte-identical to the single-slide path** → batch and single share the content-addressed disk cache; zero hit-rate loss.
- **Per-slide failure semantics**: build errors are per-item; a missing PDF after the batch launch gets one isolated retry (capped at 3, within a wall-clock deadline), so a poisoned slide fails alone instead of failing the batch.

Client side, `renderDocument` runs a pre-pass: collect every enabled visual (generic tree walk), dedupe by `visualRasterKey`, rasterize via `renderBatch` → `render` (bounded concurrency) → HTTP `/rasterize/batch`, and seed a per-render map. `renderVisualComponent` consults the map first and **falls back to the existing per-visual path on any miss** — old servers (404 on the batch route), transport failures, malformed responses, and walk gaps all degrade to the sequential status quo, never to a broken render. Rolling deploys are safe in both directions.

## Blast radius (per the issue)

- **shared** — `PptxRasterizeBatch*` types, `PptxBatchRasterizer`, `PptxServiceConfig.renderBatch`, `MAX_RASTERIZE_BATCH_SLIDES` (32), stage-tagged slide errors.
- **jto-cli** — single + batch share one engine; `createLibreOfficePptxBatchRasterizer()`. Wall-clock deadline (one batch-scaled soffice window + one pdftoppm window) bounds every run.
- **core-docx** — `prerasterizeVisuals` pre-pass, map lookup in `renderVisualComponent`, `flattenVisuals` gains optional `rasterizeBatch`. Configs without `renderBatch` still get bounded-concurrency parallelism (the issue's interim lever, for free).
- **jto** — additive `POST /rasterize/batch` on both surfaces via the shared route registrar; one rate-limit bucket with `/rasterize`; per-slide source policy; slide-content errors verbatim, tooling errors sanitized to the log; estimated pixel budgets (64 MP/slide, 256 MP/batch). Docs updated.

## Verification

- 33 new tests across collector/orchestrator/fallbacks/route validation + LibreOffice-gated integration (mixed sizes + dpi in order; poisoned slide isolated per-item). Full monorepo build/test/lint green.
- Real CLI smoke, 8-visual doc: **1 soffice launch (8 files), 3.5 s cold; 0 launches, 0.8 s warm** — previously 8 sequential launches.
- Adversarial review pass; all critical/important findings fixed (retry storm bounds, error sanitization, `{renderBatch, serverUrl}` fallback, shared limiter bucket, pixel budgets, malformed-visual resilience).

## Follow-ups (not in this PR)

- Ops: drop `RASTERIZE_RATE_LIMIT` from 600 back toward ~60 once deployed (the issue's payoff).
- Consider rate-limit weighting by slide count (1 batch = up to 32 slides of compute).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch visual rasterization for up to 32 slides per request.
  * DOCX rendering now pre-rasterizes and reuses duplicate visuals for improved efficiency.
  * Added per-slide results, validation, caching, retry handling, and fallback to individual rasterization.
  * Added batch rasterization support to the render server and CLI workflows.
* **Bug Fixes**
  * Improved handling of rasterization failures so one failed visual does not prevent other slides from completing.
  * Added pixel-budget enforcement and safer error reporting.
* **Documentation**
  * Documented the new batch rasterization endpoint and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->