### PR TITLE
Playground UX + schema export fixes

### DIFF
--- a/.changeset/copy-standard-components-media.md
+++ b/.changeset/copy-standard-components-media.md
@@ -1,0 +1,16 @@
+---
+'@json-to-office/jto': patch
+---
+
+Fix "Copy standard components" 400 for documents referencing bundled media.
+
+In safe mode, `/standard-components` validated the raw definition against the
+outbound-source policy, so any discovered document referencing relative
+`media/...` paths was rejected with a 400 — while `/generate` accepted the same
+document because it inlines discovered media first. The route now mirrors
+`/generate`'s prologue (sourceName → baseDir → inline media before source
+validation) and passes `customThemes` through as a theme registry instead of
+forcing the first custom theme. The playground client now sends
+`options.sourceName` and the current custom themes with the request, and reads
+the server's `error` field so the toast shows the real failure reason instead
+of "Request failed with status 400".

--- a/.changeset/generation-loading-ux.md
+++ b/.changeset/generation-loading-ux.md
@@ -1,0 +1,16 @@
+---
+'@json-to-office/jto': patch
+---
+
+Richer, more honest generation loading UI in the playground.
+
+The full-screen "Generating Document" loader now shows the document's title,
+a summary of what's being built (sections, visuals, images, tables,
+paragraphs…), a live elapsed timer, and — once a build takes more than a few
+seconds — rotating context hints tuned to the document (e.g. how many visuals
+are being rasterized and that later builds reuse the cache). The active stage
+uses an honest indeterminate sweep instead of a fake full progress bar, with
+proper check icons for completed stages. The overlay shown over an existing
+preview during rebuilds gains the stage message and elapsed time. Both
+surfaces get a Cancel button wired to a new store-registered abort that
+cancels the in-flight build quietly (no error banner).

--- a/.changeset/optional-props-schema-export.md
+++ b/.changeset/optional-props-schema-export.md
@@ -1,0 +1,20 @@
+---
+'@json-to-office/shared-docx': patch
+---
+
+Export `props` as optional for components that do not require it.
+
+Every component variant in the generated JSON Schema listed `props` in
+`required`, including `section`, `toc`, `image` and `text-box`, whose props
+carry no required field. The runtime disagrees: it treats an omitted `props` as
+`{}` and lets the props schema decide. Schema-driven editors trusted the export
+and reddened documents that build — the playground reported 23 errors on the
+shipped `tech-report` template, one per propless `section`. The root `docx` node
+already carried this fix locally; it now applies to every component.
+
+Root `children` moves into the schema as a required field. It was enforced only
+by the deep validator, which runs on the fallback path taken when the TypeBox
+check has already failed — so it fired only as a side effect of `props` being
+required. CI now validates the stock playground templates against the generated
+schemas, which is what would have caught the drift: the previous step only
+checked two examples that write `props` on every node.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,11 +105,24 @@ jobs:
         shell: bash
         run: pnpm validate:assets
 
-      - name: Check generated schemas against smoke examples
+      - name: Check generated schemas against smoke examples and stock templates
         shell: bash
         run: |
           node packages/jto-cli/dist/cli.js docx validate examples/invoice.docx.json --quiet --schema .schema-smoke/docx/document.schema.json
           node packages/jto-cli/dist/cli.js pptx validate examples/quarterly-review.pptx.json --quiet --schema .schema-smoke/pptx/presentation.schema.json
