### PR TITLE
fix(playground): reliable Copy standard components

### DIFF
--- a/.changeset/copy-standard-components.md
+++ b/.changeset/copy-standard-components.md
@@ -1,0 +1,33 @@
+---
+'@json-to-office/core-docx': minor
+'@json-to-office/jto-cli': minor
+'@json-to-office/jto': patch
+---
+
+fix: make the playground's "Copy standard components" reliable and cheap (#155)
+
+The action failed two ways: it was silently disabled until the first Run
+(gated on the generated output instead of the editor document), and when it
+did run, the clipboard write happened after a slow server round trip — the
+click's user activation had expired, so Chromium rejected the write with
+`NotAllowedError` even though the request succeeded. The endpoint was slow
+by construction: it used the deprecated `getStandardComponentsDefinition`,
+which runs a full generation (LibreOffice visual rasterization included)
+just to surface the JSON tree.
+
+- `core-docx`: new `expandStandardDefinition()` on plugin generators —
+  validation, theme resolution, custom-component expansion, and
+  normalization only. No fonts, no layout, no rendering, no external
+  services. Returns `StandardDefinitionResult`.
+- `jto-cli`: `GeneratorResult.getStandardDefinition` wires the new cheap
+  path (replaces the deprecated `getStandardComponentsDefinition`
+  pass-through, which no longer had in-repo callers).
+- `jto` server: `/standard-components` uses the expansion-only path and
+  maps validation failures to 400 instead of 500.
+- `jto` playground: the clipboard write starts synchronously inside the
+  click (promise-payload `ClipboardItem`), so the browser authorizes it
+  while the gesture is live and the payload resolves when the fetch lands;
+  a denied write falls back to a dialog with the JSON and its own Copy
+  button. The menu item is enabled from the editor's active document (works
+  before the first Run, themes excluded) and explains itself with a tooltip
+  when no document is open.

