### PR TITLE
Playground document outline + meta.title authoring labels

### DIFF
--- a/.changeset/annual-report-sections.md
+++ b/.changeset/annual-report-sections.md
@@ -1,0 +1,12 @@
+---
+'@json-to-office/jto': patch
+---
+
+Restructure the modern-annual-report-1/2/3 templates from a single section
+holding ~400 components into one section per page (24 sections each). The
+empty pageBreak-carrying delimiter paragraphs are replaced by explicit
+`section` components with `pageBreak: true`, matching the structure the
+layout engine was already producing internally (the generated documents
+carried 24 sectPr before and after). Rendered output is pixel-identical on
+every page of all three templates; the sidebar outline now shows a navigable,
+reorderable table of contents for them instead of one opaque section.

--- a/.changeset/playground-outline-panel.md
+++ b/.changeset/playground-outline-panel.md
@@ -1,0 +1,27 @@
+---
+'@json-to-office/jto': minor
+---
+
+Playground sidebar gains an Outline section — a semantic table of contents
+for the document in the active editor tab.
+
+PPTX documents outline as numbered slides labeled by their title text, with
+per-component rows (text, chart, table, image, shape…) carrying type icons
+and content snippets. DOCX documents outline as the heading hierarchy —
+non-heading components nest under their preceding heading, and untitled
+`section` containers borrow their first heading or paragraph as a label.
+Theme files outline as their top-level keys with nested keys and value
+previews one level down.
+
+The tree is bidirectionally synced with Monaco: clicking a node reveals and
+flashes its JSON range, and moving the cursor highlights (and auto-expands
+to) the node it sits inside. Nodes containing schema validation errors show a
+red dot, propagated to their ancestors. Sibling nodes can be drag-reordered —
+moving a slide, or a whole DOCX heading section with all its content, as a
+single undoable text edit that preserves formatting and keeps collapsed
+long-string chips intact (the collapse controller gained a
+`resyncDecorations()` primitive that re-anchors chips to their sentinels
+after text moves).
+
+The outline is built with jsonc-parser's error-tolerant `parseTree`, so it
+stays alive while the JSON is temporarily invalid mid-edit.

--- a/.changeset/section-meta-title.md
+++ b/.changeset/section-meta-title.md
@@ -1,0 +1,23 @@
+---
+'@json-to-office/shared-docx': minor
+'@json-to-office/core-docx': minor
+'@json-to-office/jto': minor
+---
+
+BREAKING (DOCX): `section` no longer accepts `title`/`level` props. They
+conflated naming with content — a section title silently synthesized a
+heading component at the top of the section (and bent TOC scoping and
+pageBreak handling around it).
+
+Sections now take `meta.title` instead: a pure authoring label, never
+rendered, shown by editors and outlines (the playground sidebar uses it as
+the section's outline label). For a visible title, add an explicit `heading`
+child — what the synthesized heading was doing anyway, now stated in the
+document.
+
+Migration: `"props": { "title": "X", "level": 2 }` becomes
+`"props": { "meta": { "title": "X" } }` plus, if the rendered heading was
+wanted, a `{ "name": "heading", "props": { "text": "X", "level": 2 } }`
+first child. Section-scoped TOCs still work via section bookmarks; they no
+longer skip a synthesized title level. No stock template or example used
+`title`.

--- a/.changeset/slide-meta-title.md
+++ b/.changeset/slide-meta-title.md
@@ -1,0 +1,16 @@
+---
+'@json-to-office/shared-pptx': minor
+'@json-to-office/jto': minor
+---
+
+PPTX slides accept `meta.title` — an authoring-only label, symmetric to the
+DOCX section `meta.title`: never rendered (generated .pptx is byte-identical
+with or without it), surfaced by editors and the playground outline as the
+slide's label.
+
+The outline's derived slide labels also got smarter for documents without
+explicit labels: template-driven slides now read their `title`/`subtitle`
+placeholders (previously such decks labeled as "Slide N"), and multi-line
+titles are joined onto one line instead of truncating at the first line
+break. All stock pptx templates ship with curated `meta.title` labels where
+the derived label was weak or duplicated.

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -8,6 +8,12 @@
       "port": 3003
     },
     {
+      "name": "playground-pptx",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["cli:dev:pptx"],
+      "port": 3004
+    },
+    {
       "name": "docs",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["docs:preview"],

--- a/docs/guide/playground.md
+++ b/docs/guide/playground.md
@@ -16,6 +16,7 @@ Both are deployments of the exact same dev server you get with `jto docx dev` / 
 ## What it offers
 
 - **Monaco JSON editor with schema autocomplete.** The editor is Monaco (the VS Code editor) wired to the generated JSON Schemas, so you get autocomplete for component names and props, inline validation errors, and hover documentation as you type. See [Validation](/guide/validation) for how the same schemas are used outside the playground.
+- **Document outline.** The sidebar shows a semantic table of contents for the active document — numbered slides labeled by their titles (PPTX), the heading hierarchy (DOCX), or top-level keys (themes). Clicking a node jumps the editor to its JSON; moving the cursor highlights the node you're in. Nodes with validation errors get a red dot, and slides or whole heading sections can be reordered by dragging them in the outline.
 - **Live preview.** The preview re-renders as the JSON changes, so you iterate on layout and content without a download-open-check loop.
 - **Template gallery.** Built-in starting templates for each format, so you never begin from an empty `{}`. Browse them in the document sidebar and use them as a base for your own documents.
 - **Theme switching.** Swap the document's theme and watch colors, fonts, and component defaults change instantly. See [Themes & styling](/guide/themes).

--- a/docs/reference/docx/document.md
+++ b/docs/reference/docx/document.md
@@ -93,8 +93,7 @@ A Word section: a run of pages sharing one header, footer, and page setup. Secti
 
 | Prop        | Type                                | Default                                     | Description                                                                                                                                                                                                                                                                                                                                                             |
 | ----------- | ----------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `title`     | `string`                            | —                                           | Optional section title, rendered as a heading at the top of the section.                                                                                                                                                                                                                                                                                                |
-| `level`     | `number` (1–9)                      | `1`                                         | Heading level used for `title`.                                                                                                                                                                                                                                                                                                                                         |
+| `meta`      | `{ title? }`                        | —                                           | Authoring metadata; never rendered. `meta.title` labels the section in editors and outlines (e.g. the playground sidebar). For a visible title, add a `heading` child.                                                                                                                                                                                                  |
 | `header`    | `Component[]` \| `'linkToPrevious'` | —                                           | Header content: an array of components (paragraphs, images, tables, ...), or the literal string `'linkToPrevious'` to reuse the previous section's header.                                                                                                                                                                                                              |
 | `footer`    | `Component[]` \| `'linkToPrevious'` | —                                           | Same as `header`, for the footer.                                                                                                                                                                                                                                                                                                                                       |
 | `pageBreak` | `boolean`                           | `true` (schema) / `false` (built-in themes) | Start the section on a new page. The schema default is `true`, but every built-in theme overrides it to `false` via `componentDefaults.section`, so sections flow continuously unless you set `pageBreak: true`. Defaults apply whether or not the node declares `props`: a section written with **no `props` key at all** behaves exactly like one with `"props": {}`. |
@@ -103,6 +102,8 @@ A Word section: a run of pages sharing one header, footer, and page setup. Secti
 
 ::: warning Behavior change
 Earlier versions skipped `componentDefaults` resolution for a node that carried no `props` key at all, so a propless section fell back to the schema default and broke to a new page. It no longer does. If a document relied on that quirk to get its page breaks, set `"pageBreak": true` explicitly.
+
+Sections also used to accept `title`/`level` props that rendered a heading at the top of the section. Those props are gone: name a section with `meta.title` (not rendered) and add an explicit `heading` child for a visible title.
 :::
 
 ### `page` override
@@ -124,8 +125,7 @@ Header and footer text supports the same inline syntax as body text, including t
 {
   "name": "section",
   "props": {
-    "title": "Financial Results",
-    "level": 1,
+    "meta": { "title": "Financial Results" },
     "pageBreak": true,
     "header": [
       {
@@ -158,6 +158,7 @@ Header and footer text supports the same inline syntax as body text, including t
     }
   },
   "children": [
+    { "name": "heading", "props": { "text": "Financial Results", "level": 1 } },
     { "name": "paragraph", "props": { "text": "Revenue for the quarter..." } }
   ]
 }

--- a/docs/reference/pptx/presentation.md
+++ b/docs/reference/pptx/presentation.md
@@ -127,15 +127,16 @@ Supported keys: `text`, `image`, `shape`, `table`, `highcharts`, `chart`. Themes
 
 ## Slide props
 
-| Prop           | Type                        | Default | Description                                                                                                                                                                              |
-| -------------- | --------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `background`   | `{ color?, image? }`        | —       | Slide background. `color` is a hex value or semantic theme name; `image` is `{ path? }` or `{ base64? }`.                                                                                |
-| `transition`   | `{ type?, speed? }`         | —       | Slide transition. `type`: `fade` \| `push` \| `wipe` \| `zoom` \| `none`; `speed`: `slow` \| `medium` \| `fast`. **Schema-only for now** — see warning below.                            |
-| `notes`        | string                      | —       | Speaker notes, shown in presenter view.                                                                                                                                                  |
-| `layout`       | string                      | —       | Slide layout name. Accepted by the schema and carried through processing, but not currently consumed by the renderer.                                                                    |
-| `hidden`       | boolean                     | —       | `true` marks the slide as hidden: it stays in the file but is skipped during the slideshow.                                                                                              |
-| `template`     | string                      | —       | Name of a template from the root `templates` array; the template is applied as this slide's master. An unknown name emits a `MISSING_TEMPLATE` warning and the slide renders without it. |
-| `placeholders` | `Record<string, Component>` | —       | Maps placeholder names (defined by the template) to full components that fill them.                                                                                                      |
+| Prop           | Type                        | Default | Description                                                                                                                                                                                  |
+| -------------- | --------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `meta`         | `{ title? }`                | —       | Authoring metadata; never rendered. `meta.title` labels the slide in editors and outlines (e.g. the playground sidebar), overriding the label otherwise derived from the slide's title text. |
+| `background`   | `{ color?, image? }`        | —       | Slide background. `color` is a hex value or semantic theme name; `image` is `{ path? }` or `{ base64? }`.                                                                                    |
+| `transition`   | `{ type?, speed? }`         | —       | Slide transition. `type`: `fade` \| `push` \| `wipe` \| `zoom` \| `none`; `speed`: `slow` \| `medium` \| `fast`. **Schema-only for now** — see warning below.                                |
+| `notes`        | string                      | —       | Speaker notes, shown in presenter view.                                                                                                                                                      |
+| `layout`       | string                      | —       | Slide layout name. Accepted by the schema and carried through processing, but not currently consumed by the renderer.                                                                        |
+| `hidden`       | boolean                     | —       | `true` marks the slide as hidden: it stays in the file but is skipped during the slideshow.                                                                                                  |
+| `template`     | string                      | —       | Name of a template from the root `templates` array; the template is applied as this slide's master. An unknown name emits a `MISSING_TEMPLATE` warning and the slide renders without it.     |
+| `placeholders` | `Record<string, Component>` | —       | Maps placeholder names (defined by the template) to full components that fill them.                                                                                                          |
 
 All props are optional; unknown keys are rejected.
 

--- a/examples/invoice.docx.json
+++ b/examples/invoice.docx.json
@@ -12,6 +12,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Invoice"
+        },
         "header": [
           {
             "name": "paragraph",
@@ -34,11 +37,17 @@
       "children": [
         {
           "name": "columns",
-          "props": { "columns": 2, "gap": 0.4 },
+          "props": {
+            "columns": 2,
+            "gap": 0.4
+          },
           "children": [
             {
               "name": "heading",
-              "props": { "text": "INVOICE", "level": 1 }
+              "props": {
+                "text": "INVOICE",
+                "level": 1
+              }
             },
             {
               "name": "paragraph",
@@ -49,10 +58,18 @@
             }
           ]
         },
-        { "name": "paragraph", "props": { "text": "" } },
+        {
+          "name": "paragraph",
+          "props": {
+            "text": ""
+          }
+        },
         {
           "name": "columns",
-          "props": { "columns": 2, "gap": 0.4 },
+          "props": {
+            "columns": 2,
+            "gap": 0.4
+          },
           "children": [
             {
               "name": "paragraph",
@@ -70,7 +87,12 @@
             }
           ]
         },
-        { "name": "paragraph", "props": { "text": "" } },
+        {
+          "name": "paragraph",
+          "props": {
+            "text": ""
+          }
+        },
         {
           "name": "heading",
           "props": {
@@ -82,42 +104,78 @@
           "name": "paragraph",
           "props": {
             "text": "Professional services rendered for the brand identity redesign, website development, and marketing collateral production per SOW-2026-014 dated January 15, 2026.",
-            "font": { "color": "textSecondary" }
+            "font": {
+              "color": "textSecondary"
+            }
           }
         },
-        { "name": "paragraph", "props": { "text": "" } },
+        {
+          "name": "paragraph",
+          "props": {
+            "text": ""
+          }
+        },
         {
           "name": "table",
           "props": {
             "headerCellDefaults": {
               "backgroundColor": "#000000",
               "color": "#FFFFFF",
-              "font": { "bold": true, "size": 10 },
-              "padding": { "top": 8, "right": 12, "bottom": 8, "left": 12 }
+              "font": {
+                "bold": true,
+                "size": 10
+              },
+              "padding": {
+                "top": 8,
+                "right": 12,
+                "bottom": 8,
+                "left": 12
+              }
             },
             "cellDefaults": {
-              "padding": { "top": 6, "right": 12, "bottom": 6, "left": 12 },
+              "padding": {
+                "top": 6,
+                "right": 12,
+                "bottom": 6,
+                "left": 12
+              },
               "verticalAlignment": "middle"
             },
             "borderColor": "E0E0E0",
             "borderSize": 1,
-            "hideBorders": { "insideVertical": true },
+            "hideBorders": {
+              "insideVertical": true
+            },
             "columns": [
               {
-                "header": { "content": "Description" },
+                "header": {
+                  "content": "Description"
+                },
                 "cells": [
-                  { "content": "Brand Strategy & Discovery Workshop (2 days)" },
+                  {
+                    "content": "Brand Strategy & Discovery Workshop (2 days)"
+                  },
                   {
                     "content": "Visual Identity Design (logo, typography, color system)"
                   },
-                  { "content": "Brand Guidelines Document (48 pages)" },
-                  { "content": "Website Design (12 pages, responsive)" },
-                  { "content": "Frontend Development (Next.js, headless CMS)" },
+                  {
+                    "content": "Brand Guidelines Document (48 pages)"
+                  },
+                  {
+                    "content": "Website Design (12 pages, responsive)"
+                  },
+                  {
+                    "content": "Frontend Development (Next.js, headless CMS)"
+                  },
                   {
                     "content": "Marketing Collateral (pitch deck, one-pager, social templates)"
                   },
-                  { "content": "QA Testing & Browser Compatibility" },
-                  { "content": "Project Management & Client Coordination" }
+                  {
+                    "content": "QA Testing & Browser Compatibility"
+                  },
+                  {
+                    "content": "Project Management & Client Coordination"
+                  }
                 ]
               },
               {
@@ -125,30 +183,69 @@
                   "content": "Hours",
                   "horizontalAlignment": "right"
                 },
-                "cellDefaults": { "horizontalAlignment": "right" },
+                "cellDefaults": {
+                  "horizontalAlignment": "right"
+                },
                 "cells": [
-                  { "content": "16" },
-                  { "content": "48" },
-                  { "content": "24" },
-                  { "content": "64" },
-                  { "content": "120" },
-                  { "content": "32" },
-                  { "content": "20" },
-                  { "content": "36" }
+                  {
+                    "content": "16"
+                  },
+                  {
+                    "content": "48"
+                  },
+                  {
+                    "content": "24"
+                  },
+                  {
+                    "content": "64"
+                  },
+                  {
+                    "content": "120"
+                  },
+                  {
+                    "content": "32"
+                  },
+                  {
+                    "content": "20"
+                  },
+                  {
+                    "content": "36"
+                  }
                 ]
               },
               {
-                "header": { "content": "Rate", "horizontalAlignment": "right" },
-                "cellDefaults": { "horizontalAlignment": "right" },
+                "header": {
+                  "content": "Rate",
+                  "horizontalAlignment": "right"
+                },
+                "cellDefaults": {
+                  "horizontalAlignment": "right"
+                },
                 "cells": [
-                  { "content": "$250/hr" },
-                  { "content": "$200/hr" },
-                  { "content": "$175/hr" },
-                  { "content": "$200/hr" },
-                  { "content": "$185/hr" },
-                  { "content": "$175/hr" },
-                  { "content": "$150/hr" },
-                  { "content": "$125/hr" }
+                  {
+                    "content": "$250/hr"
+                  },
+                  {
+                    "content": "$200/hr"
+                  },
+                  {
+                    "content": "$175/hr"
+                  },
+                  {
+                    "content": "$200/hr"
+                  },
+                  {
+                    "content": "$185/hr"
+                  },
+                  {
+                    "content": "$175/hr"
+                  },
+                  {
+                    "content": "$150/hr"
+                  },
+                  {
+                    "content": "$125/hr"
+                  }
                 ]
               },
               {
@@ -156,46 +253,91 @@
                   "content": "Amount",
                   "horizontalAlignment": "right"
                 },
-                "cellDefaults": { "horizontalAlignment": "right" },
+                "cellDefaults": {
+                  "horizontalAlignment": "right"
+                },
                 "cells": [
-                  { "content": "$4,000" },
-                  { "content": "$9,600" },
-                  { "content": "$4,200" },
-                  { "content": "$12,800" },
-                  { "content": "$22,200" },
-                  { "content": "$5,600" },
-                  { "content": "$3,000" },
-                  { "content": "$4,500" }
+                  {
+                    "content": "$4,000"
+                  },
+                  {
+                    "content": "$9,600"
+                  },
+                  {
+                    "content": "$4,200"
+                  },
+                  {
+                    "content": "$12,800"
+                  },
+                  {
+                    "content": "$22,200"
+                  },
+                  {
+                    "content": "$5,600"
+                  },
+                  {
+                    "content": "$3,000"
+                  },
+                  {
+                    "content": "$4,500"
+                  }
                 ]
               }
             ]
           }
         },
-        { "name": "paragraph", "props": { "text": "" } },
+        {
+          "name": "paragraph",
+          "props": {
+            "text": ""
+          }
+        },
         {
           "name": "table",
           "props": {
             "columns": [
               {
                 "cells": [
-                  { "content": "" },
-                  { "content": "" },
-                  { "content": "Subtotal" },
-                  { "content": "Tax (8.875% — NY Sales Tax)" },
+                  {
+                    "content": ""
+                  },
+                  {
+                    "content": ""
+                  },
+                  {
+                    "content": "Subtotal"
+                  },
+                  {
+                    "content": "Tax (8.875% — NY Sales Tax)"
+                  },
                   {
                     "content": "Discount (10% — retainer agreement)",
-                    "font": { "italic": true }
+                    "font": {
+                      "italic": true
+                    }
                   }
                 ]
               },
               {
-                "cellDefaults": { "horizontalAlignment": "right" },
+                "cellDefaults": {
+                  "horizontalAlignment": "right"
+                },
                 "cells": [
-                  { "content": "" },
-                  { "content": "" },
-                  { "content": "$65,900.00" },
-                  { "content": "$5,848.63" },
-                  { "content": "-$6,590.00" }
+                  {
+                    "content": ""
+                  },
+                  {
+                    "content": ""
+                  },
+                  {
+                    "content": "$65,900.00"
+                  },
+                  {
+                    "content": "$5,848.63"
+                  },
+                  {
+                    "content": "-$6,590.00"
+                  }
                 ]
               }
             ],
@@ -210,16 +352,24 @@
                 "cells": [
                   {
                     "content": "Total Due",
-                    "font": { "bold": true, "size": 16 }
+                    "font": {
+                      "bold": true,
+                      "size": 16
+                    }
                   }
                 ]
               },
               {
-                "cellDefaults": { "horizontalAlignment": "right" },
+                "cellDefaults": {
+                  "horizontalAlignment": "right"
+                },
                 "cells": [
                   {
                     "content": "$65,158.63",
-                    "font": { "bold": true, "size": 16 }
+                    "font": {
+                      "bold": true,
+                      "size": 16
+                    }
                   }
                 ]
               }
@@ -227,14 +377,25 @@
             "hideBorders": true
           }
         },
-        { "name": "paragraph", "props": { "text": "" } },
+        {
+          "name": "paragraph",
+          "props": {
+            "text": ""
+          }
+        },
         {
           "name": "heading",
-          "props": { "text": "Payment Instructions", "level": 2 }
+          "props": {
+            "text": "Payment Instructions",
+            "level": 2
+          }
         },
         {
           "name": "columns",
-          "props": { "columns": 2, "gap": 0.5 },
+          "props": {
+            "columns": 2,
+            "gap": 0.5
+          },
           "children": [
             {
               "name": "paragraph",
@@ -250,8 +411,19 @@
             }
           ]
         },
-        { "name": "paragraph", "props": { "text": "" } },
-        { "name": "heading", "props": { "text": "Notes", "level": 2 } },
+        {
+          "name": "paragraph",
+          "props": {
+            "text": ""
+          }
+        },
+        {
+          "name": "heading",
+          "props": {
+            "text": "Notes",
+            "level": 2
+          }
+        },
         {
           "name": "list",
           "props": {
@@ -264,13 +436,24 @@
             ]
           }
         },
-        { "name": "paragraph", "props": { "text": "" } },
+        {
+          "name": "paragraph",
+          "props": {
+            "text": ""
+          }
+        },
         {
           "name": "paragraph",
           "props": {
             "text": "This document is generated from structured JSON data using json-to-office. Learn more at github.com/json-to-office.",
-            "font": { "size": 8, "color": "textMuted", "italic": true },
-            "spacing": { "before": 400 }
+            "font": {
+              "size": 8,
+              "color": "textMuted",
+              "italic": true
+            },
+            "spacing": {
+              "before": 400
+            }
           }
         }
       ]