+          # The two examples above write `props` on every node, so they never
+          # exercised the exported schema's optionality. The stock templates do:
+          # tech-report has 23 propless `section` nodes that the runtime accepts
+          # and the exported schema rejected, and nothing in CI could see it —
+          # `validate:assets` above uses the runtime validator, which reaches the
+          # same verdict by a different path. These are the documents the
+          # playground actually opens, so they gate the schema editors consume.
+          for file in packages/jto/src/client/public/templates/*.docx.json; do
+            node packages/jto-cli/dist/cli.js docx validate "$file" --quiet --schema .schema-smoke/docx/document.schema.json
+          done
+          for file in packages/jto/src/client/public/templates/*.pptx.json; do
+            node packages/jto-cli/dist/cli.js pptx validate "$file" --quiet --schema .schema-smoke/pptx/presentation.schema.json
+          done
 
       - name: Render dependency-free smoke examples
         shell: bash

--- a/packages/jto/src/client/components/playground/editor.tsx
+++ b/packages/jto/src/client/components/playground/editor.tsx
@@ -81,6 +81,24 @@ function EditorComponent() {
   const lastBuildRequestIdRef = useRef<string>('');
   const documentVersionsRef = useRef<Map<string, number>>(new Map());
 
+  // User-initiated cancel from the loading UI: invalidate the current request
+  // id first (so both build paths take their quiet "cancelled" exit instead of
+  // surfacing a global error), then abort the controllers and the in-flight
+  // fetch.
+  const cancelActiveBuild = useCallback(() => {
+    lastBuildRequestIdRef.current = `cancelled-${Date.now()}`;
+    for (const controller of buildAbortControllersRef.current.values()) {
+      controller.abort();
+    }
+    buildAbortControllersRef.current.clear();
+    cancelGeneration();
+    setOutput({ isGenerating: false, generationProgress: undefined });
+  }, [cancelGeneration, setOutput]);
+
+  useEffect(() => {
+    setOutput({ cancelGeneration: cancelActiveBuild });
+  }, [cancelActiveBuild, setOutput]);
+
   // Get or create a document version number
   const getDocumentVersion = useCallback((docName: string) => {
     const currentVersion = documentVersionsRef.current.get(docName) || 0;
@@ -149,6 +167,7 @@ function EditorComponent() {
       setOutput({
         globalError: undefined,
         isGenerating: true,
+        generationStartedAt: Date.now(),
         generationProgress: {
           stage: 'parsing',
           message: 'Rebuilding with updated theme...',
@@ -360,6 +379,7 @@ function EditorComponent() {
       setOutput({
         globalError: undefined,
         isGenerating: true,
+        generationStartedAt: Date.now(),
         generationProgress: {
           stage: 'parsing',
           message: 'Validating JSON structure...',

--- a/packages/jto/src/client/components/playground/editor.tsx
+++ b/packages/jto/src/client/components/playground/editor.tsx
@@ -78,6 +78,8 @@ function EditorComponent() {
     new Map()
   );
   const buildTimeoutsRef = useRef<Map<string, NodeJS.Timeout>>(new Map());
+  // Debounce timer for Run-button builds (150ms to coalesce rapid clicks).
+  const flushBuildTimerRef = useRef<NodeJS.Timeout | null>(null);
   const lastBuildRequestIdRef = useRef<string>('');
   const documentVersionsRef = useRef<Map<string, number>>(new Map());
 
@@ -87,12 +89,26 @@ function EditorComponent() {
   // fetch.
   const cancelActiveBuild = useCallback(() => {
     lastBuildRequestIdRef.current = `cancelled-${Date.now()}`;
+    // Also drop queued debounced builds — without this, a pending auto-build
+    // timer could start a new generation right after the user cancelled.
+    for (const timeout of buildTimeoutsRef.current.values()) {
+      clearTimeout(timeout);
+    }
+    buildTimeoutsRef.current.clear();
+    if (flushBuildTimerRef.current) {
+      clearTimeout(flushBuildTimerRef.current);
+      flushBuildTimerRef.current = null;
+    }
     for (const controller of buildAbortControllersRef.current.values()) {
       controller.abort();
     }
     buildAbortControllersRef.current.clear();
     cancelGeneration();
-    setOutput({ isGenerating: false, generationProgress: undefined });
+    setOutput({
+      isGenerating: false,
+      generationProgress: undefined,
+      generationStartedAt: undefined,
+    });
   }, [cancelGeneration, setOutput]);
 
   useEffect(() => {
@@ -203,7 +219,11 @@ function EditorComponent() {
 
         if (signal.aborted || lastBuildRequestIdRef.current !== id) {
           console.log('Theme build cancelled for:', doc.name);
-          setOutput({ isGenerating: false, generationProgress: undefined });
+          setOutput({
+            isGenerating: false,
+            generationProgress: undefined,
+            generationStartedAt: undefined,
+          });
           return;
         }
 
@@ -229,6 +249,7 @@ function EditorComponent() {
             isGenerating: false,
             isPreviewStale: false,
             generationProgress: undefined,
+            generationStartedAt: undefined,
             lastBuiltSequence: outputStore.getState().editSequence,
             cacheStatus: (result as any).cacheStatus as
               | 'HIT'
@@ -243,7 +264,11 @@ function EditorComponent() {
       } catch (error) {
         if (signal.aborted || lastBuildRequestIdRef.current !== id) {
           console.log('Theme build cancelled with error for:', doc.name);
-          setOutput({ isGenerating: false, generationProgress: undefined });
+          setOutput({
+            isGenerating: false,
+            generationProgress: undefined,
+            generationStartedAt: undefined,
+          });
           return;
         }
 
@@ -255,6 +280,7 @@ function EditorComponent() {
           globalError: `Theme rebuild failed: ${errorMessage}`,
           isGenerating: false,
           generationProgress: undefined,
+          generationStartedAt: undefined,
         });
         setBuildError(doc.name, errorMessage);
       } finally {
@@ -372,7 +398,11 @@ function EditorComponent() {
       // Check if this is still the latest request
       if (lastBuildRequestIdRef.current !== id) {
         console.log('Skipping outdated build request for:', doc.name);
-        setOutput({ isGenerating: false, generationProgress: undefined });
+        setOutput({
+          isGenerating: false,
+          generationProgress: undefined,
+          generationStartedAt: undefined,
+        });
         return;
       }
 
@@ -469,7 +499,11 @@ function EditorComponent() {
 
         if (signal.aborted || lastBuildRequestIdRef.current !== id) {
           console.log('Build cancelled for:', doc.name);
-          setOutput({ isGenerating: false, generationProgress: undefined });
+          setOutput({
+            isGenerating: false,
+            generationProgress: undefined,
+            generationStartedAt: undefined,
+          });
           return;
         }
 
@@ -496,6 +530,7 @@ function EditorComponent() {
             isGenerating: false,
             isPreviewStale: false,
             generationProgress: undefined,
+            generationStartedAt: undefined,
             lastBuiltSequence: outputStore.getState().editSequence,
             cacheStatus: (result as any).cacheStatus as
               | 'HIT'
@@ -510,7 +545,11 @@ function EditorComponent() {
       } catch (error) {
         if (signal.aborted || lastBuildRequestIdRef.current !== id) {
           console.log('Build cancelled with error for:', doc.name);
-          setOutput({ isGenerating: false, generationProgress: undefined });
+          setOutput({
+            isGenerating: false,
+            generationProgress: undefined,
+            generationStartedAt: undefined,
+          });
           return;
         }
 
@@ -521,6 +560,7 @@ function EditorComponent() {
           globalError: errorMessage,
           isGenerating: false,
           generationProgress: undefined,
+          generationStartedAt: undefined,
         });
 
         setBuildError(doc.name, errorMessage);
@@ -827,7 +867,6 @@ function EditorComponent() {
 
   // Flush debounces and immediately build — triggered by Run button via custom event
   // Debounced at 150ms to coalesce rapid clicks
-  const flushBuildTimerRef = useRef<NodeJS.Timeout | null>(null);
   // Stable refs so the event handler never goes stale and doesn't need
   // reactive deps that would cause cleanup to cancel the pending timeout
   const buildDocumentRef = useRef(buildDocument);

--- a/packages/jto/src/client/components/playground/preview-frame.tsx
+++ b/packages/jto/src/client/components/playground/preview-frame.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { DocumentGenerationLoader, PreviewLoading } from '../ui/loading-states';
-import { Spinner } from '../ui/spinner';
+import {
+  DocumentGenerationLoader,
+  GenerationOverlay,
+  PreviewLoading,
+} from '../ui/loading-states';
 import { FORMAT_LABEL } from '../../lib/env';
 
 const PreviewFrame = React.forwardRef<
@@ -14,6 +17,12 @@ const PreviewFrame = React.forwardRef<
       stage: 'parsing' | 'building' | 'rendering' | 'finalizing';
       message?: string;
     };
+    /** Source JSON being built — feeds the loader's content summary. */
+    generationDocumentText?: string;
+    /** Date.now() when the build started — feeds the elapsed timer. */
+    generationStartedAt?: number;
+    /** Aborts the in-flight build; renders a Cancel button when present. */
+    onCancelGeneration?: () => void;
   }
 >(
   (
@@ -23,6 +32,9 @@ const PreviewFrame = React.forwardRef<
       iframeSrcDoc,
       isGenerating,
       generationProgress,
+      generationDocumentText,
+      generationStartedAt,
+      onCancelGeneration,
     },
     ref
   ) => {
@@ -59,6 +71,9 @@ const PreviewFrame = React.forwardRef<
           <DocumentGenerationLoader
             currentStage={generationProgress?.stage}
             message={generationProgress?.message}
+            documentText={generationDocumentText}
+            startedAt={generationStartedAt}
+            onCancel={onCancelGeneration}
           />
         </div>
       );