--- a/packages/core-docx/src/index.ts
+++ b/packages/core-docx/src/index.ts
@@ -173,6 +173,7 @@ export {
   type GenerationResult,
   type BufferGenerationResult,
   type FileGenerationResult,
+  type StandardDefinitionResult,
   type ValidationResult,
   type ValidationError,
 

--- a/packages/core-docx/src/plugin/__tests__/generate-standard-definition.test.ts
+++ b/packages/core-docx/src/plugin/__tests__/generate-standard-definition.test.ts
@@ -295,6 +295,89 @@ describe('generate().standardDefinition', () => {
     expect(result.standardDefinition.children!.length).toBe(2);
   });
 
+  it('expandStandardDefinition returns the same tree as generate() without rendering', async () => {
+    const generator = createDocumentGenerator({
+      theme: testTheme,
+    })
+      .addComponent(greetingComponent)
+      .addComponent(summaryComponent);
+
+    const document = {
+      name: 'docx' as const,
+      props: { metadata: { title: 'Expansion Only' }, theme: 'minimal' },
+      children: [
+        { name: 'greeting' as const, props: { name: 'Eve' } },
+        {
+          name: 'summary' as const,
+          props: { title: 'Points', points: ['a', 'b'] },
+        },
+      ],
+    };
+
+    const expanded = await generator.expandStandardDefinition(document);
+    const generated = await generator.generate(document);
+
+    expect(expanded.standardDefinition).toEqual(generated.standardDefinition);
+    // Not a GenerationResult: nothing rendered, no document produced.
+    expect(expanded).not.toHaveProperty('document');
+  });
+
+  it('expandStandardDefinition validates like generate()', async () => {
+    const generator = createDocumentGenerator({
+      theme: testTheme,
+    }).addComponent(greetingComponent);
+
+    await expect(
+      generator.expandStandardDefinition({
+        name: 'docx',
+        props: { metadata: { title: 'Invalid' } },
+        children: [{ name: 'greeting', props: {} as any }],
+      })
+    ).rejects.toThrow();
+  });
+
+  it('expandStandardDefinition never invokes rendering services', async () => {
+    // A visual component would hit services.pptx during generate(); the
+    // expansion-only path must not touch it (#155 — the whole point is
+    // skipping LibreOffice).
+    const renderSpy = { called: false };
+    const generator = createDocumentGenerator({
+      theme: testTheme,
+      services: {
+        pptx: {
+          render: async () => {
+            renderSpy.called = true;
+            return {
+              base64DataUri: 'data:image/png;base64,',
+              width: 1,
+              height: 1,
+            };
+          },
+        },
+      } as any,
+    }).addComponent(greetingComponent);
+
+    const { standardDefinition } = await generator.expandStandardDefinition({
+      name: 'docx',
+      props: { metadata: { title: 'No Render' } },
+      children: [
+        { name: 'greeting', props: { name: 'Frank' } },
+        {
+          name: 'visual',
+          props: {
+            canvas: { width: 6, height: 4 },
+            elements: [
+              { name: 'text', props: { text: 'Hi', x: 1, y: 1, w: 4, h: 1 } },
+            ],
+          },
+        },
+      ] as any,
+    });
+
+    expect(standardDefinition.children!.length).toBe(2);
+    expect(renderSpy.called).toBe(false);
+  });
+
   it('should throw DuplicateComponentError when same component name is registered twice', () => {
     const duplicateGreetingComponent = createComponent({
       name: 'greeting',

--- a/packages/core-docx/src/plugin/createDocumentGenerator.ts
+++ b/packages/core-docx/src/plugin/createDocumentGenerator.ts
@@ -16,6 +16,7 @@ import type {
   GenerationResult,
   BufferGenerationResult,
   FileGenerationResult,
+  StandardDefinitionResult,
   ValidationResult,
   GenerationValidationOptions,
 } from './types';
@@ -404,6 +405,168 @@ function createBuilderImpl<
   }
 
   /**
+   * Shared front half of the pipeline: validate, resolve theme context,
+   * expand custom components, normalize. Everything `standardDefinition`
+   * needs and nothing more — fonts, structure, layout, rendering (and the
+   * visual rasterization that rides on it) all happen after this point.
+   */
+  async function expandDocument(
+    document: ExtendedReportComponent<TComponents>,
+    options?: GenerateOptions
+  ): Promise<{
+    modedRoot: ReportComponentDefinition;
+    modedTheme: ThemeConfig;
+    themeName: string;
+    processed: {
+      standard: ComponentDefinition[];
+      preserved: ComponentDefinition[];
+    };
+    modedDoc: ReportComponentDefinition;
+    warnings: GenerationWarning[];
+    preserveSet: ReadonlySet<string> | undefined;
+  }> {
+    const preserveSet = resolvePreserveSet(options);
+
+    // Cast to ReportComponentDefinition for internal processing. A root
+    // written without a `props` key validates clean, so default it to `{}`
+    // — otherwise every downstream `props.*` read throws. Only `undefined`
+    // is defaulted, so a malformed `props: null` still reaches the
+    // validator. Matches core/generator.ts.
+    const rootIn = document as unknown as ReportComponentDefinition;
+    const internalDocument: ReportComponentDefinition =
+      rootIn.props === undefined ? { ...rootIn, props: {} } : rootIn;
+
+    // Validate the document first (plugin-aware), unless disabled. Throwing
+    // here stops a malformed document from silently building into a corrupt
+    // or incomplete DOCX.
+    const vOpts: GenerationValidationOptions = {
+      ...state.validation,
+      ...options?.validation,
+    };
+    if (vOpts.enabled !== false) {
+      const result = validateDocument(
+        internalDocument,
+        state.components as unknown as CustomComponent<TSchema>[],
+        { allowUnknownFields: vOpts.allowUnknownFields }
+      );
+      if (!result.valid) {
+        throw new ComponentValidationError(
+          (result.errors ?? []).map((e) => ({
+            path: e.path ?? '',
+            message: e.message,
+          })),
+          internalDocument
+        );
+      }
+    }
+
+    // Re-apply the same gate to the tree each custom component's render()
+    // emits. The pre-expansion pass above only saw authored nodes, so a
+    // standard component produced by a plugin would otherwise reach
+    // standardDefinition unchecked. We validate the emitted nodes in their
+    // pre-normalization form — exactly how authored nodes are validated —
+    // by reusing the already-validated document props as a wrapper, so the
+    // only new errors come from the emitted children. Undefined when
+    // validation is disabled, which short-circuits the boundary check.
+    const validateEmitted =
+      vOpts.enabled === false
+        ? undefined
+        : (emitted: ComponentDefinition[], componentLabel: string) => {
+            const result = validateDocument(
+              { ...internalDocument, children: emitted },
+              state.components as unknown as CustomComponent<TSchema>[],
+              { allowUnknownFields: vOpts.allowUnknownFields }
+            );
+            if (!result.valid) {
+              throw new ComponentValidationError(
+                (result.errors ?? []).map((e) => ({
+                  path: e.path ?? '',
+                  message: `custom component '${componentLabel}' emitted invalid output — ${e.message}`,
+                })),
+                emitted
+              );
+            }
+          };
+
+    // Initialize warnings collector
+    const warnings: GenerationWarning[] = [];
+
+    // Props defaulting, theme resolution (customThemes → doc-named
+    // built-in → constructor theme → built-in fallback, see
+    // resolveDocumentTheme), in-document overrides, export-mode pre-pass and cache-key
+    // scoping — shared with the core pipeline so the two cannot drift (see
+    // core/generationContext.ts). The pre-pass runs BEFORE custom-component
+    // expansion so components reading `theme.fonts.*` during render see the
+    // substituted names, not the original non-safe ones.
+    const {
+      document: modedRoot,
+      theme: modedTheme,
+      themeName,
+    } = resolveThemeContext(internalDocument, {
+      customThemes: state.customThemes,
+      fonts: state.fonts,
+      warnings,
+      resolveNamedTheme: resolveDocumentTheme,
+    });
+
+    // Process custom components to convert them to standard components.
+    // Builds standard (fully expanded) and preserved (partial) trees in one pass.
+    const processed = await processDocumentComponents(
+      modedRoot.children || [],
+      preserveSet,
+      warnings,
+      modedTheme,
+      validateEmitted
+    );
+
+    // Create a new document definition with processed components
+    const processedDocument: ReportComponentDefinition = {
+      ...modedRoot,
+      children: processed.standard,
+    };
+
+    // Normalize components (handle shorthand notations and nested structures)
+    // We bypass JSON validation since we've already validated with custom schemas
+    const [modedDoc] = normalizeDocument(processedDocument);
+
+    return {
+      modedRoot,
+      modedTheme,
+      themeName,
+      processed,
+      modedDoc,
+      warnings,
+      preserveSet,
+    };
+  }
+
+  /**
+   * Compute only the post-expansion standard definition. Runs validation,
+   * theme resolution, custom-component expansion, and normalization — but
+   * skips font resolution, layout, rendering, and packaging, so it never
+   * touches external services (no visual rasterization, no chart export).
+   * Orders of magnitude cheaper than `generate()` when you only need the
+   * JSON tree.
+   */
+  async function expandStandardDefinition(
+    document: ExtendedReportComponent<TComponents>,
+    options?: GenerateOptions
+  ): Promise<StandardDefinitionResult> {
+    try {
+      const { modedDoc, warnings } = await expandDocument(document, options);
+      return {
+        standardDefinition: modedDoc,
+        warnings: warnings.length > 0 ? warnings : null,
+      };
+    } catch (error) {
+      if (state.debug) {
+        console.error('Document expansion error:', error);
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Generate a document
    */
   async function generate(
@@ -411,109 +574,15 @@ function createBuilderImpl<
     options?: GenerateOptions
   ): Promise<GenerationResult<TComponents>> {
     try {
-      const preserveSet = resolvePreserveSet(options);
-
-      // Cast to ReportComponentDefinition for internal processing. A root
-      // written without a `props` key validates clean, so default it to `{}`
-      // — otherwise every downstream `props.*` read throws. Only `undefined`
-      // is defaulted, so a malformed `props: null` still reaches the
-      // validator. Matches core/generator.ts.
-      const rootIn = document as unknown as ReportComponentDefinition;
-      const internalDocument: ReportComponentDefinition =
-        rootIn.props === undefined ? { ...rootIn, props: {} } : rootIn;
-
-      // Validate the document first (plugin-aware), unless disabled. Throwing
-      // here stops a malformed document from silently building into a corrupt
-      // or incomplete DOCX.
-      const vOpts: GenerationValidationOptions = {
-        ...state.validation,
-        ...options?.validation,
-      };
-      if (vOpts.enabled !== false) {
-        const result = validateDocument(
-          internalDocument,
-          state.components as unknown as CustomComponent<TSchema>[],
-          { allowUnknownFields: vOpts.allowUnknownFields }
-        );
-        if (!result.valid) {
-          throw new ComponentValidationError(
-            (result.errors ?? []).map((e) => ({
-              path: e.path ?? '',
-              message: e.message,
-            })),
-            internalDocument
-          );
-        }
-      }
-
-      // Re-apply the same gate to the tree each custom component's render()
-      // emits. The pre-expansion pass above only saw authored nodes, so a
-      // standard component produced by a plugin would otherwise reach
-      // standardDefinition unchecked. We validate the emitted nodes in their
-      // pre-normalization form — exactly how authored nodes are validated —
-      // by reusing the already-validated document props as a wrapper, so the
-      // only new errors come from the emitted children. Undefined when
-      // validation is disabled, which short-circuits the boundary check.
-      const validateEmitted =
-        vOpts.enabled === false
-          ? undefined
-          : (emitted: ComponentDefinition[], componentLabel: string) => {
-              const result = validateDocument(
-                { ...internalDocument, children: emitted },
-                state.components as unknown as CustomComponent<TSchema>[],
-                { allowUnknownFields: vOpts.allowUnknownFields }
-              );
-              if (!result.valid) {
-                throw new ComponentValidationError(
-                  (result.errors ?? []).map((e) => ({
-                    path: e.path ?? '',
-                    message: `custom component '${componentLabel}' emitted invalid output — ${e.message}`,
-                  })),
-                  emitted
-                );
-              }
-            };
-
-      // Initialize warnings collector
-      const warnings: GenerationWarning[] = [];
-
-      // Props defaulting, theme resolution (customThemes → doc-named
-      // built-in → constructor theme → built-in fallback, see
-      // resolveDocumentTheme), in-document overrides, export-mode pre-pass and cache-key
-      // scoping — shared with the core pipeline so the two cannot drift (see
-      // core/generationContext.ts). The pre-pass runs BEFORE custom-component
-      // expansion so components reading `theme.fonts.*` during render see the
-      // substituted names, not the original non-safe ones.
       const {
-        document: modedRoot,
-        theme: modedTheme,
-        themeName,
-      } = resolveThemeContext(internalDocument, {
-        customThemes: state.customThemes,
-        fonts: state.fonts,
-        warnings,
-        resolveNamedTheme: resolveDocumentTheme,
-      });
-
-      // Process custom components to convert them to standard components.
-      // Builds standard (fully expanded) and preserved (partial) trees in one pass.
-      const processed = await processDocumentComponents(
-        modedRoot.children || [],
-        preserveSet,
-        warnings,
+        modedRoot,
         modedTheme,
-        validateEmitted
-      );
-
-      // Create a new document definition with processed components
-      const processedDocument: ReportComponentDefinition = {
-        ...modedRoot,
-        children: processed.standard,
-      };
-
-      // Normalize components (handle shorthand notations and nested structures)
-      // We bypass JSON validation since we've already validated with custom schemas
-      const [modedDoc] = normalizeDocument(processedDocument);
+        themeName,
+        processed,
+        modedDoc,
+        warnings,
+        preserveSet,
+      } = await expandDocument(document, options);
 
       // Resolve fonts (reads document + resolved theme). The helper fires
       // `fonts.onResolved` internally when a listener is registered
@@ -710,6 +779,7 @@ function createBuilderImpl<
     generate,
     generateBuffer,
     generateFile,
+    expandStandardDefinition,
     getComponentNames,
     validate,
     generateSchema,

--- a/packages/core-docx/src/plugin/index.ts
+++ b/packages/core-docx/src/plugin/index.ts
@@ -50,6 +50,7 @@ export {
   type GenerationResult,
   type BufferGenerationResult,
   type FileGenerationResult,
+  type StandardDefinitionResult,
   type ValidationResult,
   type ExtractCustomComponentType,
   type CustomComponentUnion,

--- a/packages/core-docx/src/plugin/types.ts
+++ b/packages/core-docx/src/plugin/types.ts
@@ -235,6 +235,17 @@ export interface FileGenerationResult<
 }
 
 /**
+ * Result of `expandStandardDefinition` — the post-expansion JSON tree without
+ * any of the rendering work.
+ */
+export interface StandardDefinitionResult {
+  /** Post-expansion, post-normalization standard JSON tree (custom plugins resolved). */
+  standardDefinition: ReportComponentDefinition;
+  /** Warnings collected during expansion, null if no warnings */
+  warnings: GenerationWarning[] | null;
+}
+
+/**
  * Result of document validation
  */
 export interface ValidationResult {
@@ -270,6 +281,17 @@ export interface DocumentGenerator<
     outputPath: string,
     options?: GenerateFileOptions
   ) => Promise<FileGenerationResult<TCustomComponents>>;
+
+  /**
+   * Compute only the post-expansion standard definition: validation, theme
+   * resolution, custom-component expansion, and normalization — no font
+   * resolution, no layout, no rendering, no packaging, no external services.
+   * Use this instead of `generate()` when you only need the JSON tree.
+   */
+  expandStandardDefinition: (
+    document: ExtendedReportComponent<TCustomComponents>,
+    options?: GenerateOptions
+  ) => Promise<StandardDefinitionResult>;
 
   getComponentNames: () => string[];
 

--- a/packages/jto-cli/src/format-adapter.ts
+++ b/packages/jto-cli/src/format-adapter.ts
@@ -140,8 +140,14 @@ interface GeneratorBuilder {
       baseDir?: string;
     }
   ): Promise<{ buffer: Buffer; warnings: any }>;
-  /** @deprecated Read `standardDefinition` off `generate(...)` instead. */
-  getStandardComponentsDefinition?: (document: any) => Promise<any>;
+  /**
+   * Cheap standard-definition path: expansion + normalization only, no
+   * rendering (DOCX generators expose it; PPTX ones may not).
+   */
+  expandStandardDefinition?: (
+    document: any,
+    options?: { validation?: { allowUnknownFields?: boolean } }
+  ) => Promise<{ standardDefinition: any; warnings: any }>;
 }
 
 export interface GeneratorOptions {
@@ -164,8 +170,12 @@ export interface GeneratorOptions {
 
 export interface GeneratorResult {
   generateBuffer: (document: any) => Promise<Buffer>;
-  /** @deprecated Will be removed once consumers migrate to `generate().standardDefinition`. */
-  getStandardComponentsDefinition?: (config: any) => Promise<any>;
+  /**
+   * Post-expansion standard JSON tree without any rendering work — no fonts,
+   * no layout, no visual rasterization. Present when the underlying generator
+   * supports it (plugin-aware DOCX generation does).
+   */
+  getStandardDefinition?: (config: any) => Promise<any>;
   hasPlugins: boolean;
   pluginNames: string[];
   /**
@@ -346,8 +356,26 @@ export class DocxFormatAdapter implements FormatAdapter {
         emitGenerationWarnings(result.warnings ?? []);
         return result.buffer;
       },
-      getStandardComponentsDefinition: generator.getStandardComponentsDefinition
-        ? (config: any) => generator.getStandardComponentsDefinition!(config)
+      getStandardDefinition: generator.expandStandardDefinition
+        ? async (config: any) => {
+            const parsed =
+              typeof config === 'string' ? JSON.parse(config) : config;
+            const { document: docDefinition } = withRequestedTheme(
+              parsed,
+              requestedTheme,
+              customThemes
+            );
+            const result = await generator.expandStandardDefinition!(
+              docDefinition,
+              {
+                validation: {
+                  allowUnknownFields: options.validation?.allowUnknownFields,
+                },
+              }
+            );
+            emitGenerationWarnings(result.warnings ?? []);
+            return result.standardDefinition;
+          }
         : undefined,
       hasPlugins: true,
       pluginNames,

--- a/packages/jto/src/client/components/playground/global-preview-header.tsx
+++ b/packages/jto/src/client/components/playground/global-preview-header.tsx
@@ -38,6 +38,15 @@ export function GlobalPreviewHeader({
     activeTab && documentTypes[activeTab] === 'application/json+theme'
       ? 'theme'
       : 'document';
+  // The editor's active document text (not the last generated output) so
+  // "Copy standard components" works before the first Run (#155). Themes are
+  // excluded — they have no standard-components expansion. The selector
+  // returns a string, so Zustand's equality check keeps renders cheap.
+  const editorDocumentText = useDocumentsStore((s) =>
+    s.activeTab && s.documentTypes[s.activeTab] !== 'application/json+theme'
+      ? s.documents.find((d) => d.name === s.activeTab)?.text
+      : undefined
+  );
 
   const chatOpen = __AI_ENABLED__ ? useChatStore((s) => s.chatOpen) : false;
 
@@ -87,6 +96,7 @@ export function GlobalPreviewHeader({
         onShowSchemas={() => setSchemaOpen(true)}
         onShowFonts={() => openFontPicker()}
         documentText={text}
+        editorDocumentText={editorDocumentText}
         warnings={warnings}
         renderingLibrary={renderingLibrary}
         setRenderingLibrary={(lib) =>

--- a/packages/jto/src/client/components/playground/preview-header.tsx
+++ b/packages/jto/src/client/components/playground/preview-header.tsx
@@ -36,6 +36,7 @@ import {
 } from '../ui/dropdown-menu';
 import { Switch } from '../ui/switch';
 import { Label } from '../ui/label';
+import { Textarea } from '../ui/textarea';
 import {
   Select,
   SelectContent,
@@ -84,6 +85,7 @@ function PreviewHeader({
   onShowSchemas,
   onShowFonts,
   documentText,
+  editorDocumentText,
   warnings,
   renderingLibrary,
   setRenderingLibrary,
@@ -105,6 +107,12 @@ function PreviewHeader({
   onShowSchemas?: () => void;
   onShowFonts?: () => void;
   documentText?: string;
+  /**
+   * The active editor document's text. Drives "Copy standard components":
+   * unlike `documentText` (the last generated output's source), it exists
+   * before the first Run (#155).
+   */
+  editorDocumentText?: string;
   warnings?: GenerationWarning[] | null;
   renderingLibrary?: RenderingLibrary;
   setRenderingLibrary?: (lib: RenderingLibrary) => void;
@@ -121,6 +129,10 @@ function PreviewHeader({
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const [isCopyingStandardComponents, setIsCopyingStandardComponents] =
     useState(false);
+  // Non-null when the async clipboard write was denied: the dialog re-offers
+  // the fetched JSON behind a button whose click is a fresh user gesture.
+  const [standardComponentsFallbackJson, setStandardComponentsFallbackJson] =
+    useState<string | null>(null);
   const { toast } = useToast();
   // The hook is format-agnostic (dispatches on FORMAT env); alias to a
   // neutral name so DOCX call sites don't read as if they're calling a
@@ -377,8 +389,17 @@ function PreviewHeader({
     }
   }, [toast]);
 
-  const handleCopyStandardComponents = useCallback(async () => {
-    if (!documentText) {
+  // The text "Copy standard components" operates on: the active editor
+  // document when available (works before the first Run), else the last
+  // generated output's source (#155).
+  const copySourceText = editorDocumentText ?? documentText;
+
+  const handleCopyStandardComponents = useCallback(() => {
+    // NOT async: navigator.clipboard.write must be invoked while the click's
+    // user activation is still live. The server round trip rides inside the
+    // ClipboardItem as a promise payload; awaiting it before writing is what
+    // used to kill the write with NotAllowedError (#155).
+    if (!copySourceText) {
       toast({
         title: 'No document available',
         description: 'Please select a document to copy standard components',
@@ -386,16 +407,27 @@ function PreviewHeader({
       });
       return;
     }
+    try {
+      JSON.parse(copySourceText);
+    } catch {
+      toast({
+        title: 'Document is not valid JSON',
+        description: 'Fix the JSON errors in the editor, then copy again',
+        variant: 'destructive',
+      });
+      return;
+    }
 
     setIsCopyingStandardComponents(true);
-    try {
+
+    const jsonPromise = (async () => {
       const response = await fetch(`/api/${FORMAT}/standard-components`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          jsonDefinition: documentText,
+          jsonDefinition: copySourceText,
         }),
       });
 
@@ -405,37 +437,87 @@ function PreviewHeader({
           const errorData = await response.json();
           if (errorData.message) description = errorData.message;
         } catch {}
-        toast({
-          title: 'Failed to get standard components',
-          description,
-          variant: 'destructive',
-        });
-        return;
+        throw new Error(description);
       }
 
       const result = await response.json();
-      const standardComponentsJson = JSON.stringify(result.data, null, 2);
+      return JSON.stringify(result.data, null, 2);
+    })();
 
-      await navigator.clipboard.writeText(standardComponentsJson);
+    // Start the clipboard write synchronously (gesture still live), then
+    // settle the UI asynchronously.
+    let writePromise: Promise<void>;
+    if (typeof ClipboardItem !== 'undefined' && navigator.clipboard?.write) {
+      writePromise = navigator.clipboard.write([
+        new ClipboardItem({
+          // Promise-of-Blob payload: accepted by Chromium and Safari even
+          // when it resolves after the activation window has passed.
+          'text/plain': jsonPromise.then(
+            (text) => new Blob([text], { type: 'text/plain' })
+          ),
+        }),
+      ]);
+    } else if (navigator.clipboard?.writeText) {
+      writePromise = jsonPromise.then((text) =>
+        navigator.clipboard.writeText(text)
+      );
+    } else {
+      writePromise = Promise.reject(
+        new Error('Clipboard is not available in this context')
+      );
+    }
 
+    void (async () => {
+      try {
+        await writePromise;
+        toast({
+          title: 'Copied to clipboard',
+          description: 'Standard components JSON has been copied',
+        });
+      } catch (error) {
+        // Disambiguate: a rejected fetch means there is nothing to copy —
+        // report it. A denied/unavailable clipboard write with a good payload
+        // falls back to a dialog whose Copy button gets a fresh gesture.
+        let json: string | null = null;
+        try {
+          json = await jsonPromise;
+        } catch (fetchError) {
+          console.error('Error fetching standard components:', fetchError);
+          toast({
+            title: 'Failed to get standard components',
+            description:
+              fetchError instanceof Error
+                ? fetchError.message
+                : 'Request failed',
+            variant: 'destructive',
+          });
+          return;
+        }
+        console.error('Clipboard write failed:', error);
+        setStandardComponentsFallbackJson(json);
+      } finally {
+        setIsCopyingStandardComponents(false);
+      }
+    })();
+  }, [copySourceText, toast]);
+
+  const handleCopyFromFallbackDialog = useCallback(async () => {
+    if (standardComponentsFallbackJson == null) return;
+    try {
+      await navigator.clipboard.writeText(standardComponentsFallbackJson);
       toast({
         title: 'Copied to clipboard',
         description: 'Standard components JSON has been copied',
       });
-    } catch (error) {
-      console.error('Error copying standard components:', error);
+      setStandardComponentsFallbackJson(null);
+    } catch {
       toast({
-        title: 'Error',
-        description:
-          error instanceof Error
-            ? error.message
-            : 'Failed to copy standard components',
+        title: 'Clipboard unavailable',
+        description: 'Select the JSON in the dialog and copy it manually',
         variant: 'destructive',
       });
-    } finally {
-      setIsCopyingStandardComponents(false);
     }
-  }, [documentText, toast]);
+  }, [standardComponentsFallbackJson, toast]);
 
   return (
     <>
@@ -668,15 +750,35 @@ function PreviewHeader({
                   View cache metrics
                 </DropdownMenuItem>
               )}
-              <DropdownMenuItem
-                onClick={handleCopyStandardComponents}
-                disabled={!documentText || isCopyingStandardComponents}
-              >
-                <Code2 className="h-4 w-4 mr-2" />
-                {isCopyingStandardComponents
-                  ? 'Copying...'
-                  : 'Copy standard components'}
-              </DropdownMenuItem>
+              {copySourceText ? (
+                <DropdownMenuItem
+                  onClick={handleCopyStandardComponents}
+                  disabled={isCopyingStandardComponents}
+                >
+                  <Code2 className="h-4 w-4 mr-2" />
+                  {isCopyingStandardComponents
+                    ? 'Copying...'
+                    : 'Copy standard components'}
+                </DropdownMenuItem>
+              ) : (
+                <Tooltip>
+                  {/* Disabled items swallow pointer events; the wrapper span
+                      keeps hover alive so the disabled state explains itself. */}
+                  <TooltipTrigger asChild>
+                    <span className="block">
+                      <DropdownMenuItem disabled>
+                        <Code2 className="h-4 w-4 mr-2" />
+                        Copy standard components
+                      </DropdownMenuItem>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="left">
+                    <p>
+                      No document selected — open or select a document first
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              )}
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={() => setShowClearConfirm(true)}
@@ -764,6 +866,43 @@ function PreviewHeader({
         nonSafeFonts={nonSafeFonts}
         onChoose={handleDownloadWithMode}
       />
+
+      {/* Clipboard-denied fallback: the browser refused the async write, so
+          re-offer the JSON behind a fresh click. */}
+      <Dialog
+        open={standardComponentsFallbackJson != null}
+        onOpenChange={(open) => {
+          if (!open) setStandardComponentsFallbackJson(null);
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Standard components</DialogTitle>
+            <DialogDescription>
+              The browser blocked the automatic clipboard write. Copy the JSON
+              from here instead.
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            readOnly
+            value={standardComponentsFallbackJson ?? ''}
+            className="h-64 font-mono text-xs"
+            onFocus={(e) => e.currentTarget.select()}
+          />
+          <DialogFooter>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setStandardComponentsFallbackJson(null)}
+            >
+              Close
+            </Button>
+            <Button size="sm" onClick={handleCopyFromFallbackDialog}>
+              Copy to clipboard
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Clear cache confirmation */}
       <Dialog open={showClearConfirm} onOpenChange={setShowClearConfirm}>

--- a/packages/jto/src/client/components/playground/preview.tsx
+++ b/packages/jto/src/client/components/playground/preview.tsx
@@ -94,6 +94,13 @@ export function Preview() {
   } = useOutputStore((state) => state);
   const activeTab = useDocumentsStore((state) => state.activeTab);
   const documentTypes = useDocumentsStore((state) => state.documentTypes);
+  // Editor text for "Copy standard components" — exists before the first Run,
+  // unlike the output store's `text` (#155). Themes have no expansion.
+  const editorDocumentText = useDocumentsStore((s) =>
+    s.activeTab && s.documentTypes[s.activeTab] !== 'application/json+theme'
+      ? s.documents.find((d) => d.name === s.activeTab)?.text
+      : undefined
+  );
   // Select the raw map (stable reference until themes mutate), then memoize
   // the transform. A selector that returns a freshly-constructed object on
   // every call would burn through Zustand's Object.is equality and retrigger
@@ -254,6 +261,7 @@ export function Preview() {
             isRendering={isRendering}
             onShowCacheMetrics={() => setShowCacheMetrics(true)}
             documentText={text}
+            editorDocumentText={editorDocumentText}
             warnings={warnings}
             renderingLibrary={renderingLibrary}
             setRenderingLibrary={(lib) =>

--- a/packages/jto/src/server/routes/format.ts
+++ b/packages/jto/src/server/routes/format.ts
@@ -575,10 +575,17 @@ export function createFormatRouter(adapter: FormatAdapter) {
         assertRequestSources(jsonDefinition, 'jsonDefinition');
         assertRequestSources(customThemes, 'customThemes');
 
-        const config =
-          typeof jsonDefinition === 'string'
-            ? JSON.parse(jsonDefinition)
-            : jsonDefinition;
+        let config: unknown;
+        try {
+          config =
+            typeof jsonDefinition === 'string'
+              ? JSON.parse(jsonDefinition)
+              : jsonDefinition;
+        } catch {
+          throw new HTTPException(400, {
+            message: 'jsonDefinition is not valid JSON',
+          });
+        }
 
         // If plugins are loaded, use plugin-aware generator to resolve custom components
         const registry = PluginRegistry.getInstance();
@@ -588,9 +595,12 @@ export function createFormatRouter(adapter: FormatAdapter) {
             theme: customThemes ? Object.values(customThemes)[0] : undefined,
           });
 
-          if (generatorResult.getStandardComponentsDefinition) {
+          // Expansion-only path: resolves custom components to the standard
+          // tree without fonts/layout/rendering (#155) — the old deprecated
+          // wrapper ran a full generation, LibreOffice rasterization included.
+          if (generatorResult.getStandardDefinition) {
             const standardComponents =
-              await generatorResult.getStandardComponentsDefinition(config);
+              await generatorResult.getStandardDefinition(config);
             return c.json({
               success: true,
               data: standardComponents,
@@ -611,6 +621,19 @@ export function createFormatRouter(adapter: FormatAdapter) {
           requestId,
         });
         if (error instanceof HTTPException) throw error;
+        // Mirror /generate's mapping so document mistakes read as client
+        // errors, not server faults.
+        if (error instanceof Error) {
+          const msg = error.message.toLowerCase();
+          if (
+            msg.includes('invalid') ||
+            msg.includes('validation') ||
+            msg.includes('missing required') ||
+            msg.includes('unknown component')
+          ) {
+            throw new HTTPException(400, { message: error.message });
+          }
+        }
         throw new HTTPException(500, {
           message: 'Failed to get standard components definition',
         });


### PR DESCRIPTION
Closes #155.

## What was broken
1. The **⋯ → Copy standard components** item was silently disabled until the first successful Run: it gated on the *generated output's* text instead of the editor document, with no tooltip explaining why.
2. After a Run it still failed: the clipboard write happened after awaiting the fetch, and the endpoint runs a **full generation** (LibreOffice rasterization included) via the deprecated `getStandardComponentsDefinition` — by the time the response landed, the click's user activation had expired and Chromium rejected `writeText` with `NotAllowedError`.

## Fixes
- **core-docx**: new `expandStandardDefinition()` on plugin generators — validation → theme resolution → custom-component expansion → normalization, then stop. No fonts, no layout, no rendering, no external services. `generate()` now shares this front half, so the two cannot drift.
- **jto-cli**: `GeneratorResult.getStandardDefinition` wires the cheap path (applies the same `withRequestedTheme` semantics as `generateBuffer`); the deprecated pass-through is gone.
- **server**: `/standard-components` uses the expansion-only path; malformed JSON and validation failures map to 400 instead of 500.
- **playground**:
  - The clipboard write starts **synchronously inside the click** with a promise-payload `ClipboardItem` — the browser authorizes it while the gesture is live, the payload resolves when the fetch does. Falls back to `writeText` where `ClipboardItem` is unavailable.
  - A denied write (permissions policy, http) opens a dialog with the JSON and its own **Copy** button — a fresh gesture that always works.
  - The item enables from the **editor's active document** (works before the first Run; themes excluded) and gets a tooltip when genuinely disabled.

## Verified
- `expandStandardDefinition` returns the identical tree `generate()` produces, and a spy proves `services.pptx` is never invoked (new tests).
- Live in the playground: pre-Run click on the visual-infographic template → endpoint answered in **313 ms** (was seconds), and in the clipboard-denied embedded browser the fallback dialog appeared with the JSON.
- `turbo test` green for core-docx, jto-cli, jto.