--- a/examples/visual-infographic.docx.json
+++ b/examples/visual-infographic.docx.json
@@ -11,11 +11,18 @@
   "children": [
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Infographic"
+        }
+      },
       "children": [
         {
           "name": "heading",
-          "props": { "level": 1, "text": "How a brief becomes a document" }
+          "props": {
+            "level": 1,
+            "text": "How a brief becomes a document"
+          }
         },
         {
           "name": "paragraph",
@@ -31,7 +38,9 @@
             "canvas": {
               "width": 7.2,
               "height": 2.6,
-              "background": { "color": "F4F8FF" }
+              "background": {
+                "color": "F4F8FF"
+              }
             },
             "elements": [
               {
@@ -42,7 +51,9 @@
                   "y": 0.7,
                   "w": 2.0,
                   "h": 1.2,
-                  "fill": { "color": "BBD3FF" }
+                  "fill": {
+                    "color": "BBD3FF"
+                  }
                 }
               },
               {
@@ -53,7 +64,9 @@
                   "y": 0.7,
                   "w": 2.0,
                   "h": 1.2,
-                  "fill": { "color": "6FA1F2" }
+                  "fill": {
+                    "color": "6FA1F2"
+                  }
                 }
               },
               {
@@ -64,7 +77,9 @@
                   "y": 0.7,
                   "w": 2.0,
                   "h": 1.2,
-                  "fill": { "color": "2E6BD6" }
+                  "fill": {
+                    "color": "2E6BD6"
+                  }
                 }
               },
               {
@@ -75,7 +90,9 @@
                   "y": 0.7,
                   "w": 2.0,
                   "h": 1.2,
-                  "fill": { "color": "13367F" }
+                  "fill": {
+                    "color": "13367F"
+                  }
                 }
               },
               {

--- a/packages/core-docx/src/components/toc/index.ts
+++ b/packages/core-docx/src/components/toc/index.ts
@@ -169,13 +169,9 @@ export function renderTocComponent(
   // StyleLevel requires styleName (string) and level (number)
   const stylesWithLevels: StyleLevel[] = [];
 
-  // For section-scoped TOCs, exclude heading levels equal to or above the section title level
-  // This prevents the section title from appearing in its own TOC
-  const sectionTitleLevel = context?.section?.sectionTitleLevel;
-  const startLevel =
-    effectiveScope === 'section' && sectionTitleLevel
-      ? sectionTitleLevel // Start from the level after the section title
-      : 0; // Document scope starts from level 1 (index 0)
+  // Sections no longer synthesize a title heading (a visible title is an
+  // explicit heading child), so section-scoped TOCs include every heading
+  // level their bookmark covers.
 
   // Do NOT map built-in heading styles via \t switch.
   // Use headingStyleRange (\o) exclusively for Heading 1..6 to avoid any interference
@@ -218,13 +214,8 @@ export function renderTocComponent(
   // - \z: Hide page numbers in web layout
   // - \u: Use outline levels instead of TC fields
 
-  // Calculate heading range for \o switch
-  // For section-scoped TOCs: start AFTER section title level (e.g., level 2 if section is level 1)
-  // For document-scoped TOCs: use depthStart and depthEnd from parsed depth config
-  const effectiveDepthStart =
-    effectiveScope === 'section' && sectionTitleLevel
-      ? Math.max(depthStart, startLevel + 1) // Skip section title level, but respect user's depthStart
-      : depthStart;
+  // Calculate heading range for \o switch from the parsed depth config
+  const effectiveDepthStart = depthStart;
   const effectiveDepthEnd = depthEnd;
 
   // Build TOC options

--- a/packages/core-docx/src/core/__tests__/layout-pagebreak.test.ts
+++ b/packages/core-docx/src/core/__tests__/layout-pagebreak.test.ts
@@ -18,8 +18,7 @@ describe('Layout PageBreak', () => {
         {
           name: 'section',
           props: {
-            title: 'Section 1',
-            level: 1,
+            meta: { title: 'Section 1' },
           },
           children: [
             {
@@ -49,8 +48,7 @@ describe('Layout PageBreak', () => {
         {
           name: 'section',
           props: {
-            title: 'Section 1',
-            level: 1,
+            meta: { title: 'Section 1' },
             pageBreak: false,
           },
           children: [
@@ -80,8 +78,7 @@ describe('Layout PageBreak', () => {
         {
           name: 'section',
           props: {
-            title: 'Section 1',
-            level: 1,
+            meta: { title: 'Section 1' },
             pageBreak: true,
           },
           children: [
@@ -105,8 +102,7 @@ describe('Layout PageBreak', () => {
         {
           name: 'section',
           props: {
-            title: 'Section 1',
-            level: 1,
+            meta: { title: 'Section 1' },
             pageBreak: false,
           },
           children: [{ name: 'paragraph', props: { content: 'Content 1' } }],
@@ -114,8 +110,7 @@ describe('Layout PageBreak', () => {
         {
           name: 'section',
           props: {
-            title: 'Section 2',
-            level: 1,
+            meta: { title: 'Section 2' },
             // default pageBreak: true
           },
           children: [{ name: 'paragraph', props: { content: 'Content 2' } }],
@@ -123,8 +118,7 @@ describe('Layout PageBreak', () => {
         {
           name: 'section',
           props: {
-            title: 'Section 3',
-            level: 1,
+            meta: { title: 'Section 3' },
             pageBreak: false,
           },
           children: [{ name: 'paragraph', props: { content: 'Content 3' } }],
@@ -147,17 +141,17 @@ describe('Layout PageBreak', () => {
       const components: ComponentDefinition[] = [
         {
           name: 'section',
-          props: { title: 'Section 1', level: 1 },
+          props: { meta: { title: 'Section 1' } },
           children: [{ name: 'paragraph', props: { content: 'Content 1' } }],
         },
         {
           name: 'section',
-          props: { title: 'Section 2', level: 1 },
+          props: { meta: { title: 'Section 2' } },
           children: [{ name: 'paragraph', props: { content: 'Content 2' } }],
         },
         {
           name: 'section',
-          props: { title: 'Section 3', level: 1 },
+          props: { meta: { title: 'Section 3' } },
           children: [{ name: 'paragraph', props: { content: 'Content 3' } }],
         },
       ];

--- a/packages/core-docx/src/core/__tests__/structure-pagebreak.test.ts
+++ b/packages/core-docx/src/core/__tests__/structure-pagebreak.test.ts
@@ -92,14 +92,13 @@ describe('Structure PageBreak', () => {
     });
   });
 
-  describe('Sections with titles', () => {
-    it('should not set pageBreak flag when section has title', async () => {
+  describe('Sections with meta', () => {
+    it('meta is authoring-only: renders nothing and pageBreak stays at layout level', async () => {
       const components: ComponentDefinition[] = [
         {
           name: 'section',
           props: {
-            title: 'Section Title',
-            level: 1,
+            meta: { title: 'Financial Highlights' },
             pageBreak: true,
           },
           children: [
@@ -114,20 +113,18 @@ describe('Structure PageBreak', () => {
       const sections = await extractSections(components, context);
 
       expect(sections).toHaveLength(1);
-      // pageBreak flag should NOT be set (handled by heading instead)
-      expect(sections[0].pageBreak).toBeUndefined();
-      // Heading should be inserted with pageBreak
-      expect(sections[0].components[0].name).toBe('heading');
-      expect(sections[0].components[0].props.pageBreak).toBe(true);
+      // No synthesized heading — a visible title is an explicit heading child
+      expect(sections[0].components).toHaveLength(1);
+      expect(sections[0].components[0].name).toBe('paragraph');
+      expect(sections[0].pageBreak).toBe(true);
     });
 
-    it('should insert heading with pageBreak: false when specified', async () => {
+    it('meta does not suppress pageBreak: false', async () => {
       const components: ComponentDefinition[] = [
         {
           name: 'section',
           props: {
-            title: 'Section Title',
-            level: 1,
+            meta: { title: 'Annex' },
             pageBreak: false,
           },
           children: [
@@ -142,9 +139,8 @@ describe('Structure PageBreak', () => {
       const sections = await extractSections(components, context);
 
       expect(sections).toHaveLength(1);
-      expect(sections[0].pageBreak).toBeUndefined();
-      expect(sections[0].components[0].name).toBe('heading');
-      expect(sections[0].components[0].props.pageBreak).toBe(false);
+      expect(sections[0].components).toHaveLength(1);
+      expect(sections[0].pageBreak).toBe(false);
     });
   });
 

--- a/packages/core-docx/src/core/layout.ts
+++ b/packages/core-docx/src/core/layout.ts
@@ -54,8 +54,6 @@ export interface SectionLayout {
   isUserSection: boolean;
   /** True if this layout chunk belongs to a user-defined Section (all chunks of that section) */
   belongsToUserSection: boolean;
-  /** The heading level of the section title (e.g., 1 for Heading1) - used by TOCs to exclude section title from section-scoped TOCs */
-  sectionTitleLevel?: number;
   /** Page configuration override for this section */
   pageOverride?: {
     size?: 'A4' | 'A3' | 'LETTER' | 'LEGAL' | { width: number; height: number };
@@ -116,7 +114,6 @@ export function applyLayout(
         footer: section.footer,
         isUserSection: isSourceUserSection,
         belongsToUserSection: isSourceUserSection,
-        sectionTitleLevel: section.level,
         pageOverride: section.page,
       });
       continue;
@@ -127,7 +124,8 @@ export function applyLayout(
 
       // Special handling: a single Columns component becomes its own section with explicit column children
       const isSingleColumnsGroup =
-        group.components.length === 1 && isColumnsComponent(group.components[0]);
+        group.components.length === 1 &&
+        isColumnsComponent(group.components[0]);
 
       const columnSettings = isSingleColumnsGroup
         ? createColumnSettingsFromConfig(group.components[0], theme, themeName)
@@ -144,9 +142,12 @@ export function applyLayout(
       // Build content components depending on whether this is an explicit columns group
       const contentComponents = isSingleColumnsGroup
         ? processLayoutComponents(
-          (group.components[0] as unknown as { children?: ComponentDefinition[] })
-            .children || []
-        )
+            (
+              group.components[0] as unknown as {
+                children?: ComponentDefinition[];
+              }
+            ).children || []
+          )
         : processLayoutComponents(group.components);
 
       layoutSections.push({
@@ -168,8 +169,6 @@ export function applyLayout(
         // at the start of column content.
         isUserSection: isSourceUserSection && j === 0,
         belongsToUserSection: isSourceUserSection,
-        // Pass section title level for TOC scoping
-        sectionTitleLevel: section.level,
         // Pass page override for this section
         pageOverride: section.page,
       });
@@ -281,8 +280,8 @@ export function determineComponentLayout(
 
   // Check if component contains children
   if ('children' in component && (component as any).children) {
-    const hasColumns = (component as any).children.some((child: ComponentDefinition) =>
-      isColumnsComponent(child)
+    const hasColumns = (component as any).children.some(
+      (child: ComponentDefinition) => isColumnsComponent(child)
     );
     return hasColumns ? 'multi-column' : 'single';
   }
@@ -360,17 +359,17 @@ export function getColumnSettings(
   layout: 'single' | 'multi-column'
 ): ColumnSettings {
   switch (layout) {
-  case 'multi-column':
-    // Default multi-column layout: 2 equal-width columns
-    // Note: Specific column components will override this with their own settings via createColumnSettingsFromConfig
-    return {
-      count: 2,
-      equalWidth: true,
-      space: 720, // 0.5 inch in twips
-    };
-  case 'single':
-  default:
-    return { count: 1 };
+    case 'multi-column':
+      // Default multi-column layout: 2 equal-width columns
+      // Note: Specific column components will override this with their own settings via createColumnSettingsFromConfig
+      return {
+        count: 2,
+        equalWidth: true,
+        space: 720, // 0.5 inch in twips
+      };
+    case 'single':
+    default:
+      return { count: 1 };
   }
 }
 
@@ -401,28 +400,28 @@ export function createSectionProperties(
   // Apply section-level page overrides if present
   const pageSetup = pageOverride
     ? {
-      size: {
-        ...basePageSetup.size,
-        ...(pageOverride.size && typeof pageOverride.size === 'object'
-          ? pageOverride.size
-          : pageOverride.size
-            ? (() => {
-              // Convert string size to dimensions
-              const sizes = {
-                A4: { width: 11906, height: 16838 },
-                A3: { width: 16838, height: 23811 },
-                LETTER: { width: 12240, height: 15840 },
-                LEGAL: { width: 12240, height: 20160 },
-              };
-              return sizes[pageOverride.size as keyof typeof sizes];
-            })()
-            : {}),
-      },
-      margin: {
-        ...basePageSetup.margin,
-        ...(pageOverride.margins || {}),
-      },
-    }
+        size: {
+          ...basePageSetup.size,
+          ...(pageOverride.size && typeof pageOverride.size === 'object'
+            ? pageOverride.size
+            : pageOverride.size
+              ? (() => {
+                  // Convert string size to dimensions
+                  const sizes = {
+                    A4: { width: 11906, height: 16838 },
+                    A3: { width: 16838, height: 23811 },
+                    LETTER: { width: 12240, height: 15840 },
+                    LEGAL: { width: 12240, height: 20160 },
+                  };
+                  return sizes[pageOverride.size as keyof typeof sizes];
+                })()
+              : {}),
+        },
+        margin: {
+          ...basePageSetup.margin,
+          ...(pageOverride.margins || {}),
+        },
+      }
     : basePageSetup;
 
   const properties: WordSectionProperties = {

--- a/packages/core-docx/src/core/render.ts
+++ b/packages/core-docx/src/core/render.ts
@@ -616,8 +616,6 @@ export async function renderSection(
       columnCount: section.properties.column?.count || 1,
       // Always pass the same bookmark ID for all layout chunks of the same section
       sectionBookmarkId: sectionBookmarkId,
-      // Pass section title level for TOC scoping (excludes section title from its own TOC)
-      sectionTitleLevel: section.sectionTitleLevel,
     },
   };
 

--- a/packages/core-docx/src/core/structure.ts
+++ b/packages/core-docx/src/core/structure.ts
@@ -13,10 +13,7 @@ import {
 } from '../types';
 import { ThemeConfig } from '../styles';
 import { formatDate } from '../utils/formatters';
-import {
-  resolveComponentTree,
-  resolveComponentDefaults,
-} from '../styles/utils/resolveComponentTree';
+import { resolveComponentTree } from '../styles/utils/resolveComponentTree';
 import { mergeWithDefaults } from '../styles/utils/componentDefaults';
 
 export interface ProcessedDocument {
@@ -42,8 +39,6 @@ export interface DocumentMetadata {
 }
 
 export interface ProcessedSection {
-  title?: string;
-  level?: number;
   components: ComponentDefinition[];
   header?: ComponentDefinition[] | 'linkToPrevious';
   footer?: ComponentDefinition[] | 'linkToPrevious';
@@ -183,43 +178,15 @@ export async function extractSections(
       // Determine if page break should be applied (default to true)
       const shouldPageBreak = component.props?.pageBreak !== false;
 
-      // Add section title as heading component if present
-      if (component.props?.title) {
-        // Ensure level is within valid range (1-6) for heading component
-        const headingLevel = Math.min(
-          Math.max(component.props.level || 1, 1),
-          6
-        ) as 1 | 2 | 3 | 4 | 5 | 6;
-
-        sectionComponents.unshift(
-          resolveComponentDefaults(
-            {
-              name: 'heading',
-              props: {
-                text: component.props.title,
-                level: headingLevel,
-                pageBreak: shouldPageBreak,
-                // Apply zero-spacing to prevent unwanted initial line
-                spacing: {
-                  before: 0,
-                  after: 0,
-                },
-              },
-            },
-            context.fullTheme
-          )
-        );
-      }
-
       sections.push({
-        title: component.props?.title,
-        level: component.props?.level,
         components: sectionComponents,
         header: component.props?.header,
         footer: component.props?.footer,
         isExplicitSection: true,
-        // Store pageBreak for titleless sections to be handled at layout level
-        pageBreak: !component.props?.title ? shouldPageBreak : undefined,
+        // Page break is handled at layout level (sections render no title of
+        // their own — a visible title is an explicit heading child; the
+        // authoring label lives in props.meta.title and is never rendered)
+        pageBreak: shouldPageBreak,
         // Preserve page configuration override if present
         page: component.props?.page,
       });
@@ -257,33 +224,7 @@ export async function flattenComponents(
         children: await flattenComponents(component.children, context),
       });
     } else if (isSectionComponent(component) && component.children) {
-      // Flatten nested sections
-      if (component.props?.title) {
-        // Ensure level is within valid range (1-6) for heading component
-        const headingLevel = Math.min(
-          Math.max(component.props.level || 1, 1),
-          6
-        ) as 1 | 2 | 3 | 4 | 5 | 6;
-
-        // Convert section title to heading
-        flattened.push(
-          resolveComponentDefaults(
-            {
-              name: 'heading',
-              props: {
-                text: component.props.title,
-                level: headingLevel,
-                // Apply zero-spacing to prevent unwanted initial line
-                spacing: {
-                  before: 0,
-                  after: 0,
-                },
-              },
-            },
-            context.fullTheme
-          )
-        );
-      }
+      // Flatten nested sections (their meta is authoring-only, nothing renders)
       flattened.push(...(await flattenComponents(component.children, context)));
     } else {
       // Keep content components as-is

--- a/packages/core-docx/src/plugin/__tests__/generate-standard-definition.test.ts
+++ b/packages/core-docx/src/plugin/__tests__/generate-standard-definition.test.ts
@@ -184,7 +184,7 @@ describe('generate().standardDefinition', () => {
       children: [
         {
           name: 'section',
-          props: { title: 'Introduction' },
+          props: { meta: { title: 'Introduction' } },
           children: [
             {
               name: 'greeting',

--- a/packages/core-docx/src/plugin/__tests__/preserved-components.test.ts
+++ b/packages/core-docx/src/plugin/__tests__/preserved-components.test.ts
@@ -222,7 +222,7 @@ describe('preserveCustomComponents', () => {
         children: [
           {
             name: 'section',
-            props: { title: 'S' },
+            props: { meta: { title: 'S' } },
             children: [
               { name: 'greeting', props: { name: 'Alice' } },
               { name: 'summary', props: { points: ['a'] } },

--- a/packages/core-docx/src/plugin/example/nested-section.component.ts
+++ b/packages/core-docx/src/plugin/example/nested-section.component.ts
@@ -37,10 +37,13 @@ export const nestedSectionsComponent = createComponent({
         components.push({
           name: 'section',
           props: {
-            title: 'First level 1 section',
-            level: 1,
+            meta: { title: 'First level 1 section' },
           },
           children: [
+            {
+              name: 'heading',
+              props: { text: 'First level 1 section', level: 1 },
+            },
             {
               name: 'heading',
               props: {
@@ -73,10 +76,13 @@ export const nestedSectionsComponent = createComponent({
         components.push({
           name: 'section',
           props: {
-            title: 'Second level 1 section',
-            level: 1,
+            meta: { title: 'Second level 1 section' },
           },
           children: [
+            {
+              name: 'heading',
+              props: { text: 'Second level 1 section', level: 1 },
+            },
             {
               name: 'heading',
               props: {

--- a/packages/core-docx/src/types/index.ts
+++ b/packages/core-docx/src/types/index.ts
@@ -209,8 +209,6 @@ export interface RenderContext {
     level?: number;
     /** Bookmark ID for section-scoped TOCs (when TOC is inside a section) */
     sectionBookmarkId?: string;
-    /** Heading level of the parent section title (used to exclude it from section-scoped TOCs) */
-    sectionTitleLevel?: number;
   };
   utils: {
     formatDate: (_date: Date) => string;

--- a/packages/jto/package.json
+++ b/packages/jto/package.json
@@ -80,6 +80,7 @@
     "glob": "^13.0.0",
     "hono": "4.6.14",
     "idb-keyval": "^6.2.2",
+    "jsonc-parser": "^3.3.1",
     "jsonrepair": "^3.13.3",
     "koffi": "^2.16.1",
     "lodash.debounce": "4.0.8",

--- a/packages/jto/src/client/components/json-editor/editor-monaco-json.tsx
+++ b/packages/jto/src/client/components/json-editor/editor-monaco-json.tsx
@@ -89,12 +89,15 @@ function EditorMonacoJson({
   );
 
   // Collapse newly-pasted long strings after typing settles (skips the string
-  // under the cursor so it never yanks text mid-edit).
+  // under the cursor so it never yanks text mid-edit). Re-anchor existing
+  // chips first: undo of an outline reorder moves sentinel text without
+  // moving its decoration.
   const debouncedCollapseNewRef = useRef(
     debounce(() => {
       const editorInstance = editorRef.current;
       const controller = collapseRef.current;
       if (!editorInstance || !controller) return;
+      controller.resyncDecorations();
       const position = editorInstance.getPosition();
       const model = editorInstance.getModel();
       const cursorOffset =
@@ -131,11 +134,6 @@ function EditorMonacoJson({
     editorRef.current = editor;
     monacoRef.current = monaco;
 
-    // Register editor in the refs store. Pass the sentinel reconstructor so any
-    // consumer reading live text (preview/build) expands collapsed strings.
-    registerEditor(name, editor, monaco, toStorageValue);
-    setActiveEditor(name);
-
     // Ensure the model's language is set to JSON for schema validation
     const model = editor.getModel();
     if (model) {
@@ -146,6 +144,12 @@ function EditorMonacoJson({
     // Collapse very long string values (base64, big blobs, …) into clickable chips
     collapseRef.current = installLongStringCollapser(editor, monaco);
     collapseRef.current.recollapse();
+
+    // Register editor in the refs store. Pass the sentinel reconstructor so any
+    // consumer reading live text (preview/build) expands collapsed strings, and
+    // the collapse controller so outline reorders can re-anchor chips.
+    registerEditor(name, editor, monaco, toStorageValue, collapseRef.current);
+    setActiveEditor(name);
 
     // Add context menu action for AI assistant
     editor.addAction({

--- a/packages/jto/src/client/components/playground/document-sidebar.tsx
+++ b/packages/jto/src/client/components/playground/document-sidebar.tsx
@@ -19,6 +19,7 @@ import { CompareDocumentsDialog } from './compare-documents-dialog';
 import { FORMAT } from '../../lib/env';
 import { DocumentFormDialogContentMemoized } from './document-form-dialog-content';
 import { DocumentMenuItemMemoized } from './document-menu-item';
+import { OutlinePanel } from './outline-panel';
 import { PluginSelector } from './plugin-selector';
 import { SidebarLibrary } from './sidebar-library';
 import {
@@ -586,6 +587,11 @@ function DocumentSidebarComponent({
                       </SidebarMenu>
                     </section>
                   )}
+
+                  {/* Outline of the active document. Hidden while the rail
+                      filter is active — the filter is about files, and the
+                      freed rows go to the matching results. */}
+                  {!q && <OutlinePanel />}
 
                   {/* Project library */}
                   {(libraryDocuments.length > 0 ||

--- a/packages/jto/src/client/components/playground/outline-panel.tsx
+++ b/packages/jto/src/client/components/playground/outline-panel.tsx
@@ -1,0 +1,508 @@
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  BarChart3,
+  Box,
+  Braces,
+  ChevronRight,
+  Hash,
+  Heading,
+  Image as ImageIcon,
+  Layers,
+  List as ListIcon,
+  ListTree,
+  Pilcrow,
+  Presentation,
+  Square,
+  Table as TableIcon,
+  Type,
+} from 'lucide-react';
+import debounce from 'lodash.debounce';
+import { useShallow } from 'zustand/react/shallow';
+import {
+  buildOutline,
+  collectErrorNodeIds,
+  computeReorderEdit,
+  pathToOffset,
+  type OutlineDocType,
+  type OutlineNode,
+} from '../../lib/document-outline';
+import { FORMAT } from '../../lib/env';
+import { cn } from '../../lib/utils';
+import { useDocumentsStore } from '../../store/documents-store-provider';
+import { useEditorRefsStore } from '../../store/editor-refs-store';
+import { RailIconButton, SectionLabel } from './sidebar-shared';
+
+/**
+ * Sidebar "Outline" section: a semantic table of contents for the document in
+ * the active editor tab. Slides/headings/components (or theme keys) map to
+ * exact ranges in the Monaco model, giving click-to-reveal, cursor-follow
+ * highlighting, validation-error badges, and drag-to-reorder of siblings.
+ */
+
+const KIND_ICONS: Record<
+  string,
+  React.ComponentType<{ className?: string }>
+> = {
+  slide: Presentation,
+  heading: Heading,
+  text: Type,
+  paragraph: Pilcrow,
+  chart: BarChart3,
+  highcharts: BarChart3,
+  table: TableIcon,
+  image: ImageIcon,
+  shape: Square,
+  list: ListIcon,
+  toc: ListTree,
+  section: Layers,
+  columns: Layers,
+  'text-box': Type,
+  statistic: Hash,
+  key: Braces,
+};
+
+interface DragState {
+  dragId: string;
+  /** Tree id of the dragged node's parent ('' for a root-level node). */
+  parentId: string;
+  overId: string | null;
+  overHalf: 'before' | 'after';
+}
+
+/** Resolve a positional tree id ("2.0.1") back to a node in a fresh outline. */
+function findById(nodes: OutlineNode[], id: string): OutlineNode | null {
+  let list = nodes;
+  let node: OutlineNode | null = null;
+  for (const part of id.split('.')) {
+    node = list[Number(part)] ?? null;
+    if (!node) return null;
+    list = node.children;
+  }
+  return node;
+}
+
+function parentIdOf(id: string): string {
+  const i = id.lastIndexOf('.');
+  return i === -1 ? '' : id.slice(0, i);
+}
+
+function OutlinePanelComponent() {
+  const { activeTab, documentTypes } = useDocumentsStore(
+    useShallow((state) => ({
+      activeTab: state.activeTab,
+      documentTypes: state.documentTypes,
+    }))
+  );
+  const storeText = useDocumentsStore((state) =>
+    state.activeTab
+      ? state.documents.find((d) => d.name === state.activeTab)?.text
+      : undefined
+  );
+  const editorRef = useEditorRefsStore((state) =>
+    activeTab ? state.editors.get(activeTab) ?? null : null
+  );
+
+  const docType: OutlineDocType =
+    activeTab && documentTypes[activeTab] === 'application/json+theme'
+      ? 'theme'
+      : 'document';
+
+  const [open, setOpen] = useState<boolean>(() => {
+    try {
+      const stored = localStorage.getItem('dev-env.outline-open');
+      return stored ? stored === 'true' : true;
+    } catch {
+      return true;
+    }
+  });
+  useEffect(() => {
+    try {
+      localStorage.setItem('dev-env.outline-open', String(open));
+    } catch {}
+  }, [open]);
+
+  const [outline, setOutline] = useState<OutlineNode[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [errorIds, setErrorIds] = useState<Set<string>>(() => new Set());
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const [drag, setDrag] = useState<DragState | null>(null);
+
+  const outlineRef = useRef<OutlineNode[]>(outline);
+  outlineRef.current = outline;
+  const listRef = useRef<HTMLDivElement>(null);
+  const lastInitTabRef = useRef<string | null>(null);
+
+  const rebuild = useCallback(() => {
+    if (!activeTab) {
+      setOutline([]);
+      return;
+    }
+    const text = editorRef?.editor.getModel()?.getValue() ?? storeText ?? '';
+    const nodes = buildOutline(text, FORMAT, docType);
+    setOutline(nodes);
+    if (lastInitTabRef.current !== activeTab) {
+      lastInitTabRef.current = activeTab;
+      // DOCX reports open with the heading skeleton visible; slides and theme
+      // keys start folded — cursor-follow expands the path you're in anyway.
+      const init = new Set<string>();
+      if (docType === 'document' && FORMAT === 'docx') {
+        for (const n of nodes) if (n.kind === 'heading') init.add(n.id);
+      }
+      setExpanded(init);
+      setActiveId(null);
+    }
+  }, [activeTab, editorRef, storeText, docType]);
+
+  // Rebuild on tab switch / external text changes, and (debounced) on typing.
+  useEffect(() => {
+    rebuild();
+    const model = editorRef?.editor.getModel();
+    if (!model) return;
+    const debounced = debounce(rebuild, 300);
+    const sub = model.onDidChangeContent(() => debounced());
+    return () => {
+      debounced.cancel();
+      sub.dispose();
+    };
+  }, [rebuild, editorRef]);
+
+  // Cursor-follow: highlight and reveal the node the cursor is inside.
+  useEffect(() => {
+    if (!editorRef) return;
+    const { editor } = editorRef;
+    const debounced = debounce(() => {
+      const model = editor.getModel();
+      const position = editor.getPosition();
+      if (!model || !position) return;
+      const offset = model.getOffsetAt(position);
+      const path = pathToOffset(outlineRef.current, offset);
+      if (path.length === 0) {
+        setActiveId(null);
+        return;
+      }
+      setActiveId(path[path.length - 1]);
+      const ancestors = path.slice(0, -1);
+      if (ancestors.length) {
+        setExpanded((prev) => {
+          if (ancestors.every((id) => prev.has(id))) return prev;
+          const next = new Set(prev);
+          for (const id of ancestors) next.add(id);
+          return next;
+        });
+      }
+    }, 150);
+    const sub = editor.onDidChangeCursorPosition(() => debounced());
+    return () => {
+      debounced.cancel();
+      sub.dispose();
+    };
+  }, [editorRef]);
+
+  // Keep the active row in view.
+  useEffect(() => {
+    if (!activeId || !listRef.current) return;
+    const el = listRef.current.querySelector(
+      `[data-oid="${CSS.escape(activeId)}"]`
+    );
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [activeId]);
+
+  // Validation-error badges, remapped whenever markers or the outline change.
+  useEffect(() => {
+    if (!editorRef) {
+      setErrorIds(new Set());
+      return;
+    }
+    const { editor, monaco } = editorRef;
+    const compute = () => {
+      const model = editor.getModel();
+      if (!model) return;
+      const offsets = monaco.editor
+        .getModelMarkers({ resource: model.uri })
+        .filter((m) => m.severity === monaco.MarkerSeverity.Error)
+        .map((m) =>
+          model.getOffsetAt({
+            lineNumber: m.startLineNumber,
+            column: m.startColumn,
+          })
+        );
+      setErrorIds(collectErrorNodeIds(outlineRef.current, offsets));
+    };
+    compute();
+    const sub = monaco.editor.onDidChangeMarkers((uris) => {
+      const model = editor.getModel();
+      if (model && uris.some((u) => u.toString() === model.uri.toString())) {
+        compute();
+      }
+    });
+    return () => sub.dispose();
+  }, [editorRef, outline]);
+
+  const toggleExpanded = useCallback((id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const revealNode = useCallback(
+    (node: OutlineNode) => {
+      setActiveId(node.id);
+      if (!editorRef) return;
+      const { editor, monaco } = editorRef;
+      const model = editor.getModel();
+      if (!model) return;
+      const start = model.getPositionAt(node.start);
+      const end = model.getPositionAt(node.end);
+      const range = new monaco.Range(
+        start.lineNumber,
+        start.column,
+        end.lineNumber,
+        end.column
+      );
+      editor.revealRangeNearTopIfOutsideViewport(
+        range,
+        monaco.editor.ScrollType.Smooth
+      );
+      editor.setPosition(start);
+      editor.focus();
+      const flash = editor.deltaDecorations(
+        [],
+        [{ range, options: { className: 'jto-outline-flash' } }]
+      );
+      window.setTimeout(() => editor.deltaDecorations(flash, []), 700);
+    },
+    [editorRef]
+  );
+
+  /**
+   * Reorder is computed against a FRESH parse of the live model text — the
+   * rendered outline can be up to 300ms stale, and applying stale offsets
+   * would corrupt the document. Ids resolve positionally; if the structure
+   * changed underneath the drag, resolution fails and we abort quietly.
+   */
+  const performDrop = useCallback(
+    (state: DragState) => {
+      if (!editorRef || !state.overId) return;
+      const { editor, monaco, collapse } = editorRef;
+      const model = editor.getModel();
+      if (!model) return;
+      const liveText = model.getValue();
+      const liveOutline = buildOutline(liveText, FORMAT, docType);
+      const siblings = state.parentId
+        ? findById(liveOutline, state.parentId)?.children ?? []
+        : liveOutline;
+      const from = siblings.findIndex((n) => n.id === state.dragId);
+      const overIndex = siblings.findIndex((n) => n.id === state.overId);
+      if (from === -1 || overIndex === -1) return;
+      let to = overIndex + (state.overHalf === 'after' ? 1 : 0);
+      if (from < to) to -= 1;
+      const edit = computeReorderEdit(liveText, siblings, from, to);
+      if (!edit) return;
+      const start = model.getPositionAt(edit.start);
+      const end = model.getPositionAt(edit.end);
+      editor.executeEdits('outline-reorder', [
+        {
+          range: new monaco.Range(
+            start.lineNumber,
+            start.column,
+            end.lineNumber,
+            end.column
+          ),
+          text: edit.text,
+        },
+      ]);
+      collapse?.resyncDecorations();
+    },
+    [editorRef, docType]
+  );
+
+  const rows = useMemo(() => {
+    const out: React.ReactNode[] = [];
+    const render = (nodes: OutlineNode[], depth: number, parentId: string) => {
+      const groupId = nodes[0]?.reorder?.groupId;
+      const draggableGroup =
+        nodes.length > 1 &&
+        groupId !== undefined &&
+        nodes.every((n) => n.reorder?.groupId === groupId);
+      nodes.forEach((node) => {
+        const Icon = KIND_ICONS[node.kind] ?? Box;
+        const hasChildren = node.children.length > 0;
+        const isExpanded = expanded.has(node.id);
+        const isActive = activeId === node.id;
+        const isDragOver = drag?.overId === node.id;
+        out.push(
+          <div
+            key={node.id}
+            data-oid={node.id}
+            role="treeitem"
+            aria-selected={isActive}
+            aria-expanded={hasChildren ? isExpanded : undefined}
+            tabIndex={0}
+            draggable={draggableGroup}
+            onClick={() => revealNode(node)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                revealNode(node);
+              }
+              if (e.key === 'ArrowRight' && hasChildren && !isExpanded) {
+                toggleExpanded(node.id);
+              }
+              if (e.key === 'ArrowLeft' && hasChildren && isExpanded) {
+                toggleExpanded(node.id);
+              }
+            }}
+            onDragStart={(e) => {
+              e.dataTransfer.setData('text/plain', node.id);
+              e.dataTransfer.effectAllowed = 'move';
+              setDrag({
+                dragId: node.id,
+                parentId,
+                overId: null,
+                overHalf: 'before',
+              });
+            }}
+            onDragOver={(e) => {
+              if (!drag || drag.dragId === node.id) return;
+              if (parentIdOf(drag.dragId) !== parentId) return;
+              e.preventDefault();
+              e.dataTransfer.dropEffect = 'move';
+              const rect = e.currentTarget.getBoundingClientRect();
+              const half =
+                e.clientY < rect.top + rect.height / 2 ? 'before' : 'after';
+              if (drag.overId !== node.id || drag.overHalf !== half) {
+                setDrag({ ...drag, overId: node.id, overHalf: half });
+              }
+            }}
+            onDrop={(e) => {
+              e.preventDefault();
+              if (drag) {
+                performDrop({
+                  ...drag,
+                  overId: node.id,
+                  overHalf: drag.overHalf,
+                });
+              }
+              setDrag(null);
+            }}
+            onDragEnd={() => setDrag(null)}
+            className={cn(
+              'group flex h-6 w-full cursor-pointer items-center gap-1 rounded-sm pr-1',
+              'text-[12px] text-sidebar-foreground/80 transition-colors select-none',
+              'hover:bg-sidebar-accent hover:text-sidebar-foreground',
+              'focus-visible:ring-sidebar-ring focus-visible:ring-1 focus-visible:outline-none',
+              isActive &&
+                'bg-sidebar-accent font-medium text-sidebar-foreground',
+              isDragOver &&
+                drag?.overHalf === 'before' &&
+                'shadow-[inset_0_2px_0_hsl(var(--ring))]',
+              isDragOver &&
+                drag?.overHalf === 'after' &&
+                'shadow-[inset_0_-2px_0_hsl(var(--ring))]'
+            )}
+            style={{ paddingLeft: 4 + depth * 12 }}
+          >
+            {hasChildren ? (
+              <span
+                role="button"
+                aria-label={isExpanded ? 'Collapse' : 'Expand'}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleExpanded(node.id);
+                }}
+                className="flex size-3.5 shrink-0 items-center justify-center rounded-xs text-sidebar-foreground/55 hover:text-sidebar-foreground"
+              >
+                <ChevronRight
+                  className={cn(
+                    'size-3 transition-transform',
+                    isExpanded && 'rotate-90'
+                  )}
+                />
+              </span>
+            ) : (
+              <span className="size-3.5 shrink-0" />
+            )}
+            {node.kind === 'slide' && (
+              <span className="w-3 shrink-0 text-right text-[10px] tabular-nums text-sidebar-foreground/50">
+                {node.detail}
+              </span>
+            )}
+            <Icon className="size-3.5 shrink-0 text-sidebar-foreground/55" />
+            <span className="min-w-0 flex-1 truncate">{node.label}</span>
+            {node.kind !== 'slide' && node.detail && (
+              <span className="shrink-0 text-[10px] text-sidebar-foreground/50">
+                {node.detail}
+              </span>
+            )}
+            {errorIds.has(node.id) && (
+              <span
+                aria-label="Contains validation errors"
+                className="bg-destructive size-1.5 shrink-0 rounded-full"
+              />
+            )}
+          </div>
+        );
+        if (hasChildren && isExpanded) {
+          render(node.children, depth + 1, node.id);
+        }
+      });
+    };
+    render(outline, 0, '');
+    return out;
+  }, [
+    outline,
+    expanded,
+    activeId,
+    errorIds,
+    drag,
+    revealNode,
+    toggleExpanded,
+    performDrop,
+  ]);
+
+  if (!activeTab) return null;
+
+  return (
+    // shrink-0: as a flex child of the scrollable SidebarContent this section
+    // must keep its content height — with min-h-0 it would absorb all the
+    // shrinkage once the rail overflows and clip every row to nothing.
+    <section className="mt-3 shrink-0">
+      <SectionLabel
+        count={outline.length || undefined}
+        actions={
+          <RailIconButton
+            aria-label={open ? 'Collapse outline' : 'Expand outline'}
+            aria-expanded={open}
+            onClick={() => setOpen((v) => !v)}
+          >
+            <ChevronRight
+              className={cn('transition-transform', open && 'rotate-90')}
+            />
+          </RailIconButton>
+        }
+      >
+        Outline
+      </SectionLabel>
+      {open &&
+        (outline.length > 0 ? (
+          <div
+            ref={listRef}
+            role="tree"
+            aria-label="Document outline"
+            className="max-h-[45vh] overflow-y-auto"
+          >
+            {rows}
+          </div>
+        ) : (
+          <p className="px-2 py-1 text-[12px] leading-tight text-sidebar-foreground/60">
+            No structure to show yet.
+          </p>
+        ))}
+    </section>
+  );
+}
+
+export const OutlinePanel = memo(OutlinePanelComponent);

--- a/packages/jto/src/client/index.css
+++ b/packages/jto/src/client/index.css
@@ -396,3 +396,10 @@
 ::-webkit-scrollbar-thumb:hover {
   background: hsl(var(--muted-foreground) / 0.4);
 }
+
+/* Brief highlight painted over a JSON node when it's revealed from the
+   sidebar outline. Removed by a timeout, so keep it transition-free. */
+.jto-outline-flash {
+  background: hsl(var(--ring) / 0.16);
+  border-radius: 2px;
+}

--- a/packages/jto/src/client/lib/__tests__/document-outline.test.ts
+++ b/packages/jto/src/client/lib/__tests__/document-outline.test.ts
@@ -151,6 +151,23 @@ describe('buildOutline (docx)', () => {
     expect(hit?.id).toBe(feesPara.id);
   });
 
+  it('labels sections from meta.title when present', () => {
+    const doc = JSON.stringify({
+      name: 'docx',
+      children: [
+        {
+          name: 'section',
+          props: { meta: { title: 'Financial Highlights' } },
+          children: [
+            { name: 'heading', props: { text: 'Something else', level: 2 } },
+          ],
+        },
+      ],
+    });
+    const sections = buildOutline(doc, 'docx', 'document');
+    expect(sections[0].label).toBe('Financial Highlights');
+  });
+
   it('labels untitled sections from their first heading child', () => {
     const doc = JSON.stringify({
       name: 'docx',

--- a/packages/jto/src/client/lib/__tests__/document-outline.test.ts
+++ b/packages/jto/src/client/lib/__tests__/document-outline.test.ts
@@ -83,7 +83,7 @@ describe('buildOutline (pptx)', () => {
   it('lists slides with title-derived labels', () => {
     expect(outline).toHaveLength(3);
     expect(outline[0].kind).toBe('slide');
-    expect(outline[0].label).toBe('Q2 Review');
+    expect(outline[0].label).toBe('Q2 Review Subline');
     expect(outline[1].label).toBe('Performance');
     expect(outline[2].label).toBe('Slide 3');
   });
@@ -114,6 +114,46 @@ describe('buildOutline (pptx)', () => {
     const groups = new Set(outline.map((n) => n.reorder?.groupId));
     expect(groups.size).toBe(1);
     expect([...groups][0]).toBeTruthy();
+  });
+
+  it('prefers meta.title over content-derived labels', () => {
+    const doc = JSON.stringify({
+      name: 'pptx',
+      children: [
+        {
+          name: 'slide',
+          props: { meta: { title: 'Cover' } },
+          children: [
+            { name: 'text', props: { text: 'Something else', style: 'title' } },
+          ],
+        },
+      ],
+    });
+    const slides = buildOutline(doc, 'pptx', 'document');
+    expect(slides[0].label).toBe('Cover');
+  });
+
+  it('labels template-driven slides from their title placeholder', () => {
+    const doc = JSON.stringify({
+      name: 'pptx',
+      children: [
+        {
+          name: 'slide',
+          props: {
+            template: 'COVER_TEMPLATE',
+            placeholders: {
+              subtitle: { name: 'text', props: { text: 'The subtitle' } },
+              title: {
+                name: 'text',
+                props: { text: 'Slide system\nshowcase' },
+              },
+            },
+          },
+        },
+      ],
+    });
+    const slides = buildOutline(doc, 'pptx', 'document');
+    expect(slides[0].label).toBe('Slide system showcase');
   });
 });
 
@@ -221,7 +261,7 @@ describe('error tolerance', () => {
     const broken = pptxDoc.replace('"type": "bar",', '"type": "bar",,');
     const outline = buildOutline(broken, 'pptx', 'document');
     expect(outline.length).toBe(3);
-    expect(outline[0].label).toBe('Q2 Review');
+    expect(outline[0].label).toBe('Q2 Review Subline');
   });
 
   it('returns [] for empty or hopeless input', () => {
@@ -265,7 +305,7 @@ describe('computeReorderEdit', () => {
     const next = apply(pptxDoc, edit!);
     const parsed = JSON.parse(next);
     const labels = buildOutline(next, 'pptx', 'document').map((n) => n.label);
-    expect(labels).toEqual(['Performance', 'Slide 2', 'Q2 Review']);
+    expect(labels).toEqual(['Performance', 'Slide 2', 'Q2 Review Subline']);
     expect(parsed.children).toHaveLength(3);
   });
 

--- a/packages/jto/src/client/lib/__tests__/document-outline.test.ts
+++ b/packages/jto/src/client/lib/__tests__/document-outline.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildOutline,
+  collectErrorNodeIds,
+  computeReorderEdit,
+  findDeepestNodeAt,
+  type OutlineNode,
+} from '../document-outline';
+
+const pptxDoc = JSON.stringify(
+  {
+    name: 'pptx',
+    props: { title: 'Deck', theme: 'corporate' },
+    children: [
+      {
+        name: 'slide',
+        props: { notes: 'intro notes' },
+        children: [
+          {
+            name: 'text',
+            props: { text: 'Q2 Review\nSubline', style: 'title' },
+          },
+          { name: 'shape', props: { type: 'line' } },
+        ],
+      },
+      {
+        name: 'slide',
+        children: [
+          { name: 'text', props: { text: 'Performance', style: 'heading1' } },
+          {
+            name: 'chart',
+            props: { type: 'bar', title: 'Revenue ($k)', data: [] },
+          },
+          {
+            name: 'table',
+            props: {
+              rows: [
+                ['a', 'b', 'c'],
+                ['d', 'e', 'f'],
+              ],
+            },
+          },
+        ],
+      },
+      {
+        name: 'slide',
+        children: [
+          { name: 'image', props: { src: 'https://x.test/logo.png' } },
+        ],
+      },
+    ],
+  },
+  null,
+  2
+);
+
+const docxDoc = JSON.stringify(
+  {
+    name: 'docx',
+    props: { theme: 'minimal' },
+    children: [
+      { name: 'heading', props: { text: 'Agreement', level: 1 } },
+      { name: 'paragraph', props: { text: 'Intro paragraph.' } },
+      { name: 'heading', props: { text: 'Fees', level: 2 } },
+      { name: 'paragraph', props: { text: 'Fees paragraph.' } },
+      { name: 'list', props: { items: ['a', 'b', 'c'] } },
+      { name: 'heading', props: { text: 'Termination', level: 2 } },
+      { name: 'paragraph', props: { text: 'Termination paragraph.' } },
+      { name: 'heading', props: { text: 'Annex', level: 1 } },
+      {
+        name: 'table',
+        props: { columns: [{ header: 'H', cells: ['1', '2'] }] },
+      },
+    ],
+  },
+  null,
+  2
+);
+
+describe('buildOutline (pptx)', () => {
+  const outline = buildOutline(pptxDoc, 'pptx', 'document');
+
+  it('lists slides with title-derived labels', () => {
+    expect(outline).toHaveLength(3);
+    expect(outline[0].kind).toBe('slide');
+    expect(outline[0].label).toBe('Q2 Review');
+    expect(outline[1].label).toBe('Performance');
+    expect(outline[2].label).toBe('Slide 3');
+  });
+
+  it('labels components semantically', () => {
+    const slide2 = outline[1];
+    expect(slide2.children.map((c) => c.kind)).toEqual([
+      'text',
+      'chart',
+      'table',
+    ]);
+    expect(slide2.children[1].label).toBe('Revenue ($k)');
+    expect(slide2.children[1].detail).toBe('bar');
+    expect(slide2.children[2].detail).toBe('2×3');
+    expect(outline[2].children[0].label).toBe('logo.png');
+  });
+
+  it('assigns nested ids and containment ranges', () => {
+    const slide2 = outline[1];
+    expect(slide2.children[0].id).toBe('1.0');
+    for (const child of slide2.children) {
+      expect(child.start).toBeGreaterThanOrEqual(slide2.start);
+      expect(child.end).toBeLessThanOrEqual(slide2.end);
+    }
+  });
+
+  it('marks slides reorderable within one group', () => {
+    const groups = new Set(outline.map((n) => n.reorder?.groupId));
+    expect(groups.size).toBe(1);
+    expect([...groups][0]).toBeTruthy();
+  });
+});
+
+describe('buildOutline (docx)', () => {
+  const outline = buildOutline(docxDoc, 'docx', 'document');
+
+  it('builds a heading hierarchy', () => {
+    expect(outline.map((n) => n.label)).toEqual(['Agreement', 'Annex']);
+    const agreement = outline[0];
+    expect(agreement.children.map((n) => n.label)).toEqual([
+      'Intro paragraph.',
+      'Fees',
+      'Termination',
+    ]);
+    expect(agreement.children[1].children.map((n) => n.kind)).toEqual([
+      'paragraph',
+      'list',
+    ]);
+  });
+
+  it('extends heading ranges and slices over their sections', () => {
+    const agreement = outline[0];
+    const termination = agreement.children[2];
+    const lastPara = termination.children[0];
+    expect(termination.end).toBeGreaterThanOrEqual(lastPara.end);
+    expect(termination.reorder!.sliceEnd).toBeGreaterThanOrEqual(lastPara.end);
+    expect(agreement.reorder!.sliceEnd).toBeGreaterThanOrEqual(
+      termination.reorder!.sliceEnd
+    );
+  });
+
+  it('finds the deepest node at an offset', () => {
+    const feesPara = outline[0].children[1].children[0];
+    const hit = findDeepestNodeAt(outline, feesPara.start + 5);
+    expect(hit?.id).toBe(feesPara.id);
+  });
+
+  it('labels untitled sections from their first heading child', () => {
+    const doc = JSON.stringify({
+      name: 'docx',
+      children: [
+        {
+          name: 'section',
+          props: { pageBreak: true },
+          children: [
+            { name: 'heading', props: { text: 'Market analysis', level: 2 } },
+            { name: 'paragraph', props: { text: 'Body.' } },
+          ],
+        },
+      ],
+    });
+    const sections = buildOutline(doc, 'docx', 'document');
+    expect(sections[0].kind).toBe('section');
+    expect(sections[0].label).toBe('Market analysis');
+  });
+});
+
+describe('buildOutline (theme)', () => {
+  const theme = JSON.stringify(
+    {
+      $schema: 'x',
+      name: 'corporate',
+      colors: { primary: '#1B4B66', accent: '#F05A28' },
+      fonts: { heading: { family: 'Inter' } },
+      noProofWords: ['Wiseair'],
+    },
+    null,
+    2
+  );
+  const outline = buildOutline(theme, 'docx', 'theme');
+
+  it('lists top-level keys (skipping $schema) with nested keys one level down', () => {
+    expect(outline.map((n) => n.label)).toEqual([
+      'name',
+      'colors',
+      'fonts',
+      'noProofWords',
+    ]);
+    const colors = outline[1];
+    expect(colors.children.map((n) => n.label)).toEqual(['primary', 'accent']);
+    expect(colors.children[0].detail).toBe('#1B4B66');
+    expect(outline[3].detail).toBe('1 items');
+  });
+});
+
+describe('error tolerance', () => {
+  it('still outlines a document with a syntax error', () => {
+    const broken = pptxDoc.replace('"type": "bar",', '"type": "bar",,');
+    const outline = buildOutline(broken, 'pptx', 'document');
+    expect(outline.length).toBe(3);
+    expect(outline[0].label).toBe('Q2 Review');
+  });
+
+  it('returns [] for empty or hopeless input', () => {
+    expect(buildOutline('', 'pptx', 'document')).toEqual([]);
+    expect(buildOutline('not json at all', 'pptx', 'document')).toEqual([]);
+  });
+
+  it('strips collapse sentinels from labels', () => {
+    const doc = JSON.stringify({
+      name: 'docx',
+      children: [{ name: 'paragraph', props: { text: 'head §jtoc:3§ tail' } }],
+    });
+    const outline = buildOutline(doc, 'docx', 'document');
+    expect(outline[0].label).toBe('head … tail');
+  });
+});
+
+describe('collectErrorNodeIds', () => {
+  it('marks the deepest node and all ancestors', () => {
+    const outline = buildOutline(pptxDoc, 'pptx', 'document');
+    const chart = outline[1].children[1];
+    const ids = collectErrorNodeIds(outline, [chart.start + 3]);
+    expect(ids.has(chart.id)).toBe(true);
+    expect(ids.has(outline[1].id)).toBe(true);
+    expect(ids.has(outline[0].id)).toBe(false);
+  });
+});
+
+describe('computeReorderEdit', () => {
+  function apply(
+    text: string,
+    edit: { start: number; end: number; text: string }
+  ) {
+    return text.slice(0, edit.start) + edit.text + text.slice(edit.end);
+  }
+
+  it('moves a pptx slide and keeps the JSON valid and complete', () => {
+    const outline = buildOutline(pptxDoc, 'pptx', 'document');
+    const edit = computeReorderEdit(pptxDoc, outline, 0, 2);
+    expect(edit).not.toBeNull();
+    const next = apply(pptxDoc, edit!);
+    const parsed = JSON.parse(next);
+    const labels = buildOutline(next, 'pptx', 'document').map((n) => n.label);
+    expect(labels).toEqual(['Performance', 'Slide 2', 'Q2 Review']);
+    expect(parsed.children).toHaveLength(3);
+  });
+
+  it('moves a docx heading section with all its content', () => {
+    const outline = buildOutline(docxDoc, 'docx', 'document');
+    const agreement = outline[0];
+    // Move "Fees" (index 1 among Agreement's children) after "Termination"
+    const edit = computeReorderEdit(docxDoc, agreement.children, 1, 2);
+    const next = apply(docxDoc, edit!);
+    const parsed = JSON.parse(next);
+    const names = parsed.children.map(
+      (c: { name: string; props?: { text?: string } }) =>
+        c.props?.text ?? c.name
+    );
+    expect(names).toEqual([
+      'Agreement',
+      'Intro paragraph.',
+      'Termination',
+      'Termination paragraph.',
+      'Fees',
+      'Fees paragraph.',
+      'list',
+      'Annex',
+      'table',
+    ]);
+  });
+
+  it('preserves inter-item separators verbatim', () => {
+    const compact =
+      '{"name":"pptx","children":[{"name":"slide"},  {"name":"slide","props":{"notes":"b"}},\n{"name":"slide","props":{"notes":"c"}}]}';
+    const outline = buildOutline(compact, 'pptx', 'document');
+    const edit = computeReorderEdit(compact, outline, 2, 0);
+    const next = apply(compact, edit!);
+    expect(JSON.parse(next).children.map((s: any) => s.props?.notes)).toEqual([
+      'c',
+      undefined,
+      'b',
+    ]);
+    // The two separator strings (",  " and ",\n") must both survive.
+    expect(next).toContain(',  ');
+    expect(next).toContain(',\n');
+  });
+
+  it('refuses no-ops, cross-group moves, and suspicious separators', () => {
+    const outline = buildOutline(pptxDoc, 'pptx', 'document');
+    expect(computeReorderEdit(pptxDoc, outline, 1, 1)).toBeNull();
+    expect(computeReorderEdit(pptxDoc, outline, 0, 99)).toBeNull();
+    const mixed: OutlineNode[] = [
+      outline[0],
+      { ...outline[1], reorder: { ...outline[1].reorder!, groupId: 'other' } },
+    ];
+    expect(computeReorderEdit(pptxDoc, mixed, 0, 1)).toBeNull();
+  });
+});

--- a/packages/jto/src/client/lib/document-outline.ts
+++ b/packages/jto/src/client/lib/document-outline.ts
@@ -82,8 +82,13 @@ function arrayItems(n: Node | undefined): Node[] {
   return n?.type === 'array' && n.children ? n.children : [];
 }
 
-function truncate(raw: string, max = LABEL_MAX): string {
-  const clean = raw.replace(SENTINEL_RE, '…').split('\n')[0].trim();
+function truncate(raw: string, max = LABEL_MAX, joinLines = false): string {
+  const flat = raw.replace(SENTINEL_RE, '…');
+  // Titles read better joined ("WHAT IS A\nMANAGEMENT PLAN" → one label);
+  // body text keeps its first line only.
+  const clean = joinLines
+    ? flat.replace(/\s*\n\s*/g, ' ').trim()
+    : flat.split('\n')[0].trim();
   return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
 }
 
@@ -276,12 +281,44 @@ function buildChildren(childrenArr: Node | undefined): OutlineNode[] {
 }
 
 /**
- * Best slide title: first `text` child styled 'title', else the first
- * 'heading*' style, else the first text at all. Looks one container level
- * deep so grouped layouts still label their slide.
+ * Best slide title, in priority order: the authoring label `meta.title`, then
+ * a 'title' placeholder or `text` child styled 'title', then
+ * 'subtitle'/'heading*', then any text. Children are scanned one container
+ * level deep so grouped layouts still label their slide; multi-line titles
+ * are joined onto one line.
  */
 function slideLabel(slideEl: Node): string | undefined {
+  const props = propValue(slideEl, 'props');
+  const metaTitle = stringValue(propValue(propValue(props, 'meta'), 'title'));
+  if (metaTitle) return truncate(metaTitle, 48, true);
+
   let best: { rank: number; text: string } | undefined;
+  const offer = (rank: number, text: string | undefined) => {
+    if (text && (!best || rank < best.rank)) best = { rank, text };
+  };
+
+  // Template-driven decks carry their text in props.placeholders.
+  const placeholders = propValue(props, 'placeholders');
+  if (placeholders?.type === 'object' && placeholders.children) {
+    for (const prop of placeholders.children) {
+      if (prop.type !== 'property' || !prop.children) continue;
+      const [key, valueNode] = prop.children;
+      const keyName = typeof key?.value === 'string' ? key.value : '';
+      const info = valueNode ? componentInfo(valueNode) : null;
+      const text = info
+        ? stringValue(propValue(info.props, 'text'))
+        : undefined;
+      offer(
+        keyName === 'title'
+          ? 0
+          : keyName === 'subtitle' || keyName.startsWith('heading')
+            ? 1
+            : 2,
+        text
+      );
+    }
+  }
+
   const consider = (el: Node, depth: number) => {
     const info = componentInfo(el);
     if (!info) return;
@@ -289,9 +326,10 @@ function slideLabel(slideEl: Node): string | undefined {
       const text = stringValue(propValue(info.props, 'text'));
       if (text) {
         const style = stringValue(propValue(info.props, 'style')) ?? '';
-        const rank =
-          style === 'title' ? 0 : style.startsWith('heading') ? 1 : 2;
-        if (!best || rank < best.rank) best = { rank, text };
+        offer(
+          style === 'title' ? 0 : style.startsWith('heading') ? 1 : 2,
+          text
+        );
       }
     }
     if (depth < 1) {
@@ -300,7 +338,7 @@ function slideLabel(slideEl: Node): string | undefined {
     }
   };
   for (const el of arrayItems(propValue(slideEl, 'children'))) consider(el, 0);
-  return best ? truncate(best.text, 48) : undefined;
+  return best ? truncate(best.text, 48, true) : undefined;
 }
 
 function buildPptxOutline(root: Node): OutlineNode[] {

--- a/packages/jto/src/client/lib/document-outline.ts
+++ b/packages/jto/src/client/lib/document-outline.ts
@@ -171,7 +171,11 @@ function componentLabel(
       };
     }
     case 'section': {
-      const title = stringValue(propValue(props, 'title'));
+      // meta.title is the authoring label (never rendered); bare `title` is
+      // the pre-meta spelling, still honored so old documents stay navigable.
+      const title =
+        stringValue(propValue(propValue(props, 'meta'), 'title')) ??
+        stringValue(propValue(props, 'title'));
       return { label: title ? truncate(title) : 'section' };
     }
     case 'statistic': {

--- a/packages/jto/src/client/lib/document-outline.ts
+++ b/packages/jto/src/client/lib/document-outline.ts
@@ -1,0 +1,565 @@
+/**
+ * Semantic outline of a json-to-office document, built from the Monaco model
+ * text. Powers the sidebar "Outline" section: every node carries the exact
+ * character offsets of the JSON it represents, so the tree can reveal, track
+ * the cursor, badge validation errors, and reorder siblings by text surgery.
+ *
+ * Built on jsonc-parser (the parser VS Code's JSON mode uses) rather than the
+ * hand-rolled scanner in font-lens-scan.ts because the outline must survive
+ * mid-edit states: `parseTree` is error-tolerant and still yields a partial
+ * tree with correct offsets while the document is temporarily invalid.
+ *
+ * IMPORTANT: callers must feed the *model* text (with `§jtoc:<id>§` collapse
+ * sentinels), never the storage text — offsets only match what's on screen.
+ */
+import { parseTree, type Node } from 'jsonc-parser';
+import type { FormatName } from './env';
+
+export interface OutlineNode {
+  /** Positional tree path (e.g. "2.0.1") — unique within one outline snapshot. */
+  id: string;
+  /** Component name ('slide', 'heading', 'chart', …) or 'key' for theme entries. */
+  kind: string;
+  label: string;
+  /** Secondary text: style name, chart type, table size, H-level, … */
+  detail?: string;
+  /** Offset range used for reveal / cursor tracking / error mapping. */
+  start: number;
+  end: number;
+  children: OutlineNode[];
+  /** Present when this node can be reordered among siblings sharing groupId. */
+  reorder?: ReorderInfo;
+}
+
+export interface ReorderInfo {
+  /** Identifies the underlying JSON array; siblings must share it to reorder. */
+  groupId: string;
+  /**
+   * Offset range of the contiguous slice of array items this node owns. For a
+   * DOCX heading this spans the heading item plus everything until the next
+   * same-or-higher heading; for everything else it's the item's own range.
+   */
+  sliceStart: number;
+  sliceEnd: number;
+}
+
+export interface ReorderEdit {
+  start: number;
+  end: number;
+  text: string;
+}
+
+const LABEL_MAX = 60;
+const SENTINEL_RE = /§jtoc:\d+§/g;
+
+// ---------------------------------------------------------------------------
+// AST helpers
+// ---------------------------------------------------------------------------
+
+function propValue(obj: Node | undefined, key: string): Node | undefined {
+  if (!obj || obj.type !== 'object' || !obj.children) return undefined;
+  for (const prop of obj.children) {
+    if (prop.type !== 'property' || !prop.children) continue;
+    const [k, v] = prop.children;
+    if (k?.value === key) return v;
+  }
+  return undefined;
+}
+
+function stringValue(n: Node | undefined): string | undefined {
+  return n?.type === 'string' && typeof n.value === 'string'
+    ? n.value
+    : undefined;
+}
+
+function numberValue(n: Node | undefined): number | undefined {
+  return n?.type === 'number' && typeof n.value === 'number'
+    ? n.value
+    : undefined;
+}
+
+function arrayItems(n: Node | undefined): Node[] {
+  return n?.type === 'array' && n.children ? n.children : [];
+}
+
+function truncate(raw: string, max = LABEL_MAX): string {
+  const clean = raw.replace(SENTINEL_RE, '…').split('\n')[0].trim();
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+}
+
+// ---------------------------------------------------------------------------
+// Component labels
+// ---------------------------------------------------------------------------
+
+/** `columns: [{header, cells}]` (DOCX) or `rows: [[…]]` / `rows: [{cells}]` (PPTX). */
+function tableDetail(props: Node | undefined): string | undefined {
+  const columns = arrayItems(propValue(props, 'columns'));
+  if (columns.length > 0) {
+    const rows = Math.max(
+      0,
+      ...columns.map((c) => arrayItems(propValue(c, 'cells')).length)
+    );
+    return `${rows}×${columns.length}`;
+  }
+  const rows = arrayItems(propValue(props, 'rows'));
+  if (rows.length > 0) {
+    const first = rows[0];
+    const cols =
+      first?.type === 'array'
+        ? arrayItems(first).length
+        : arrayItems(propValue(first, 'cells')).length;
+    return cols > 0 ? `${rows.length}×${cols}` : `${rows.length} rows`;
+  }
+  return undefined;
+}
+
+function imageLabel(props: Node | undefined): string {
+  const alt = stringValue(propValue(props, 'alt'));
+  if (alt) return truncate(alt);
+  const src = stringValue(propValue(props, 'src'));
+  if (src) {
+    if (src.startsWith('data:')) {
+      const mime = src.slice(5).split(/[;,]/)[0];
+      return mime ? `image (${mime.split('/').pop()})` : 'image';
+    }
+    const base = src.split(/[?#]/)[0].split('/').pop();
+    if (base) return truncate(base, 40);
+  }
+  return 'image';
+}
+
+function componentLabel(
+  name: string,
+  props: Node | undefined
+): { label: string; detail?: string } {
+  const text = stringValue(propValue(props, 'text'));
+  switch (name) {
+    case 'heading': {
+      const level = numberValue(propValue(props, 'level')) ?? 1;
+      return { label: text ? truncate(text) : 'heading', detail: `H${level}` };
+    }
+    case 'text':
+      return {
+        label: text ? truncate(text) : 'text',
+        detail: stringValue(propValue(props, 'style')),
+      };
+    case 'paragraph':
+      return { label: text ? truncate(text) : 'paragraph' };
+    case 'chart':
+    case 'highcharts': {
+      const title =
+        stringValue(propValue(props, 'title')) ??
+        stringValue(propValue(propValue(props, 'options'), 'title'));
+      return {
+        label: title ? truncate(title) : name,
+        detail: stringValue(propValue(props, 'type')),
+      };
+    }
+    case 'table':
+      return { label: 'table', detail: tableDetail(props) };
+    case 'image':
+      return { label: imageLabel(props) };
+    case 'shape':
+      return {
+        label: stringValue(propValue(props, 'type')) ?? 'shape',
+      };
+    case 'list': {
+      const items = arrayItems(propValue(props, 'items'));
+      return {
+        label: 'list',
+        detail: items.length > 0 ? `${items.length} items` : undefined,
+      };
+    }
+    case 'section': {
+      const title = stringValue(propValue(props, 'title'));
+      return { label: title ? truncate(title) : 'section' };
+    }
+    case 'statistic': {
+      const value =
+        stringValue(propValue(props, 'value')) ??
+        numberValue(propValue(props, 'value'))?.toString();
+      const label = stringValue(propValue(props, 'label'));
+      return { label: truncate(label ?? value ?? 'statistic'), detail: value };
+    }
+    default:
+      return { label: text ? truncate(text) : name };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Document outlines
+// ---------------------------------------------------------------------------
+
+interface ComponentInfo {
+  name: string;
+  props: Node | undefined;
+  childrenArr: Node | undefined;
+}
+
+function componentInfo(el: Node): ComponentInfo | null {
+  if (el.type !== 'object') return null;
+  const name = stringValue(propValue(el, 'name'));
+  if (!name) return null;
+  return {
+    name,
+    props: propValue(el, 'props'),
+    childrenArr: propValue(el, 'children'),
+  };
+}
+
+/**
+ * First textual content inside a container, for label fallback. Headings and
+ * styled text win over plain paragraphs (a cover section's first paragraph is
+ * usually its display title, so paragraphs still make a decent fallback).
+ */
+function firstTextLabel(childrenArr: Node | undefined): string | undefined {
+  let paragraph: string | undefined;
+  for (const el of arrayItems(childrenArr)) {
+    const info = componentInfo(el);
+    if (!info) continue;
+    const text = stringValue(propValue(info.props, 'text'));
+    if (!text) continue;
+    if (info.name === 'heading' || info.name === 'text') {
+      return truncate(text, 48);
+    }
+    if (info.name === 'paragraph' && paragraph === undefined) {
+      paragraph = truncate(text, 48);
+    }
+  }
+  return paragraph;
+}
+
+function makeNode(
+  el: Node,
+  info: ComponentInfo,
+  reorder: ReorderInfo | undefined
+): OutlineNode {
+  let { label, detail } = componentLabel(info.name, info.props);
+  // Untitled containers borrow their first heading so a section-based
+  // document doesn't outline as a wall of identical "section" rows.
+  if (label === info.name && info.childrenArr) {
+    label = firstTextLabel(info.childrenArr) ?? label;
+  }
+  return {
+    id: '',
+    kind: info.name,
+    label,
+    detail,
+    start: el.offset,
+    end: el.offset + el.length,
+    children: buildChildren(info.childrenArr),
+    reorder,
+  };
+}
+
+/** Generic recursion into a `children` array (used inside slides/containers). */
+function buildChildren(childrenArr: Node | undefined): OutlineNode[] {
+  if (!childrenArr || childrenArr.type !== 'array') return [];
+  const groupId = `arr@${childrenArr.offset}`;
+  const out: OutlineNode[] = [];
+  for (const el of arrayItems(childrenArr)) {
+    const info = componentInfo(el);
+    if (!info) continue;
+    out.push(
+      makeNode(el, info, {
+        groupId,
+        sliceStart: el.offset,
+        sliceEnd: el.offset + el.length,
+      })
+    );
+  }
+  return out;
+}
+
+/**
+ * Best slide title: first `text` child styled 'title', else the first
+ * 'heading*' style, else the first text at all. Looks one container level
+ * deep so grouped layouts still label their slide.
+ */
+function slideLabel(slideEl: Node): string | undefined {
+  let best: { rank: number; text: string } | undefined;
+  const consider = (el: Node, depth: number) => {
+    const info = componentInfo(el);
+    if (!info) return;
+    if (info.name === 'text' || info.name === 'heading') {
+      const text = stringValue(propValue(info.props, 'text'));
+      if (text) {
+        const style = stringValue(propValue(info.props, 'style')) ?? '';
+        const rank =
+          style === 'title' ? 0 : style.startsWith('heading') ? 1 : 2;
+        if (!best || rank < best.rank) best = { rank, text };
+      }
+    }
+    if (depth < 1) {
+      for (const child of arrayItems(info.childrenArr))
+        consider(child, depth + 1);
+    }
+  };
+  for (const el of arrayItems(propValue(slideEl, 'children'))) consider(el, 0);
+  return best ? truncate(best.text, 48) : undefined;
+}
+
+function buildPptxOutline(root: Node): OutlineNode[] {
+  const childrenArr = propValue(root, 'children');
+  if (!childrenArr || childrenArr.type !== 'array') return [];
+  const groupId = `arr@${childrenArr.offset}`;
+  const out: OutlineNode[] = [];
+  let slideNumber = 0;
+  for (const el of arrayItems(childrenArr)) {
+    const info = componentInfo(el);
+    if (!info) continue;
+    const reorder: ReorderInfo = {
+      groupId,
+      sliceStart: el.offset,
+      sliceEnd: el.offset + el.length,
+    };
+    if (info.name === 'slide') {
+      slideNumber += 1;
+      out.push({
+        id: '',
+        kind: 'slide',
+        label: slideLabel(el) ?? `Slide ${slideNumber}`,
+        detail: `${slideNumber}`,
+        start: el.offset,
+        end: el.offset + el.length,
+        children: buildChildren(info.childrenArr),
+        reorder,
+      });
+    } else {
+      out.push(makeNode(el, info, reorder));
+    }
+  }
+  return out;
+}
+
+/**
+ * DOCX: headings structure the flat root `children` array into a tree. A
+ * heading node owns everything after it up to the next heading of the same or
+ * a higher level — both in the tree and in its reorder slice, so dragging a
+ * section moves its whole content.
+ */
+function buildDocxOutline(root: Node): OutlineNode[] {
+  const childrenArr = propValue(root, 'children');
+  if (!childrenArr || childrenArr.type !== 'array') return [];
+  const groupId = `arr@${childrenArr.offset}`;
+  const rootNodes: OutlineNode[] = [];
+  const stack: { level: number; node: OutlineNode }[] = [];
+
+  for (const el of arrayItems(childrenArr)) {
+    const info = componentInfo(el);
+    if (!info) continue;
+    const reorder: ReorderInfo = {
+      groupId,
+      sliceStart: el.offset,
+      sliceEnd: el.offset + el.length,
+    };
+    const target = () =>
+      stack.length ? stack[stack.length - 1].node.children : rootNodes;
+
+    if (info.name === 'heading') {
+      const level = numberValue(propValue(info.props, 'level')) ?? 1;
+      while (stack.length && stack[stack.length - 1].level >= level) {
+        stack.pop();
+      }
+      const node = makeNode(el, info, reorder);
+      target().push(node);
+      stack.push({ level, node });
+    } else {
+      target().push(makeNode(el, info, reorder));
+    }
+  }
+
+  // A heading's range/slice extends over its children so cursor tracking and
+  // drag both treat the section as one unit.
+  const extend = (node: OutlineNode): void => {
+    node.children.forEach(extend);
+    const last = node.children[node.children.length - 1];
+    if (node.kind === 'heading' && last) {
+      node.end = Math.max(node.end, last.end);
+      if (node.reorder && last.reorder) {
+        node.reorder.sliceEnd = Math.max(
+          node.reorder.sliceEnd,
+          last.reorder.sliceEnd
+        );
+      }
+    }
+  };
+  rootNodes.forEach(extend);
+  return rootNodes;
+}
+
+// ---------------------------------------------------------------------------
+// Theme outline
+// ---------------------------------------------------------------------------
+
+function themeLeafDetail(value: Node): string | undefined {
+  switch (value.type) {
+    case 'string':
+      return truncate(String(value.value ?? ''), 24);
+    case 'number':
+    case 'boolean':
+      return String(value.value);
+    case 'array':
+      return `${arrayItems(value).length} items`;
+    case 'object':
+      return undefined;
+    default:
+      return undefined;
+  }
+}
+
+function buildThemeOutline(root: Node): OutlineNode[] {
+  if (root.type !== 'object' || !root.children) return [];
+  const out: OutlineNode[] = [];
+  for (const prop of root.children) {
+    if (prop.type !== 'property' || !prop.children) continue;
+    const [key, value] = prop.children;
+    const keyName = typeof key?.value === 'string' ? key.value : undefined;
+    if (!keyName || keyName === '$schema' || !value) continue;
+    const children: OutlineNode[] = [];
+    if (value.type === 'object' && value.children) {
+      for (const sub of value.children) {
+        if (sub.type !== 'property' || !sub.children) continue;
+        const [subKey, subValue] = sub.children;
+        const subName =
+          typeof subKey?.value === 'string' ? subKey.value : undefined;
+        if (!subName || !subValue) continue;
+        children.push({
+          id: '',
+          kind: 'key',
+          label: subName,
+          detail: themeLeafDetail(subValue),
+          start: sub.offset,
+          end: sub.offset + sub.length,
+          children: [],
+        });
+      }
+    }
+    out.push({
+      id: '',
+      kind: 'key',
+      label: keyName,
+      detail: children.length === 0 ? themeLeafDetail(value) : undefined,
+      start: prop.offset,
+      end: prop.offset + prop.length,
+      children,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export type OutlineDocType = 'document' | 'theme';
+
+export function buildOutline(
+  text: string,
+  format: FormatName,
+  docType: OutlineDocType
+): OutlineNode[] {
+  if (!text.trim()) return [];
+  const root = parseTree(text, [], { allowTrailingComma: true });
+  if (!root) return [];
+  const nodes =
+    docType === 'theme'
+      ? buildThemeOutline(root)
+      : format === 'pptx'
+        ? buildPptxOutline(root)
+        : buildDocxOutline(root);
+  assignIds(nodes, '');
+  return nodes;
+}
+
+function assignIds(nodes: OutlineNode[], prefix: string): void {
+  nodes.forEach((node, i) => {
+    node.id = prefix ? `${prefix}.${i}` : `${i}`;
+    assignIds(node.children, node.id);
+  });
+}
+
+/** Deepest node whose range contains `offset` (ranges are strictly nested). */
+export function findDeepestNodeAt(
+  nodes: OutlineNode[],
+  offset: number
+): OutlineNode | null {
+  for (const node of nodes) {
+    if (offset >= node.start && offset < node.end) {
+      return findDeepestNodeAt(node.children, offset) ?? node;
+    }
+  }
+  return null;
+}
+
+/** Ids of the node containing `offset` at each depth (root-first). */
+export function pathToOffset(nodes: OutlineNode[], offset: number): string[] {
+  const path: string[] = [];
+  let list = nodes;
+  for (;;) {
+    const hit = list.find((n) => offset >= n.start && offset < n.end);
+    if (!hit) return path;
+    path.push(hit.id);
+    list = hit.children;
+  }
+}
+
+/** Every node id whose range contains at least one of the given offsets. */
+export function collectErrorNodeIds(
+  nodes: OutlineNode[],
+  offsets: number[]
+): Set<string> {
+  const out = new Set<string>();
+  for (const offset of offsets) {
+    for (const id of pathToOffset(nodes, offset)) out.add(id);
+  }
+  return out;
+}
+
+/**
+ * Text edit that moves `siblings[from]` so it lands at index `to` (indices in
+ * the current sibling order). Preserves every inter-item separator verbatim,
+ * so formatting survives untouched. Returns null when the move is invalid —
+ * slices overlapping, or a separator that doesn't hold exactly one comma
+ * (mid-edit text) — rather than risk corrupting the document.
+ */
+export function computeReorderEdit(
+  text: string,
+  siblings: OutlineNode[],
+  from: number,
+  to: number
+): ReorderEdit | null {
+  if (from === to) return null;
+  if (from < 0 || to < 0 || from >= siblings.length || to >= siblings.length) {
+    return null;
+  }
+  const slices = siblings.map((s) => s.reorder);
+  if (slices.some((s) => !s)) return null;
+  const groupId = slices[0]!.groupId;
+  if (slices.some((s) => s!.groupId !== groupId)) return null;
+  for (let i = 1; i < slices.length; i++) {
+    if (slices[i]!.sliceStart < slices[i - 1]!.sliceEnd) return null;
+  }
+
+  const pieces = slices.map((s) => text.slice(s!.sliceStart, s!.sliceEnd));
+  const separators: string[] = [];
+  for (let i = 1; i < slices.length; i++) {
+    const sep = text.slice(slices[i - 1]!.sliceEnd, slices[i]!.sliceStart);
+    if ((sep.match(/,/g) ?? []).length !== 1) return null;
+    separators.push(sep);
+  }
+
+  const order = pieces.map((_, i) => i);
+  order.splice(to, 0, order.splice(from, 1)[0]);
+
+  let out = '';
+  order.forEach((idx, pos) => {
+    out += pieces[idx];
+    if (pos < separators.length) out += separators[pos];
+  });
+  return {
+    start: slices[0]!.sliceStart,
+    end: slices[slices.length - 1]!.sliceEnd,
+    text: out,
+  };
+}

--- a/packages/jto/src/client/lib/monaco-collapse-strings.ts
+++ b/packages/jto/src/client/lib/monaco-collapse-strings.ts
@@ -60,6 +60,14 @@ export interface CollapseController {
   isApplyingEdits(): boolean;
   /** True if a marker range falls inside a currently-collapsed value. */
   isRangeCollapsed(range: IRange): boolean;
+  /**
+   * Re-anchor chip decorations to their sentinels' current positions. Call
+   * after an edit that MOVES text wholesale (outline drag-reorder, undo of
+   * one): Monaco collapses decorations that sat inside a replaced range, but
+   * the sentinel text itself travels with the edit and carries its id, so the
+   * decoration can always be rebuilt at the sentinel's new location.
+   */
+  resyncDecorations(): void;
   dispose(): void;
 }
 
@@ -521,6 +529,61 @@ export function installLongStringCollapser(
         if (r && rangesOverlap(r, range)) return true;
       }
       return false;
+    },
+
+    resyncDecorations() {
+      const model = editorInstance.getModel();
+      if (!model || tracked.size === 0) return;
+      const text = model.getValue();
+      for (const t of [...tracked.values()]) {
+        if (t.expanded) {
+          // The full value is plain text in the model; if the collapse chip
+          // still marks exactly that text, keep it — otherwise drop the entry
+          // (the value simply stays expanded).
+          const r = model.getDecorationRange(t.decorationId);
+          if (!r || model.getValueInRange(r) !== t.middle) {
+            editorInstance.deltaDecorations([t.decorationId], []);
+            tracked.delete(t.id);
+          }
+          continue;
+        }
+        const sentinel = makeSentinel(t.id);
+        const offset = text.indexOf(sentinel);
+        if (offset === -1) {
+          // Sentinel text was destroyed by an edit; the hidden middle is gone
+          // the same way it would be if the user deleted the chip directly.
+          editorInstance.deltaDecorations([t.decorationId], []);
+          tracked.delete(t.id);
+          continue;
+        }
+        const start = model.getPositionAt(offset);
+        const end = model.getPositionAt(offset + sentinel.length);
+        const current = model.getDecorationRange(t.decorationId);
+        if (
+          current &&
+          current.startLineNumber === start.lineNumber &&
+          current.startColumn === start.column &&
+          current.endLineNumber === end.lineNumber &&
+          current.endColumn === end.column
+        ) {
+          continue; // already anchored correctly
+        }
+        const [decorationId] = editorInstance.deltaDecorations(
+          [t.decorationId],
+          [
+            {
+              range: new monaco.Range(
+                start.lineNumber,
+                start.column,
+                end.lineNumber,
+                end.column
+              ),
+              options: collapsedDecoration(t.middle.length),
+            },
+          ]
+        );
+        t.decorationId = decorationId;
+      }
     },
 
     dispose() {

--- a/packages/jto/src/client/public/templates/Alternative deck 16_9.pptx.json
+++ b/packages/jto/src/client/public/templates/Alternative deck 16_9.pptx.json
@@ -2133,6 +2133,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Cover with stats"
+        },
         "template": "COVER_STATS_TEMPLATE",
         "notes": "Cover variant with at-a-glance metrics and customer logo strip.",
         "placeholders": {
@@ -2231,6 +2234,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Text + visual split"
+        },
         "template": "TEXT_VISUAL_TEMPLATE",
         "notes": "Text + visual split — narrative left, visual right on dark panel.",
         "placeholders": {
@@ -2259,6 +2265,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Image + text split"
+        },
         "template": "IMG_TEXT_TEMPLATE",
         "notes": "Image + text split — visual left, narrative and stats right.",
         "placeholders": {
@@ -2358,6 +2367,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Timeline"
+        },
         "template": "TIMELINE_TEMPLATE",
         "notes": "Timeline / process — four-step horizontal flow.",
         "placeholders": {
@@ -2451,6 +2463,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Market sizing"
+        },
         "template": "MARKET_TEMPLATE",
         "notes": "Market sizing — three big-stat columns with footnote.",
         "placeholders": {
@@ -2532,6 +2547,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Unit economics"
+        },
         "template": "UNIT_ECONOMICS_TEMPLATE",
         "notes": "Unit economics — six metric tiles on dark canvas.",
         "placeholders": {
@@ -2685,6 +2703,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Revenue breakdown"
+        },
         "template": "REVENUE_BREAKDOWN_TEMPLATE",
         "notes": "Revenue breakdown — chart left, segment cards right.",
         "placeholders": {
@@ -2810,6 +2831,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Pricing tiers"
+        },
         "template": "PRICING_TEMPLATE",
         "notes": "Pricing — three tiers with highlighted middle plan.",
         "placeholders": {
@@ -2943,6 +2967,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Fundraise ask"
+        },
         "template": "FUNDRAISE_TEMPLATE",
         "notes": "Fundraise ask — headline amount with three use-of-funds tiles.",
         "placeholders": {

--- a/packages/jto/src/client/public/templates/Brand template 16_9.pptx.json
+++ b/packages/jto/src/client/public/templates/Brand template 16_9.pptx.json
@@ -1609,6 +1609,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Cover"
+        },
         "template": "COVER",
         "placeholders": {
           "preTitle": {
@@ -1642,6 +1645,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Section divider"
+        },
         "template": "SECTION_DIVIDER",
         "placeholders": {
           "ghostNumber": {
@@ -1675,6 +1681,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Content"
+        },
         "template": "CONTENT",
         "placeholders": {
           "section": {
@@ -1711,6 +1720,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Two-column comparison"
+        },
         "template": "TWO_COLUMN",
         "placeholders": {
           "section": {
@@ -1756,6 +1768,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Metrics"
+        },
         "template": "METRICS",
         "placeholders": {
           "section": {
@@ -1901,6 +1916,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Chart"
+        },
         "template": "CHART",
         "placeholders": {
           "section": {
@@ -1958,6 +1976,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Closing"
+        },
         "template": "CLOSING",
         "placeholders": {
           "preheading": {

--- a/packages/jto/src/client/public/templates/Company deck 16_9.pptx.json
+++ b/packages/jto/src/client/public/templates/Company deck 16_9.pptx.json
@@ -4567,6 +4567,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Cover"
+        },
         "template": "COVER_TEMPLATE",
         "notes": "Cover slide with mock title and subtitle.",
         "placeholders": {
@@ -4594,6 +4597,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Three columns"
+        },
         "template": "THREE_COL_TEMPLATE",
         "notes": "Three parallel propositions on a light background.",
         "placeholders": {
@@ -4720,6 +4726,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Stacked points (dark)"
+        },
         "template": "STACKED_POINTS_DARK_TEMPLATE",
         "notes": "Three numbered narrative points on a dark background.",
         "placeholders": {
@@ -4798,6 +4807,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Three columns (dark)"
+        },
         "template": "THREE_COL_DARK_TEMPLATE",
         "notes": "Three stacked modules on dark background.",
         "placeholders": {
@@ -4927,6 +4939,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Comparison table"
+        },
         "template": "COMPARISON_TEMPLATE",
         "notes": "Mock table illustrating the comparison layout.",
         "placeholders": {
@@ -5073,6 +5088,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "KPI dashboard"
+        },
         "template": "DASHBOARD_TEMPLATE",
         "notes": "KPI cards above a chart.",
         "placeholders": {
@@ -5190,6 +5208,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Three tiers + narrative"
+        },
         "template": "THREE_COL_NARRATIVE_TEMPLATE",
         "notes": "Three tiered options with a narrative summary below.",
         "placeholders": {
@@ -5340,6 +5361,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Two columns + narrative"
+        },
         "template": "TWO_COL_NARRATIVE_TEMPLATE",
         "notes": "Two contrasting columns with a shared narrative.",
         "placeholders": {
@@ -5398,6 +5422,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Quote"
+        },
         "template": "QUOTE_TEMPLATE",
         "notes": "Standalone testimonial slide.",
         "placeholders": {
@@ -5426,6 +5453,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Logo grid"
+        },
         "template": "LOGO_GRID_TEMPLATE",
         "notes": "Customer logo wall with a footnote. Logos are placeholders.",
         "placeholders": {
@@ -5609,6 +5639,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Doughnut chart"
+        },
         "template": "CHART_TEMPLATE",
         "notes": "Full-width doughnut chart.",
         "placeholders": {
@@ -5660,6 +5693,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Big stat"
+        },
         "template": "BIG_STAT_TEMPLATE",
         "notes": "A single hero statistic.",
         "placeholders": {
@@ -5693,6 +5729,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "KPI cards (dark)"
+        },
         "template": "METRICS_TEMPLATE",
         "notes": "Four KPI cards on a dark background.",
         "placeholders": {
@@ -5794,6 +5833,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Insight + table"
+        },
         "template": "INSIGHT_TEMPLATE",
         "notes": "A sourced insight paired with a defensibility table.",
         "placeholders": {
@@ -5925,6 +5967,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Stacked points"
+        },
         "template": "STACKED_POINTS_TEMPLATE",
         "notes": "Three numbered growth levers on a light background.",
         "placeholders": {
@@ -6007,6 +6052,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Team"
+        },
         "template": "TEAM_TEMPLATE",
         "notes": "Four-person founder/team layout.",
         "placeholders": {
@@ -6124,6 +6172,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Section divider (azure)"
+        },
         "template": "SECTION_AZURE_TEMPLATE",
         "notes": "Section divider (azure) — use to introduce major sections.",
         "placeholders": {
@@ -6152,6 +6203,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Section divider (light)"
+        },
         "template": "SECTION_LIGHT_TEMPLATE",
         "notes": "Section divider (light blue) — alternate section break.",
         "placeholders": {
@@ -6180,6 +6234,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Two-column content"
+        },
         "template": "TWO_COL_TEMPLATE",
         "notes": "Two-column content — narrative left, bullets right.",
         "placeholders": {
@@ -6231,6 +6288,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Closing"
+        },
         "template": "CLOSING_TEMPLATE",
         "notes": "Closing slide with a single call to action.",
         "placeholders": {

--- a/packages/jto/src/client/public/templates/Company deck 4_3.pptx.json
+++ b/packages/jto/src/client/public/templates/Company deck 4_3.pptx.json
@@ -4253,6 +4253,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Cover"
+        },
         "template": "COVER_TEMPLATE",
         "notes": "Cover slide — customize title, subtitle, and date",
         "placeholders": {
@@ -4281,6 +4284,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Section divider (azure)"
+        },
         "template": "SECTION_AZURE_TEMPLATE",
         "notes": "Section divider (azure) — use to introduce major sections",
         "placeholders": {
@@ -4309,6 +4315,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Text + visual split"
+        },
         "template": "TEXT_VISUAL_TEMPLATE",
         "notes": "Text + visual split — narrative left, visual right on dark panel",
         "placeholders": {
@@ -4337,6 +4346,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Three-column features"
+        },
         "template": "THREE_COL_TEMPLATE",
         "notes": "Three-column feature cards with icons",
         "placeholders": {
@@ -4463,6 +4475,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "KPI dashboard"
+        },
         "template": "METRICS_TEMPLATE",
         "notes": "KPI / metrics dashboard — dark background with 4 metric cards",
         "placeholders": {
@@ -4596,6 +4611,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Two-column content"
+        },
         "template": "TWO_COL_TEMPLATE",
         "notes": "Two-column content — narrative left, custom bullets right",
         "placeholders": {
@@ -4647,6 +4665,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Bar chart"
+        },
         "template": "CHART_TEMPLATE",
         "notes": "Bar chart — revenue growth by quarter",
         "placeholders": {
@@ -4699,6 +4720,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Quote"
+        },
         "template": "QUOTE_TEMPLATE",
         "notes": "Quote / testimonial — centered on dark slate background",
         "placeholders": {
@@ -4727,6 +4751,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Timeline"
+        },
         "template": "TIMELINE_TEMPLATE",
         "notes": "Timeline / process — four-step horizontal flow",
         "placeholders": {
@@ -4820,6 +4847,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Section divider (light)"
+        },
         "template": "SECTION_LIGHT_TEMPLATE",
         "notes": "Section divider (light blue) — alternate section break",
         "placeholders": {
@@ -4848,6 +4878,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Image + text split"
+        },
         "template": "IMG_TEXT_TEMPLATE",
         "notes": "Image + text split — visual left, narrative and stats right",
         "placeholders": {
@@ -4947,6 +4980,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Comparison table"
+        },
         "template": "COMPARISON_TEMPLATE",
         "notes": "Comparison table — competitive differentiation",
         "placeholders": {
@@ -5162,6 +5198,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Team grid"
+        },
         "template": "TEAM_TEMPLATE",
         "notes": "Team grid — four team member cards with avatars and bios",
         "placeholders": {
@@ -5279,6 +5318,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Big stat"
+        },
         "template": "BIG_STAT_TEMPLATE",
         "notes": "Big stat — single dramatic metric for maximum impact",
         "placeholders": {
@@ -5312,6 +5354,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Closing"
+        },
         "template": "CLOSING_TEMPLATE",
         "notes": "Closing slide — thank you with contact details",
         "placeholders": {

--- a/packages/jto/src/client/public/templates/data-report-presentation.pptx.json
+++ b/packages/jto/src/client/public/templates/data-report-presentation.pptx.json
@@ -167,6 +167,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Cover"
+        },
         "background": {
           "color": "background"
         },
@@ -268,6 +271,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Trend analysis"
+        },
         "background": {
           "color": "secondary"
         },
@@ -483,6 +489,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Areas for growth"
+        },
         "background": {
           "color": "accent"
         },
@@ -716,6 +725,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Revenue model"
+        },
         "background": {
           "color": "accent4"
         },
@@ -850,6 +862,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Current data trend"
+        },
         "background": {
           "color": "primary"
         },
@@ -1054,6 +1069,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Graphic data"
+        },
         "background": {
           "color": "text"
         },
@@ -1172,6 +1190,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Progress reveal"
+        },
         "background": {
           "color": "accent5"
         },
@@ -1408,6 +1429,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Data insights"
+        },
         "background": {
           "color": "background"
         },
@@ -1736,6 +1760,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Nested-circles insight"
+        },
         "background": {
           "color": "accent"
         },
@@ -1959,6 +1986,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Doughnut gauges"
+        },
         "background": {
           "color": "text"
         },
@@ -2192,6 +2222,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Four options"
+        },
         "background": {
           "color": "secondary"
         },
@@ -2414,6 +2447,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Three-angle data"
+        },
         "background": {
           "color": "accent4"
         },
@@ -2570,6 +2606,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Our data growth"
+        },
         "background": {
           "color": "background"
         },
@@ -2765,6 +2804,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Understanding model"
+        },
         "background": {
           "color": "accent5"
         },
@@ -2961,6 +3003,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Data review"
+        },
         "background": {
           "color": "primary"
         },

--- a/packages/jto/src/client/public/templates/management-plan.pptx.json
+++ b/packages/jto/src/client/public/templates/management-plan.pptx.json
@@ -192,7 +192,7 @@
         "background": {
           "color": "secondary"
         },
-        "notes": "Cover \u2014 Management Plan 2025."
+        "notes": "Cover — Management Plan 2025."
       },
       "children": [
         {
@@ -469,7 +469,7 @@
       "name": "slide",
       "props": {
         "template": "grid",
-        "notes": "Key objectives \u2014 01 Efficiency, 02 Accountability, 03 Coordination, 04 Growth."
+        "notes": "Key objectives — 01 Efficiency, 02 Accountability, 03 Coordination, 04 Growth."
       },
       "children": [
         {
@@ -793,7 +793,7 @@
       "name": "slide",
       "props": {
         "template": "grid",
-        "notes": "What is a management plan \u2014 definition, purpose, importance."
+        "notes": "What is a management plan — definition, purpose, importance."
       },
       "children": [
         {
@@ -931,7 +931,7 @@
       "name": "slide",
       "props": {
         "template": "grid",
-        "notes": "Vision and mission connection \u2014 company vision vs mission."
+        "notes": "Vision and mission connection — company vision vs mission."
       },
       "children": [
         {
@@ -1002,7 +1002,7 @@
             "y": 3.213,
             "w": 3.05,
             "h": 0.4,
-            "text": "COMPANY\u2019S VISION"
+            "text": "COMPANY’S VISION"
           }
         },
         {
@@ -1081,7 +1081,7 @@
             "y": 3.213,
             "w": 3.05,
             "h": 0.4,
-            "text": "COMPANY\u2019S MISSION",
+            "text": "COMPANY’S MISSION",
             "color": "background"
           }
         },
@@ -1255,7 +1255,7 @@
       "name": "slide",
       "props": {
         "template": "grid",
-        "notes": "Strategic priorities \u2014 +122% with short/medium/long-term cards."
+        "notes": "Strategic priorities — +122% with short/medium/long-term cards."
       },
       "children": [
         {
@@ -1492,7 +1492,7 @@
         "background": {
           "color": "secondary"
         },
-        "notes": "Operational workflow \u2014 4 steps with arrows."
+        "notes": "Operational workflow — 4 steps with arrows."
       },
       "children": [
         {
@@ -1742,7 +1742,7 @@
       "name": "slide",
       "props": {
         "template": "grid",
-        "notes": "Managing resources \u2014 25M total resource donut gauge."
+        "notes": "Managing resources — 25M total resource donut gauge."
       },
       "children": [
         {
@@ -1926,6 +1926,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Process grid"
+        },
         "template": "grid",
         "notes": "Process grid 01-06 with flow arrows."
       },
@@ -2307,6 +2310,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Communication channels"
+        },
         "template": "grid",
         "notes": "Internal & external communication; 5K stat tile."
       },
@@ -2656,7 +2662,7 @@
       "name": "slide",
       "props": {
         "template": "grid",
-        "notes": "Mitigating risks \u2014 photos, who we serve, +122%."
+        "notes": "Mitigating risks — photos, who we serve, +122%."
       },
       "children": [
         {
@@ -2927,7 +2933,7 @@
         "background": {
           "color": "secondary"
         },
-        "notes": "Adapting to change \u2014 short-term 46K-55K card over photo."
+        "notes": "Adapting to change — short-term 46K-55K card over photo."
       },
       "children": [
         {
@@ -3183,7 +3189,7 @@
             "fontSize": 21,
             "fontFace": "Archivo",
             "lineSpacing": 25.2,
-            "text": "46K \u2013 55K",
+            "text": "46K – 55K",
             "color": "background"
           }
         }
@@ -3193,7 +3199,7 @@
       "name": "slide",
       "props": {
         "template": "grid",
-        "notes": "Budget & forecasting \u2014 76K/46K/56K stats and cards."
+        "notes": "Budget & forecasting — 76K/46K/56K stats and cards."
       },
       "children": [
         {
@@ -3398,7 +3404,7 @@
             "fontSize": 21,
             "fontFace": "Archivo",
             "lineSpacing": 25.2,
-            "text": "46K \u2013 55K",
+            "text": "46K – 55K",
             "color": "text"
           }
         },
@@ -3453,7 +3459,7 @@
             "fontSize": 21,
             "fontFace": "Archivo",
             "lineSpacing": 25.2,
-            "text": "46K \u2013 55K",
+            "text": "46K – 55K",
             "color": "background"
           }
         },
@@ -3575,7 +3581,7 @@
       "name": "slide",
       "props": {
         "template": "grid",
-        "notes": "Change management \u2014 4 photo/caption columns."
+        "notes": "Change management — 4 photo/caption columns."
       },
       "children": [
         {
@@ -3821,7 +3827,7 @@
       "name": "slide",
       "props": {
         "template": "grid",
-        "notes": "Sustainable practices \u2014 two banners 01/02."
+        "notes": "Sustainable practices — two banners 01/02."
       },
       "children": [
         {
@@ -4018,7 +4024,7 @@
         "background": {
           "color": "secondary"
         },
-        "notes": "Growing our people \u2014 photo band and blue bar chart card."
+        "notes": "Growing our people — photo band and blue bar chart card."
       },
       "children": [
         {
@@ -4494,7 +4500,7 @@
       "name": "slide",
       "props": {
         "template": "grid",
-        "notes": "Compliance framework \u2014 25M, 20/43/78%, +43,43% potential risks."
+        "notes": "Compliance framework — 25M, 20/43/78%, +43,43% potential risks."
       },
       "children": [
         {
@@ -4809,7 +4815,7 @@
       "name": "slide",
       "props": {
         "template": "grid",
-        "notes": "Tracking progress \u2014 20/40/60/76% donut gauges."
+        "notes": "Tracking progress — 20/40/60/76% donut gauges."
       },
       "children": [
         {
@@ -5033,8 +5039,11 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Team member"
+        },
         "template": "grid",
-        "notes": "Team member \u2014 portraits and blue info card."
+        "notes": "Team member — portraits and blue info card."
       },
       "children": [
         {
@@ -5313,7 +5322,7 @@
       "name": "slide",
       "props": {
         "template": "grid",
-        "notes": "Moving forward \u2014 contact strip and photo."
+        "notes": "Moving forward — contact strip and photo."
       },
       "children": [
         {
@@ -5648,7 +5657,7 @@
         "background": {
           "color": "secondary"
         },
-        "notes": "Thank you for watching \u2014 contact info."
+        "notes": "Thank you for watching — contact info."
       },
       "children": [
         {

--- a/packages/jto/src/client/public/templates/minimalist-pitch-deck.pptx.json
+++ b/packages/jto/src/client/public/templates/minimalist-pitch-deck.pptx.json
@@ -161,6 +161,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Cover"
+        },
         "background": {
           "gradient": {
             "type": "radial",
@@ -833,6 +836,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Market gap chart"
+        },
         "background": {
           "gradient": {
             "type": "radial",
@@ -1708,6 +1714,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Case timeline"
+        },
         "template": "dawn-diagonal",
         "notes": "Arc timeline with four cases."
       },
@@ -2057,6 +2066,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Market overview"
+        },
         "template": "haze-bottom-left",
         "notes": "Market overview pies."
       },
@@ -2298,6 +2310,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Target audience"
+        },
         "background": {
           "gradient": {
             "type": "radial",
@@ -2503,6 +2518,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Competitive landscape"
+        },
         "template": "veil-bottom-right",
         "notes": "Competitive landscape stats and images."
       },
@@ -2686,6 +2704,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Laptop mockup"
+        },
         "template": "veil-top-left",
         "notes": "Laptop mockup slide."
       },
@@ -2815,6 +2836,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Values"
+        },
         "template": "dawn-diagonal",
         "notes": "Values list and percent column."
       },
@@ -2976,6 +3000,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Revenue KPIs"
+        },
         "template": "haze-bottom-left",
         "notes": "Revenue KPIs."
       },
@@ -3123,6 +3150,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Focus areas diagram"
+        },
         "background": {
           "gradient": {
             "type": "radial",
@@ -3724,6 +3754,9 @@
     {
       "name": "slide",
       "props": {
+        "meta": {
+          "title": "Thank you"
+        },
         "background": {
           "gradient": {
             "type": "radial",

--- a/packages/jto/src/client/public/templates/modern-annual-report-1.docx.json
+++ b/packages/jto/src/client/public/templates/modern-annual-report-1.docx.json
@@ -79,7 +79,8 @@
             "bottom": 36,
             "left": 36
           }
-        }
+        },
+        "pageBreak": false
       },
       "children": [
         {
@@ -348,17 +349,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -728,17 +736,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -954,17 +969,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -1464,17 +1486,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -1622,17 +1651,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -1943,17 +1979,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -2422,17 +2465,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -2976,17 +3026,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -3098,17 +3155,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -3399,17 +3463,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -3973,17 +4044,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -4851,17 +4929,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -5957,17 +6042,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -6710,17 +6802,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -7157,17 +7256,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -7517,17 +7623,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -7901,17 +8014,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -8132,17 +8252,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -8365,17 +8492,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -8728,17 +8862,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -9239,17 +9380,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -10264,17 +10412,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {
@@ -10590,17 +10745,24 @@
               }
             }
           ]
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 36,
+            "right": 36,
+            "bottom": 36,
+            "left": 36
           }
         },
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "image",
           "props": {

--- a/packages/jto/src/client/public/templates/modern-annual-report-1.docx.json
+++ b/packages/jto/src/client/public/templates/modern-annual-report-1.docx.json
@@ -71,6 +71,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Cover"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -355,6 +358,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Table of contents"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -742,6 +748,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "CEO message"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -975,6 +984,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Company overview"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -1492,6 +1504,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "About us"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -1657,6 +1672,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Business focus"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -1985,6 +2003,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Global presence"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -2471,6 +2492,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Mission & long-term vision"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -3032,6 +3056,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Vision & values"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -3161,6 +3188,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Operational highlights"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -3469,6 +3499,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Achievement overview"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -4050,6 +4083,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Financial metrics"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -4935,6 +4971,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Income statement"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -6048,6 +6087,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Balance sheet"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -6808,6 +6850,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Balance sheet (continued)"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -7262,6 +7307,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Business model & strategy"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -7629,6 +7677,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Shareholding structure"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -8020,6 +8071,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Company statement"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -8258,6 +8312,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Market outlook"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -8498,6 +8555,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Environmental & social"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -8868,6 +8928,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Awards & recognition"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -9386,6 +9449,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Key financial ratios"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -10418,6 +10484,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Closing statement"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -10751,6 +10820,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Back cover"
+        },
         "page": {
           "size": "A4",
           "margins": {

--- a/packages/jto/src/client/public/templates/modern-annual-report-2.docx.json
+++ b/packages/jto/src/client/public/templates/modern-annual-report-2.docx.json
@@ -45,7 +45,8 @@
           }
         },
         "header": [],
-        "footer": []
+        "footer": [],
+        "pageBreak": false
       },
       "children": [
         {
@@ -394,7 +395,7 @@
         {
           "name": "paragraph",
           "props": {
-            "text": "\u00a9",
+            "text": "©",
             "font": {
               "size": 28,
               "color": "background",
@@ -627,17 +628,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -1457,17 +1467,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -1653,7 +1672,7 @@
         {
           "name": "paragraph",
           "props": {
-            "text": "CEO \u2013 Your Company",
+            "text": "CEO – Your Company",
             "font": {
               "size": 18
             },
@@ -1882,17 +1901,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -2420,17 +2448,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -2787,17 +2824,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -3341,17 +3387,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -3950,17 +4005,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -4508,17 +4572,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -5029,17 +5102,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -5362,7 +5444,7 @@
         {
           "name": "paragraph",
           "props": {
-            "text": "40% OY \u2013 USD 1.42B",
+            "text": "40% OY – USD 1.42B",
             "font": {
               "size": 18,
               "lineSpacing": {
@@ -5754,17 +5836,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -6809,17 +6900,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -7776,17 +7876,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -8593,17 +8702,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -9674,17 +9792,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -10561,17 +10688,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -10984,17 +11120,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -11586,17 +11731,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -11897,7 +12051,7 @@
         {
           "name": "paragraph",
           "props": {
-            "text": "Grow by 8\u201310% in 2051, driven by rapid adoption of AI, cloud, and cybersecurity solutions.",
+            "text": "Grow by 8–10% in 2051, driven by rapid adoption of AI, cloud, and cybersecurity solutions.",
             "font": {
               "size": 18,
               "color": "primary",
@@ -11956,7 +12110,7 @@
         {
           "name": "paragraph",
           "props": {
-            "text": "projects revenue growth of 10\u201312% and net profit expansion of 9% in FY2052, supported by scalable platforms, a recurring revenue model, and disciplined capital expenditure.",
+            "text": "projects revenue growth of 10–12% and net profit expansion of 9% in FY2052, supported by scalable platforms, a recurring revenue model, and disciplined capital expenditure.",
             "font": {
               "size": 18,
               "color": "primary",
@@ -12040,17 +12194,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -12390,7 +12553,7 @@
         {
           "name": "paragraph",
           "props": {
-            "text": "The company\u2019s annual ",
+            "text": "The company’s annual ",
             "font": {
               "size": 18,
               "color": "primary",
@@ -12500,17 +12663,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -12803,17 +12975,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -13414,17 +13595,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -14341,17 +14531,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -14420,7 +14619,7 @@
         {
           "name": "paragraph",
           "props": {
-            "text": "AUDITOR \u2013 YOUR COMPANY",
+            "text": "AUDITOR – YOUR COMPANY",
             "font": {
               "size": 18,
               "lineSpacing": {
@@ -14666,7 +14865,7 @@
         {
           "name": "paragraph",
           "props": {
-            "text": "AUDITOR\u2019S",
+            "text": "AUDITOR’S",
             "font": {
               "size": 36,
               "bold": true,
@@ -14728,17 +14927,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "pageBreak": true,
-            "font": {
-              "size": 8
-            }
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -15094,7 +15302,7 @@
         {
           "name": "paragraph",
           "props": {
-            "text": "LET\u2019S MOVE TOGETHER",
+            "text": "LET’S MOVE TOGETHER",
             "font": {
               "size": 30,
               "color": "background",
@@ -15305,7 +15513,7 @@
         {
           "name": "paragraph",
           "props": {
-            "text": "\u00a9",
+            "text": "©",
             "font": {
               "size": 28,
               "color": "background",

--- a/packages/jto/src/client/public/templates/modern-annual-report-2.docx.json
+++ b/packages/jto/src/client/public/templates/modern-annual-report-2.docx.json
@@ -35,6 +35,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Cover"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -634,6 +637,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Table of contents"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -1473,6 +1479,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "CEO message"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -1907,6 +1916,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Company overview"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -2454,6 +2466,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "About us"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -2830,6 +2845,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Business focus"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -3393,6 +3411,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Global presence"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -4011,6 +4032,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Mission & long-term value"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -4578,6 +4602,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Business model & strategy"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -5108,6 +5135,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Performance overview"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -5842,6 +5872,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Financial highlights"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -6906,6 +6939,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Income statement"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -7882,6 +7918,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Shareholding structure"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -8708,6 +8747,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Financial summary"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -9798,6 +9840,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Shareholder breakdown"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -10694,6 +10739,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "ESG pillars"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -11126,6 +11174,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Sustainability & ESG"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -11737,6 +11788,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Market outlook"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -12200,6 +12254,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Stakeholder engagement"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -12669,6 +12726,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Human capital development"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -12981,6 +13041,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Awards"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -13601,6 +13664,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Future outlook"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -14537,6 +14603,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Auditor's summary"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -14933,6 +15002,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Back cover"
+        },
         "page": {
           "size": "A4",
           "margins": {

--- a/packages/jto/src/client/public/templates/modern-annual-report-3.docx.json
+++ b/packages/jto/src/client/public/templates/modern-annual-report-3.docx.json
@@ -33,6 +33,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Cover"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -410,6 +413,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Table of contents"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -823,6 +829,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "CEO message"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -1146,6 +1155,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Company overview"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -1614,6 +1626,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "About us"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -1894,6 +1909,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Business focus"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -2464,6 +2482,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Global presence"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -3140,6 +3161,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Vision & milestones"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -3775,6 +3799,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Operational framework"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -4175,6 +4202,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Performance overview"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -4910,6 +4940,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Financial highlights"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -5896,6 +5929,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Income statement"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -7041,6 +7077,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Shareholding structure"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -7518,6 +7557,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Balance sheet"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -8299,6 +8341,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Shareholder breakdown"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -9119,6 +9164,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Risk management"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -9456,6 +9504,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Environmental initiatives"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -9853,6 +9904,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Growth outlook"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -10262,6 +10316,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Stakeholder engagement"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -10501,6 +10558,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Human capital development"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -10825,6 +10885,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Awards"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -11265,6 +11328,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Key financial ratios"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -12425,6 +12491,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Auditor's summary"
+        },
         "page": {
           "size": "A4",
           "margins": {
@@ -12838,6 +12907,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Back cover"
+        },
         "page": {
           "size": "A4",
           "margins": {

--- a/packages/jto/src/client/public/templates/modern-annual-report-3.docx.json
+++ b/packages/jto/src/client/public/templates/modern-annual-report-3.docx.json
@@ -43,7 +43,8 @@
           }
         },
         "header": [],
-        "footer": []
+        "footer": [],
+        "pageBreak": false
       },
       "children": [
         {
@@ -403,21 +404,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -811,21 +817,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -1129,21 +1140,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -1592,21 +1608,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -1867,21 +1888,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -2432,21 +2458,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -3103,21 +3134,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -3733,21 +3769,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -4128,21 +4169,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -4858,21 +4904,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -5839,21 +5890,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -6979,21 +7035,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -7451,21 +7512,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -8227,21 +8293,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -9042,21 +9113,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -9374,21 +9450,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -9766,21 +9847,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -10170,21 +10256,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -10404,21 +10495,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -10723,21 +10819,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -11158,21 +11259,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -12313,21 +12419,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {
@@ -12721,21 +12832,26 @@
               }
             }
           }
-        },
-        {
-          "name": "paragraph",
-          "props": {
-            "text": "",
-            "font": {
-              "size": 8,
-              "lineSpacing": {
-                "type": "exactly",
-                "value": 8
-              }
-            },
-            "pageBreak": true
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "props": {
+        "page": {
+          "size": "A4",
+          "margins": {
+            "top": 1440,
+            "right": 1440,
+            "bottom": 1440,
+            "left": 1440
           }
         },
+        "header": [],
+        "footer": [],
+        "pageBreak": true
+      },
+      "children": [
         {
           "name": "visual",
           "props": {

--- a/packages/jto/src/client/public/templates/standard-annual-report.docx.json
+++ b/packages/jto/src/client/public/templates/standard-annual-report.docx.json
@@ -78,6 +78,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Cover"
+        },
         "header": [],
         "footer": [],
         "pageBreak": false
@@ -320,7 +323,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Table of contents"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -727,7 +734,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Letter from the CEO"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -931,7 +942,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Key figures"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -1315,7 +1330,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Our culture"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -1709,7 +1728,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Board of directors"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -2051,7 +2074,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Company values"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -2564,7 +2591,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Business management"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -2898,7 +2929,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Client results"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -3330,7 +3365,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Future growth strategies"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -3793,7 +3832,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Revenue by service"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -4146,7 +4189,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Project highlight"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -4483,7 +4530,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Project details"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -4750,7 +4801,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Financial strategy"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -5070,7 +5125,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Market analysis"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -5943,7 +6002,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Targets & projections"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -6355,7 +6418,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Marketing goals"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -6708,7 +6775,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Global market"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -6994,7 +7065,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Looking ahead"
+        }
+      },
       "children": [
         {
           "name": "image",
@@ -7297,7 +7372,11 @@
     },
     {
       "name": "section",
-      "props": {},
+      "props": {
+        "meta": {
+          "title": "Back cover"
+        }
+      },
       "children": [
         {
           "name": "image",

--- a/packages/jto/src/client/public/templates/tech-report.docx.json
+++ b/packages/jto/src/client/public/templates/tech-report.docx.json
@@ -80,6 +80,9 @@
     {
       "name": "section",
       "props": {
+        "meta": {
+          "title": "Cover"
+        },
         "header": [],
         "footer": [],
         "pageBreak": false
@@ -351,7 +354,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Table of contents"
+        }
+      }
     },
     {
       "name": "section",
@@ -756,7 +764,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Contents overview"
+        }
+      }
     },
     {
       "name": "section",
@@ -939,7 +952,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Letter from the CEO"
+        }
+      }
     },
     {
       "name": "section",
@@ -1285,7 +1303,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Company overview"
+        }
+      }
     },
     {
       "name": "section",
@@ -1611,7 +1634,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Key highlights"
+        }
+      }
     },
     {
       "name": "section",
@@ -1902,7 +1930,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Business highlights"
+        }
+      }
     },
     {
       "name": "section",
@@ -2124,7 +2157,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Vision, mission & purpose"
+        }
+      }
     },
     {
       "name": "section",
@@ -2496,7 +2534,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Revenue mix"
+        }
+      }
     },
     {
       "name": "section",
@@ -2784,7 +2827,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Market trends & insights"
+        }
+      }
     },
     {
       "name": "section",
@@ -3065,7 +3113,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Regional presence"
+        }
+      }
     },
     {
       "name": "section",
@@ -3356,7 +3409,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Business segments"
+        }
+      }
     },
     {
       "name": "section",
@@ -3578,7 +3636,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "R&D & innovation"
+        }
+      }
     },
     {
       "name": "section",
@@ -3810,7 +3873,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "ESG & sustainability"
+        }
+      }
     },
     {
       "name": "section",
@@ -4113,7 +4181,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "People & culture"
+        }
+      }
     },
     {
       "name": "section",
@@ -4238,7 +4311,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Financial performance"
+        }
+      }
     },
     {
       "name": "section",
@@ -4634,7 +4712,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Profitability"
+        }
+      }
     },
     {
       "name": "section",
@@ -5010,7 +5093,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Global footprint"
+        }
+      }
     },
     {
       "name": "section",
@@ -5313,7 +5401,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Key deals"
+        }
+      }
     },
     {
       "name": "section",
@@ -5422,7 +5515,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Risk control"
+        }
+      }
     },
     {
       "name": "section",
@@ -5893,7 +5991,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Risk factors"
+        }
+      }
     },
     {
       "name": "section",
@@ -6153,7 +6256,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Future outlook"
+        }
+      }
     },
     {
       "name": "section",
@@ -6318,7 +6426,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Partners & testimonials"
+        }
+      }
     },
     {
       "name": "section",
@@ -6497,7 +6610,12 @@
             }
           }
         }
-      ]
+      ],
+      "props": {
+        "meta": {
+          "title": "Contact information"
+        }
+      }
     }
   ]
 }

--- a/packages/jto/src/client/store/editor-refs-store.ts
+++ b/packages/jto/src/client/store/editor-refs-store.ts
@@ -6,6 +6,7 @@
 import { create } from 'zustand';
 import type { editor as MonacoEditorType } from 'monaco-editor';
 import type { Monaco } from '@monaco-editor/react';
+import type { CollapseController } from '../lib/monaco-collapse-strings';
 
 export interface EditorReference {
   editor: MonacoEditorType.IStandaloneCodeEditor;
@@ -18,6 +19,12 @@ export interface EditorReference {
    * MUST pipe it through this, or sentinels leak into the output.
    */
   toStorageValue: (modelText: string) => string;
+  /**
+   * Long-string collapse controller for this editor, when installed. Consumers
+   * that apply edits which MOVE model text (e.g. the outline drag-reorder)
+   * must call `collapse.resyncDecorations()` afterwards so chips re-anchor.
+   */
+  collapse?: CollapseController;
 }
 
 interface EditorRefsState {
@@ -30,7 +37,8 @@ interface EditorRefsActions {
     documentName: string,
     editor: MonacoEditorType.IStandaloneCodeEditor,
     monaco: Monaco,
-    toStorageValue?: (modelText: string) => string
+    toStorageValue?: (modelText: string) => string,
+    collapse?: CollapseController
   ) => void;
   unregisterEditor: (documentName: string) => void;
   setActiveEditor: (documentName: string | null) => void;
@@ -44,7 +52,7 @@ export const useEditorRefsStore = create<EditorRefsStore>((set, get) => ({
   editors: new Map(),
   activeEditorName: null,
 
-  registerEditor: (documentName, editor, monaco, toStorageValue) => {
+  registerEditor: (documentName, editor, monaco, toStorageValue, collapse) => {
     set((state) => {
       const newEditors = new Map(state.editors);
       newEditors.set(documentName, {
@@ -52,6 +60,7 @@ export const useEditorRefsStore = create<EditorRefsStore>((set, get) => ({
         monaco,
         documentName,
         toStorageValue: toStorageValue ?? ((text) => text),
+        collapse,
       });
       return { editors: newEditors };
     });

--- a/packages/jto/src/server/prompts/instructions-docx.md
+++ b/packages/jto/src/server/prompts/instructions-docx.md
@@ -33,7 +33,7 @@ A DOCX document is an array of component objects. Use `Report` as the root conta
 ## Design Patterns
 
 - **Heading hierarchy**: use level 1 once (document title), level 2 for major sections, level 3 for subsections
-- **Section grouping**: wrap related content in a `Section` for page break control
+- **Section grouping**: wrap related content in a `Section` for page break control; label it with `"meta": { "title": "..." }` (authoring-only, never rendered) so editors show a navigable outline
 - **Side-by-side content**: use `Columns` for comparisons, before/after, or multi-column layouts
 - **Data presentation**: use `Table` for structured data, `Statistic` for key metrics
 - **Readability**: alternate between Paragraphs, Tables, and Lists — avoid long runs of the same component

--- a/packages/shared-docx/src/schemas/components/section.ts
+++ b/packages/shared-docx/src/schemas/components/section.ts
@@ -9,18 +9,21 @@ import { SpacingSchema } from './common';
 export const createSectionPropsSchema = (componentRef?: TSchema) =>
   Type.Object(
     {
-      title: Type.Optional(
-        Type.String({
-          description: 'Section title (optional)',
-        })
-      ),
-      level: Type.Optional(
-        Type.Number({
-          minimum: 1,
-          maximum: 9,
-          description: 'Heading level for section title (1-9)',
-          default: 1,
-        })
+      meta: Type.Optional(
+        Type.Object(
+          {
+            title: Type.Optional(
+              Type.String({
+                description:
+                  'Authoring label for this section, shown in editors and outlines. Never rendered — add a heading child for a visible title.',
+              })
+            ),
+          },
+          {
+            additionalProperties: false,
+            description: 'Authoring metadata; has no effect on the document.',
+          }
+        )
       ),
       header: Type.Optional(
         Type.Union([

--- a/packages/shared-pptx/src/schemas/components/slide.ts
+++ b/packages/shared-pptx/src/schemas/components/slide.ts
@@ -7,6 +7,22 @@ import { SlideBackgroundSchema, TransitionSchema } from './common';
 
 export const SlidePropsSchema = Type.Object(
   {
+    meta: Type.Optional(
+      Type.Object(
+        {
+          title: Type.Optional(
+            Type.String({
+              description:
+                'Authoring label for this slide, shown in editors and outlines. Never rendered — slide content is unaffected.',
+            })
+          ),
+        },
+        {
+          additionalProperties: false,
+          description: 'Authoring metadata; has no effect on the presentation.',
+        }
+      )
+    ),
     background: Type.Optional(SlideBackgroundSchema),
     transition: Type.Optional(TransitionSchema),
     notes: Type.Optional(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
       idb-keyval:
         specifier: ^6.2.2
         version: 6.2.2
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       jsonrepair:
         specifier: ^3.13.3
         version: 3.13.3
@@ -4019,6 +4022,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -9337,6 +9343,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsonfile@4.0.0:
     optionalDependencies:


### PR DESCRIPTION
## Summary

Adds a semantic **Outline** panel to the playground sidebar and introduces **`meta.title`** authoring labels on DOCX sections and PPTX slides, then restructures/labels the stock templates so every document ships with a navigable table of contents.

- **Playground outline**: sidebar section outlining the active tab (slides / heading hierarchy / theme keys) with two-way Monaco sync, validation-error badges, and drag-to-reorder (single undoable edit; collapse-sentinel safe via the new `resyncDecorations()`).
- **Template restructure**: `modern-annual-report-1/2/3` split from one ~400-component section into one section per page — pixel-identical LibreOffice renders on all 24 pages of each.
- **DOCX `section.meta.title`** (breaking): replaces `title`/`level` (which synthesized a heading); render-inert, byte-identical `document.xml`. All docx templates/examples get curated labels.
- **PPTX `slide.meta.title`** (additive): symmetric labels; outline derivation also learned template placeholders and multi-line title joining; stock decks curated.

*Note: merged via rebase before a follow-up conformance fix landed on the branch — the fix for `core-docx` shipped templates still using `section.level` follows in a separate PR.*