@@ -89,12 +104,12 @@ const PreviewFrame = React.forwardRef<
           {/* Generating/Rendering overlay on top of existing content */}
           {(isGenerating || isLoading) && (
             <div className="absolute inset-0 bg-background/60 backdrop-blur-[2px] flex items-center justify-center z-20 transition-opacity duration-200">
-              <div className="flex flex-col items-center gap-2">
-                <Spinner size="lg" />
-                <p className="text-sm text-muted-foreground">
-                  {isGenerating ? 'Generating...' : 'Rendering...'}
-                </p>
-              </div>
+              <GenerationOverlay
+                mode={isGenerating ? 'generating' : 'rendering'}
+                message={isGenerating ? generationProgress?.message : undefined}
+                startedAt={isGenerating ? generationStartedAt : undefined}
+                onCancel={isGenerating ? onCancelGeneration : undefined}
+              />
             </div>
           )}
           {/* Key forces remount when switching between srcDoc (sandboxed) and

--- a/packages/jto/src/client/components/playground/preview-header.tsx
+++ b/packages/jto/src/client/components/playground/preview-header.tsx
@@ -428,6 +428,11 @@ function PreviewHeader({
         },
         body: JSON.stringify({
           jsonDefinition: copySourceText,
+          customThemes: getFreshThemeData(),
+          // sourceName lets the server inline a discovered document's bundled
+          // media before safe-mode source validation — without it, templates
+          // referencing relative media paths 400 here while rendering fine.
+          options: { sourceName: name },
         }),
       });
 
@@ -435,7 +440,9 @@ function PreviewHeader({
         let description = `Request failed with status ${response.status}`;
         try {
           const errorData = await response.json();
-          if (errorData.message) description = errorData.message;
+          // The server error handler serializes HTTPExceptions as `error`.
+          const message = errorData.error ?? errorData.message;
+          if (typeof message === 'string' && message) description = message;
         } catch {}
         throw new Error(description);
       }
@@ -499,7 +506,7 @@ function PreviewHeader({
         setIsCopyingStandardComponents(false);
       }
     })();
-  }, [copySourceText, toast]);
+  }, [copySourceText, name, getFreshThemeData, toast]);
 
   const handleCopyFromFallbackDialog = useCallback(async () => {
     if (standardComponentsFallbackJson == null) return;

--- a/packages/jto/src/client/components/playground/preview.tsx
+++ b/packages/jto/src/client/components/playground/preview.tsx
@@ -80,6 +80,8 @@ export function Preview() {
     blob,
     isGenerating,
     generationProgress,
+    generationStartedAt,
+    cancelGeneration,
     globalError,
     cacheStatus,
     cacheHitRate,
@@ -385,6 +387,9 @@ export function Preview() {
                   }
                 : generationProgress;
             })()}
+            generationDocumentText={editorDocumentText ?? text}
+            generationStartedAt={generationStartedAt}
+            onCancelGeneration={cancelGeneration}
           />
         )}
       </div>

--- a/packages/jto/src/client/components/ui/loading-states.tsx
+++ b/packages/jto/src/client/components/ui/loading-states.tsx
@@ -188,11 +188,7 @@ export function DocumentGenerationLoader({
   const hintIndex = Math.floor(Math.max(0, elapsed - 3) / 5) % hints.length;
 
   return (
-    <div
-      className={cn('p-6 max-w-lg mx-auto space-y-5', className)}
-      role="status"
-      aria-live="polite"
-    >
+    <div className={cn('p-6 max-w-lg mx-auto space-y-5', className)}>
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-center gap-3 min-w-0">
           <Spinner size="md" />
@@ -202,12 +198,22 @@ export function DocumentGenerationLoader({
                 ? `Generating “${summary.title}”`
                 : 'Generating document'}
             </p>
-            <p className="text-xs text-muted-foreground truncate">
+            {/* The live region covers only the stage message — putting it on
+                the container would re-announce the whole loader every 100ms
+                elapsed-timer tick. */}
+            <p
+              className="text-xs text-muted-foreground truncate"
+              role="status"
+              aria-live="polite"
+            >
               {message || `${stageLabels[currentStage]}...`}
             </p>
           </div>
         </div>
-        <span className="shrink-0 rounded-full bg-secondary px-2 py-0.5 text-xs text-muted-foreground tabular-nums">
+        <span
+          className="shrink-0 rounded-full bg-secondary px-2 py-0.5 text-xs text-muted-foreground tabular-nums"
+          aria-hidden="true"
+        >
           {elapsed.toFixed(1)}s
         </span>
       </div>
@@ -318,15 +324,18 @@ export function GenerationOverlay({
         'flex flex-col items-center gap-2 rounded-md border bg-background/95 px-6 py-4 shadow-sm',
         className
       )}
-      role="status"
-      aria-live="polite"
     >
       <div className="flex items-center gap-2">
         <Spinner size="md" />
-        <p className="text-sm font-medium">
+        {/* Live region on the label only — the elapsed badge ticks every
+            100ms and must not retrigger screen-reader announcements. */}
+        <p className="text-sm font-medium" role="status" aria-live="polite">
           {mode === 'generating' ? 'Generating' : 'Rendering'}
         </p>
-        <span className="rounded-full bg-secondary px-2 py-0.5 text-xs text-muted-foreground tabular-nums">
+        <span
+          className="rounded-full bg-secondary px-2 py-0.5 text-xs text-muted-foreground tabular-nums"
+          aria-hidden="true"
+        >
           {elapsed.toFixed(1)}s
         </span>
       </div>

--- a/packages/jto/src/client/components/ui/loading-states.tsx
+++ b/packages/jto/src/client/components/ui/loading-states.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useMemo, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { Spinner } from './spinner';
 import { Skeleton } from './skeleton';
+import { Button } from './button';
 
 interface LoadingOverlayProps {
   isLoading: boolean;
@@ -34,15 +36,139 @@ interface DocumentGenerationLoaderProps {
   className?: string;
   currentStage?: 'parsing' | 'building' | 'rendering' | 'finalizing';
   message?: string;
+  /** Source JSON of the document being built — drives the content summary. */
+  documentText?: string;
+  /** Date.now() when the build started — drives the elapsed timer. */
+  startedAt?: number;
+  /** When provided, renders a Cancel button that aborts the build. */
+  onCancel?: () => void;
 }
+
+/** Ticks every 100ms and returns whole elapsed seconds since `startedAt`. */
+function useElapsedSeconds(startedAt?: number): number {
+  // Freeze the fallback start on first render so a caller that never passes
+  // `startedAt` still gets a stable timer instead of one reset per render.
+  const [fallbackStart] = useState(() => Date.now());
+  const start = startedAt ?? fallbackStart;
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 100);
+    return () => clearInterval(id);
+  }, []);
+  return Math.max(0, (now - start) / 1000);
+}
+
+interface DocumentSummary {
+  title?: string;
+  counts: { label: string; count: number }[];
+  visualCount: number;
+  imageCount: number;
+}
+
+/**
+ * Walk a JTO document tree and count the component types worth narrating.
+ * Best-effort: any parse/shape surprise returns null and the loader simply
+ * omits the summary row.
+ */
+function summarizeDocument(text?: string): DocumentSummary | null {
+  if (!text) return null;
+  try {
+    const root = JSON.parse(text);
+    if (!root || typeof root !== 'object') return null;
+    const counts = new Map<string, number>();
+    const stack: unknown[] = [root];
+    while (stack.length > 0) {
+      const node = stack.pop();
+      if (!node || typeof node !== 'object') continue;
+      const { name, children } = node as {
+        name?: unknown;
+        children?: unknown;
+      };
+      if (typeof name === 'string') {
+        counts.set(name, (counts.get(name) ?? 0) + 1);
+      }
+      if (Array.isArray(children)) stack.push(...children);
+    }
+    // Ordered by how much each type usually tells the user about build cost.
+    const interesting: [key: string, singular: string, plural: string][] = [
+      ['slide', 'slide', 'slides'],
+      ['section', 'section', 'sections'],
+      ['visual', 'visual', 'visuals'],
+      ['chart', 'chart', 'charts'],
+      ['image', 'image', 'images'],
+      ['table', 'table', 'tables'],
+      ['shape', 'shape', 'shapes'],
+      ['paragraph', 'paragraph', 'paragraphs'],
+    ];
+    const summary = interesting
+      .map(([key, singular, plural]) => {
+        const count = counts.get(key) ?? 0;
+        return { label: count === 1 ? singular : plural, count };
+      })
+      .filter((entry) => entry.count > 0)
+      .slice(0, 5);
+    const title = (root as { props?: { metadata?: { title?: unknown } } }).props
+      ?.metadata?.title;
+    return {
+      title: typeof title === 'string' ? title : undefined,
+      counts: summary,
+      visualCount: (counts.get('visual') ?? 0) + (counts.get('chart') ?? 0),
+      imageCount: counts.get('image') ?? 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Rotating context lines shown once a build takes more than a moment. */
+function buildHints(summary: DocumentSummary | null): string[] {
+  const hints: string[] = [];
+  if (summary && summary.visualCount > 0) {
+    hints.push(
+      `${summary.visualCount} visual${summary.visualCount === 1 ? '' : 's'} in this document ${
+        summary.visualCount === 1 ? 'is' : 'are'
+      } rasterized on first build — later builds reuse the cached renders.`
+    );
+  }
+  if (summary && summary.imageCount > 3) {
+    hints.push(
+      'Large embedded images dominate build time — downscaling them speeds up iteration.'
+    );
+  }
+  hints.push(
+    'Re-running an unchanged document is served from the cache almost instantly.',
+    'Generation warnings, if any, will appear above the preview when the build completes.'
+  );
+  return hints;
+}
+
+const CheckIcon = () => (
+  <svg
+    className="h-3.5 w-3.5 text-success"
+    viewBox="0 0 16 16"
+    fill="none"
+    aria-hidden="true"
+  >
+    <path
+      d="M3 8.5L6.5 12L13 4.5"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
 
 export function DocumentGenerationLoader({
   className,
   currentStage = 'parsing',
   message,
+  documentText,
+  startedAt,
+  onCancel,
 }: DocumentGenerationLoaderProps) {
-  const stages = ['parsing', 'building', 'rendering', 'finalizing'];
-  const stageLabels = {
+  const stages = ['parsing', 'building', 'rendering', 'finalizing'] as const;
+  const stageLabels: Record<(typeof stages)[number], string> = {
     parsing: 'Validating JSON',
     building: 'Building structure',
     rendering: 'Rendering content',
@@ -50,26 +176,65 @@ export function DocumentGenerationLoader({
   };
 
   const currentStageIndex = stages.indexOf(currentStage);
+  const elapsed = useElapsedSeconds(startedAt);
+  const summary = useMemo(
+    () => summarizeDocument(documentText),
+    [documentText]
+  );
+  const hints = useMemo(() => buildHints(summary), [summary]);
+  // Hints appear only for builds long enough to leave the user wondering,
+  // then rotate so a long rasterization pass keeps saying something new.
+  const showHints = elapsed > 3;
+  const hintIndex = Math.floor(Math.max(0, elapsed - 3) / 5) % hints.length;
 
   return (
-    <div className={cn('p-6 space-y-4', className)}>
-      <div className="flex items-center gap-3">
-        <Spinner size="md" />
-        <div className="space-y-1">
-          <p className="text-sm font-medium">Generating Document</p>
-          <p className="text-xs text-muted-foreground">
-            {message || `${stageLabels[currentStage]}...`}
-          </p>
+    <div
+      className={cn('p-6 max-w-lg mx-auto space-y-5', className)}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <Spinner size="md" />
+          <div className="space-y-0.5 min-w-0">
+            <p className="text-sm font-medium truncate">
+              {summary?.title
+                ? `Generating “${summary.title}”`
+                : 'Generating document'}
+            </p>
+            <p className="text-xs text-muted-foreground truncate">
+              {message || `${stageLabels[currentStage]}...`}
+            </p>
+          </div>
         </div>
+        <span className="shrink-0 rounded-full bg-secondary px-2 py-0.5 text-xs text-muted-foreground tabular-nums">
+          {elapsed.toFixed(1)}s
+        </span>
       </div>
+
+      {summary && summary.counts.length > 0 && (
+        <div className="flex flex-wrap gap-1.5" aria-label="Document contents">
+          {summary.counts.map(({ label, count }) => (
+            <span
+              key={label}
+              className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs text-muted-foreground"
+            >
+              <span className="font-medium text-foreground tabular-nums">
+                {count}
+              </span>
+              {label}
+            </span>
+          ))}
+        </div>
+      )}
 
       <div className="space-y-3">
         {stages.map((stage, index) => {
           const isActive = index === currentStageIndex;
           const isCompleted = index < currentStageIndex;
           return (
-            <div key={stage} className="space-y-2">
-              <div className="flex justify-between text-xs">
+            <div key={stage} className="space-y-1.5">
+              <div className="flex items-center justify-between text-xs">
                 <span
                   className={cn(
                     isActive
@@ -79,31 +244,102 @@ export function DocumentGenerationLoader({
                         : 'text-muted-foreground/60'
                   )}
                 >
-                  {stageLabels[stage as keyof typeof stageLabels]}
+                  {stageLabels[stage]}
                 </span>
-                <span className="text-muted-foreground">
-                  {isCompleted ? '✓' : isActive ? '...' : '○'}
-                </span>
+                {isCompleted ? (
+                  <CheckIcon />
+                ) : isActive ? (
+                  <Spinner size="sm" className="h-3.5 w-3.5" />
+                ) : (
+                  <span className="h-3.5 w-3.5 rounded-full border border-muted-foreground/40" />
+                )}
               </div>
-              <div className="w-full bg-secondary rounded-full h-1.5">
-                <div
-                  className={cn(
-                    'h-1.5 rounded-full transition-all duration-300',
-                    isCompleted
-                      ? 'bg-success'
-                      : isActive
-                        ? 'bg-primary animate-pulse'
-                        : 'bg-transparent'
-                  )}
-                  style={{
-                    width: isCompleted ? '100%' : isActive ? '100%' : '0%',
-                  }}
-                />
+              <div className="w-full bg-secondary rounded-full h-1.5 overflow-hidden">
+                {isCompleted ? (
+                  <div className="h-full w-full rounded-full bg-success" />
+                ) : isActive ? (
+                  // Honest indeterminate sweep — we have no real progress
+                  // signal within a stage, so don't fake a full bar.
+                  <div className="h-full w-2/5 rounded-full bg-primary animate-progress-indeterminate" />
+                ) : null}
               </div>
             </div>
           );
         })}
       </div>
+
+      <div className="flex items-center justify-between gap-3 min-h-8">
+        <p
+          className={cn(
+            'text-xs text-muted-foreground/80 italic transition-opacity duration-500',
+            showHints ? 'opacity-100' : 'opacity-0'
+          )}
+        >
+          {hints[hintIndex]}
+        </p>
+        {onCancel && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onCancel}
+            className="shrink-0"
+          >
+            Cancel
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface GenerationOverlayProps {
+  mode: 'generating' | 'rendering';
+  message?: string;
+  startedAt?: number;
+  onCancel?: () => void;
+  className?: string;
+}
+
+/**
+ * Compact card for the overlay shown on top of an existing preview while a
+ * rebuild or re-render is in flight.
+ */
+export function GenerationOverlay({
+  mode,
+  message,
+  startedAt,
+  onCancel,
+  className,
+}: GenerationOverlayProps) {
+  const elapsed = useElapsedSeconds(startedAt);
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center gap-2 rounded-md border bg-background/95 px-6 py-4 shadow-sm',
+        className
+      )}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2">
+        <Spinner size="md" />
+        <p className="text-sm font-medium">
+          {mode === 'generating' ? 'Generating' : 'Rendering'}
+        </p>
+        <span className="rounded-full bg-secondary px-2 py-0.5 text-xs text-muted-foreground tabular-nums">
+          {elapsed.toFixed(1)}s
+        </span>
+      </div>
+      {message && (
+        <p className="max-w-xs text-center text-xs text-muted-foreground truncate">
+          {message}
+        </p>
+      )}
+      {mode === 'generating' && onCancel && (
+        <Button variant="outline" size="sm" onClick={onCancel}>
+          Cancel
+        </Button>
+      )}
     </div>
   );
 }

--- a/packages/jto/src/client/index.css
+++ b/packages/jto/src/client/index.css
@@ -290,6 +290,17 @@
 
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
+  --animate-progress-indeterminate: progress-indeterminate 1.4s ease-in-out infinite;
+
+  /* Indeterminate progress: a 40%-wide bar sweeping across its track. */
+  @keyframes progress-indeterminate {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(350%);
+    }
+  }
 
   @keyframes accordion-down {
     from {

--- a/packages/jto/src/client/store/output-store.ts
+++ b/packages/jto/src/client/store/output-store.ts
@@ -18,6 +18,8 @@ export type OutputState = {
     stage: 'parsing' | 'building' | 'rendering' | 'finalizing';
     message?: string;
   };
+  generationStartedAt?: number; // Date.now() when the current build started
+  cancelGeneration?: () => void; // registered by the editor; aborts the in-flight build
   cacheStatus?: 'HIT' | 'MISS' | 'UNKNOWN'; // cache hit/miss status
   cacheHitRate?: string; // cache hit rate percentage
   warnings?: GenerationWarning[] | null; // warnings from custom component processing

--- a/packages/jto/src/server/routes/format.ts
+++ b/packages/jto/src/server/routes/format.ts
@@ -565,22 +565,32 @@ export function createFormatRouter(adapter: FormatAdapter) {
     contentTypeMw,
     tbValidator(LooseDocumentGenerationRequestSchema),
     async (c) => {
-      const { jsonDefinition, customThemes } = getValidated<{
+      const { jsonDefinition, customThemes, options } = getValidated<{
         jsonDefinition: any;
         customThemes?: Record<string, any>;
+        options?: { sourceName?: string };
       }>(c, 'json');
       const requestId = c.get('requestId');
 
       try {
-        assertRequestSources(jsonDefinition, 'jsonDefinition');
+        // Same prologue as /generate: inline a discovered document's bundled
+        // media before safe-mode source validation, otherwise templates that
+        // reference relative media paths 400 here while rendering fine there.
+        const baseDir = await resolveSourceBaseDir(options);
+        const effectiveDefinition = await inlineDiscoveredMedia(
+          jsonDefinition,
+          baseDir
+        );
+
+        assertRequestSources(effectiveDefinition, 'jsonDefinition');
         assertRequestSources(customThemes, 'customThemes');
 
         let config: unknown;
         try {
           config =
-            typeof jsonDefinition === 'string'
-              ? JSON.parse(jsonDefinition)
-              : jsonDefinition;
+            typeof effectiveDefinition === 'string'
+              ? JSON.parse(effectiveDefinition)
+              : effectiveDefinition;
         } catch {
           throw new HTTPException(400, {
             message: 'jsonDefinition is not valid JSON',
@@ -592,7 +602,8 @@ export function createFormatRouter(adapter: FormatAdapter) {
         if (registry.hasPlugins()) {
           const plugins = registry.getPlugins();
           const generatorResult = await adapter.createGenerator(plugins, {
-            theme: customThemes ? Object.values(customThemes)[0] : undefined,
+            customThemes,
+            baseDir,
           });
 
           // Expansion-only path: resolves custom components to the standard

--- a/packages/shared-docx/src/__tests__/optional-props-schema.test.ts
+++ b/packages/shared-docx/src/__tests__/optional-props-schema.test.ts
@@ -1,0 +1,105 @@
+/**
+ * `props` must be required in the exported schema exactly when the runtime
+ * rejects the component without it.
+ *
+ * Every component variant exported `props` as required, including the ones
+ * whose props carry no required field. The runtime disagrees: it treats an
+ * omitted `props` as `{}` and lets the props schema decide (deep-validator.ts).
+ * Nothing in CI compared the two — the asset gate runs the runtime validator,
+ * and the one step that used the exported schema only saw examples that write
+ * `props` everywhere. So the playground reddened all 23 propless `section`
+ * nodes in the shipped tech-report template while every gate stayed green.
+ *
+ * These assertions are parity checks, not restatements of the rule: each case
+ * runs the same document through both validators and requires the same answer.
+ */
+import { describe, it, expect } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+import { generateUnifiedDocumentSchema } from '../schemas/generator';
+import { convertToJsonSchema } from '../schemas/export';
+import { validateStrict } from '../validation/unified';
+
+const exported = generateUnifiedDocumentSchema({ customComponents: [] });
+
+/** Wrap a component in the minimum valid document around it. */
+function inSection(child: Record<string, unknown>) {
+  return { name: 'docx', children: [{ name: 'section', children: [child] }] };
+}
+
+function variantRequired(name: string): string[] {
+  const json = convertToJsonSchema(exported) as Record<string, any>;
+  const variants = json.definitions.ComponentDefinition.anyOf;
+  const variant = variants.find(
+    (v: any) => v?.properties?.name?.const === name
+  );
+  expect(variant, `no exported variant for "${name}"`).toBeDefined();
+  return variant.required ?? [];
+}
+
+// Props schemas with no required field: a bare `{ name }` is a valid node.
+const PROPLESS_OK = ['section', 'toc', 'image', 'text-box'] as const;
+// Props schemas that demand a field: omitting `props` omits that field too.
+const PROPS_REQUIRED = [
+  'heading',
+  'paragraph',
+  'statistic',
+  'table',
+  'list',
+  'columns',
+  'highcharts',
+  'visual',
+] as const;
+
+describe('props optionality', () => {
+  it.each(PROPLESS_OK)('exports `props` as optional for %s', (name) => {
+    expect(variantRequired(name)).not.toContain('props');
+  });
+
+  it.each(PROPS_REQUIRED)('keeps `props` required for %s', (name) => {
+    expect(variantRequired(name)).toContain('props');
+  });
+
+  it.each(PROPLESS_OK)('both validators accept a propless %s', (name) => {
+    const doc =
+      name === 'section'
+        ? { name: 'docx', children: [{ name: 'section' }] }
+        : inSection({ name });
+    expect(validateStrict.document(doc).valid).toBe(true);
+    expect(Value.Check(exported, doc)).toBe(true);
+  });
+
+  it.each(PROPS_REQUIRED)('both validators reject a propless %s', (name) => {
+    const doc = inSection({ name });
+    expect(validateStrict.document(doc).valid).toBe(false);
+    expect(Value.Check(exported, doc)).toBe(false);
+  });
+
+  it('accepts the shipped tech-report shape: sections with no props', () => {
+    const doc = {
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          children: [{ name: 'paragraph', props: { text: 'A' } }],
+        },
+        {
+          name: 'section',
+          children: [{ name: 'paragraph', props: { text: 'B' } }],
+        },
+      ],
+    };
+    expect(validateStrict.document(doc).valid).toBe(true);
+    expect(Value.Check(exported, doc)).toBe(true);
+  });
+
+  it('still requires `children` on the root', () => {
+    // Root `children` was enforced only by the deep validator, which runs on
+    // the fallback path taken when the TypeBox check has already failed. It
+    // fired only because `props` was required; relaxing `props` would have
+    // retired the rule silently, so the schema now carries it.
+    expect(variantRequired('docx')).toContain('children');
+    expect(validateStrict.document({ name: 'docx' }).valid).toBe(false);
+    expect(Value.Check(exported, { name: 'docx' })).toBe(false);
+  });
+});

--- a/packages/shared-docx/src/schemas/component-registry.ts
+++ b/packages/shared-docx/src/schemas/component-registry.ts
@@ -280,6 +280,18 @@ export function isStandardComponent(name: string): boolean {
 // ============================================================================
 
 /**
+ * True when a props schema rejects `{}`, i.e. the `props` key cannot be omitted.
+ *
+ * Only object schemas are inspected. Anything else (a union, a bare ref) is
+ * treated as demanding props, preserving the previous stricter behavior for
+ * shapes this cannot reason about.
+ */
+function demandsProps(propsSchema: TSchema): boolean {
+  const schema = propsSchema as { type?: string; required?: readonly string[] };
+  return schema.type !== 'object' || (schema.required?.length ?? 0) > 0;
+}
+
+/**
  * Generate TypeBox schema object for a component.
  *
  * @param component - Component definition from the registry
@@ -311,14 +323,33 @@ export function createComponentSchemaObject(
 
   // selfRef (full union) is intentionally passed to createPropsSchema so that
   // header/footer sub-schemas and table cell content can reference any component.
-  schema.props =
+  const propsSchema =
     component.createPropsSchema && selfRef
       ? component.createPropsSchema(selfRef)
       : component.propsSchema;
 
-  // Add children support if applicable
+  // `props` is required only when the props schema itself demands a field.
+  // The runtime validator treats an omitted `props` as `{}` and lets the props
+  // schema decide (see deep-validator.ts), so `section`, `toc`, `image` and
+  // `text-box` are legal without the key. Exporting `props` as unconditionally
+  // required reddened documents that build: the playground flagged all 23
+  // propless sections in the shipped tech-report template while every runtime
+  // gate stayed green. The root `docx` node already carried this fix locally in
+  // generator.ts; this generalizes it to every component.
+  schema.props = demandsProps(propsSchema)
+    ? propsSchema
+    : Type.Optional(propsSchema);
+
+  // Add children support if applicable. The root component requires its
+  // `children` array — deep-validator.ts enforces the same rule, but only on
+  // the fallback path it takes when the TypeBox check already failed. That
+  // made the rule fire only as a side effect of `props` being required, so
+  // relaxing `props` above would silently retire it. Nested containers may
+  // legitimately be empty.
   if (component.hasChildren && childrenType) {
-    schema.children = Type.Optional(Type.Array(childrenType));
+    schema.children = component.special?.hasSchemaField
+      ? Type.Array(childrenType)
+      : Type.Optional(Type.Array(childrenType));
   }
 
   return Type.Object(schema, { additionalProperties: false });

--- a/packages/shared-docx/src/schemas/generator.ts
+++ b/packages/shared-docx/src/schemas/generator.ts
@@ -252,12 +252,12 @@ export function generateUnifiedDocumentSchema(
       // the generator, both of which treat a propless root as `props: {}`.
       // Schema-driven editors would otherwise flag a document that builds.
       props: Type.Optional(reportComponent.propsSchema),
-      children: Type.Optional(
-        Type.Array(
-          Type.Union([...capturedRootChildSchemas, ...capturedPluginSchemas], {
-            discriminator: { propertyName: 'name' },
-          })
-        )
+      // Required, matching the runtime validator: a root without `children`
+      // is rejected (deep-validator.ts), so the exported schema says so too.
+      children: Type.Array(
+        Type.Union([...capturedRootChildSchemas, ...capturedPluginSchemas], {
+          discriminator: { propertyName: 'name' },
+        })
       ),
     },
     {


### PR DESCRIPTION
Three related playground/schema fixes, each with its own changeset.

## 1. Schema export: `props` optional when not required (`shared-docx`)
Every component variant in the generated JSON Schema listed `props` as required, including `section`, `toc`, `image`, `text-box` whose props have no required field. The runtime treats omitted `props` as `{}`, so schema-driven editors reddened documents that build (23 false errors on the stock tech-report template). Now `props` is exported optional unless the props schema demands a field, root `children` becomes required (matching the runtime deep validator), and CI validates all stock playground templates against the generated schemas — the check that would have caught this drift.

## 2. Copy standard components: 400 for docs with bundled media (`jto`)
In safe mode, `/standard-components` ran outbound-source validation on the raw definition, so any discovered document referencing relative `media/...` paths got a 400 while `/generate` accepted it (it inlines media first). The route now mirrors `/generate`'s prologue (sourceName → baseDir → inline media before validation) and passes `customThemes` through properly; the client sends `options.sourceName` + current themes and surfaces the server's real error message instead of "Request failed with status 400". Verified against a live safe-mode server: modern-annual-report-3 went 400 → 200.

## 3. Generation loading UI (`jto`)
The full-screen loader now shows the document title, content-summary chips (sections/visuals/images/paragraphs…), a live elapsed timer, honest indeterminate progress for the active stage (no more fake full bars), and rotating context hints tuned to the document (e.g. "24 visuals are rasterized on first build — later builds reuse the cache"). The rebuild overlay gains stage message + elapsed. Both get a Cancel button wired to a store-registered abort that cancels the in-flight build quietly. Verified live in the browser, including cancel.

## Test plan
- `pnpm --filter @json-to-office/jto test` — 162 passed
- New `optional-props-schema.test.ts` in shared-docx
- Manual browser verification of loader, overlay, cancel, and standard-components copy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added richer document-generation progress with document details, build stages, elapsed time, contextual guidance, completion indicators, and cancellation.
  - Added clearer full-screen status overlays while generating or rendering documents.

- **Bug Fixes**
  - Improved standard component handling for bundled relative media and custom themes.
  - Improved playground request naming and error feedback.

- **Schema & Validation**
  - Made component properties optional when no required fields exist.
  - Required root document content and expanded validation across standard DOCX and PPTX templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->