### PR TITLE
fix(schemas): export name unions as if/then discriminated unions

### DIFF
--- a/.changeset/name-completion-hints.md
+++ b/.changeset/name-completion-hints.md
@@ -1,0 +1,39 @@
+---
+'@json-to-office/shared': minor
+'@json-to-office/shared-docx': patch
+'@json-to-office/shared-pptx': patch
+'@json-to-office/jto': patch
+---
+
+Exported component unions are now canonical if/then discriminated unions —
+fixing both component-name autocomplete and union diagnostics.
+
+Monaco / VS Code resolve a partially-typed node against a flat `anyOf` by
+keeping the single best-matching branch. While typing `{ "name": | }`, every
+branch requiring `props` failed validation, so its name never reached
+autocomplete (a section's children suggested only `image`, `text-box`, `toc`),
+and diagnostics reported one arbitrary branch's complaints — `Missing property
+"props"` plus `Value must be "heading"` — instead of the real problem.
+
+`restructureNameDiscriminatedUnions` (new export from `@json-to-office/shared`,
+applied inside both `convertToJsonSchema` implementations, JSON-Schema export
+only — runtime TypeBox validation is untouched) rewrites each
+name-discriminated union into `properties.name` (the discriminator enum, with
+per-component descriptions) plus `allOf[].if/then` dispatch. The accepted
+document set is exactly the same — verified by parity tests and ajv over all
+shipped templates — but editors now behave deterministically:
+
+- completing `name` offers every legal component, with its description
+- an empty component reports only `Missing property "name"`
+- an empty or wrong name reports only `Value is not accepted. Valid values: …`
+- a valid name activates exactly its branch for keys, props and errors
+
+`unionBranches` (also exported) iterates branch objects shape-agnostically for
+consumers that post-process them. Standard component branches additionally
+carry their registry `description`. Versioned plugin branches stay grouped in
+a small `anyOf` inside their `then`.
+
+Plugin toggles also round-trip exactly: the playground sends its selection as
+an explicit `plugins=` query (empty means "no plugins") and the discovery
+endpoint honors it, instead of treating an empty selection as "all registered
+plugins". Only a missing param still falls back to everything.

--- a/packages/jto/src/client/lib/json-schema-generator.ts
+++ b/packages/jto/src/client/lib/json-schema-generator.ts
@@ -323,17 +323,18 @@ export function generateMonacoSchemaConfigs(): MonacoSchemaConfig[] {
 function enhanceSchemaDescriptions(schema: any): void {
   if (typeof schema !== 'object' || schema === null) return;
 
-  if (schema.anyOf) {
-    schema.anyOf.forEach((subSchema: any) => {
-      if (subSchema.properties?.name?.const) {
-        const componentType = subSchema.properties.name?.const;
-        subSchema.description = getComponentDescription(componentType);
+  // A component branch — wherever it sits: flat `anyOf` union or the
+  // restructured if/then dispatch (`allOf[].then`).
+  if (typeof schema.properties?.name?.const === 'string') {
+    const componentType = schema.properties.name.const;
+    // Registry descriptions (attached at generation) win; fill gaps only.
+    if (!schema.description) {
+      schema.description = getComponentDescription(componentType);
+    }
 
-        if (subSchema.properties?.props) {
-          enhancePropsDescriptions(componentType, subSchema.properties.props);
-        }
-      }
-    });
+    if (schema.properties?.props) {
+      enhancePropsDescriptions(componentType, schema.properties.props);
+    }
   }
 
   Object.values(schema).forEach((value) => {

--- a/packages/jto/src/client/lib/monaco-config.ts
+++ b/packages/jto/src/client/lib/monaco-config.ts
@@ -12,6 +12,7 @@ import {
 import { schemaService } from './schema-service';
 import { registerFontCodeLens } from './monaco-fonts-codelens';
 import { registerMonacoThemes } from './monaco-theme';
+import { unionBranches } from '@json-to-office/shared';
 
 let isConfigured = false;
 let completionDisposable: { dispose(): void } | null = null;
@@ -188,11 +189,9 @@ function injectCustomThemeNames(schema: any, themeNames: string[]): void {
   // Direct path (docx schema)
   inject(schema?.properties?.props?.properties?.theme);
 
-  // anyOf branches (pptx schema)
-  if (Array.isArray(schema?.anyOf)) {
-    for (const branch of schema.anyOf) {
-      inject(branch?.properties?.props?.properties?.theme);
-    }
+  // Union branches (pptx schema) — flat anyOf or restructured if/then dispatch
+  for (const branch of unionBranches(schema)) {
+    inject((branch as any)?.properties?.props?.properties?.theme);
   }
 }
 

--- a/packages/jto/src/client/lib/schema-service.ts
+++ b/packages/jto/src/client/lib/schema-service.ts
@@ -23,13 +23,15 @@ class SchemaService {
    * @param pluginNames Optional array of plugin names to include in the schema
    */
   async fetchDocumentSchema(pluginNames?: string[]): Promise<any> {
-    // Create cache key based on plugins
-    const cacheKey = pluginNames?.length
+    // Create cache key based on plugins. An explicit selection (even [])
+    // is cached apart from the "unspecified" default, which the server
+    // resolves to every registered plugin.
+    const cacheKey = pluginNames
       ? `document-${pluginNames.sort().join(',')}`
       : 'document';
 
     // Check cache first
-    if (pluginNames?.length) {
+    if (pluginNames) {
       const cached = this.pluginSchemaCache.get(cacheKey);
       if (cached && this.isCacheValid(cacheKey)) {
         return cached;
@@ -39,9 +41,11 @@ class SchemaService {
     }
 
     try {
-      // Build URL with plugin query params
+      // Build URL with plugin query params. An explicit selection is always
+      // sent — `plugins=` (empty) tells the server "no plugins", instead of
+      // silently falling back to the all-plugins default.
       let url = `${API_BASE_URL}/discovery/schemas/document`;
-      if (pluginNames?.length) {
+      if (pluginNames) {
         // eslint-disable-next-line no-undef
         const params = new URLSearchParams();
         params.append('plugins', pluginNames.join(','));
@@ -63,7 +67,7 @@ class SchemaService {
       }
 
       // Cache the schema
-      if (pluginNames?.length) {
+      if (pluginNames) {
         if (this.pluginSchemaCache.size >= this.MAX_PLUGIN_CACHE) {
           const firstKey = this.pluginSchemaCache.keys().next().value;
           if (firstKey) this.pluginSchemaCache.delete(firstKey);

--- a/packages/jto/src/client/lib/schema-service.ts
+++ b/packages/jto/src/client/lib/schema-service.ts
@@ -27,7 +27,7 @@ class SchemaService {
     // is cached apart from the "unspecified" default, which the server
     // resolves to every registered plugin.
     const cacheKey = pluginNames
-      ? `document-${pluginNames.sort().join(',')}`
+      ? `document-${[...pluginNames].sort().join(',')}`
       : 'document';
 
     // Check cache first

--- a/packages/jto/src/server/routes/discovery.ts
+++ b/packages/jto/src/server/routes/discovery.ts
@@ -33,7 +33,10 @@ function getSelectedPlugins(pluginNames?: string[]) {
   const registry = PluginRegistry.getInstance();
   if (!registry.hasPlugins()) return [];
 
-  const plugins = pluginNames?.length
+  // An explicit array is an exact selection — [] means "no plugins", so a
+  // playground with every plugin toggled off gets the plugin-free schema.
+  // Only an absent selection falls back to every registered plugin.
+  const plugins = pluginNames
     ? pluginNames.map((n) => registry.getPlugin(n)).filter(Boolean)
     : registry.getPlugins();
 
@@ -292,9 +295,12 @@ discoveryRouter.get('/schemas/document', async (c) => {
   try {
     const adapter = Container.getAdapter();
     const pluginsParam = c.req.query('plugins');
-    const pluginNames = pluginsParam
-      ? pluginsParam.split(',').filter(Boolean)
-      : undefined;
+    // `?plugins=` (empty) is an explicit "no plugins"; only a missing param
+    // means "all registered plugins".
+    const pluginNames =
+      pluginsParam !== undefined
+        ? pluginsParam.split(',').filter(Boolean)
+        : undefined;
     const schema = await generateDocumentSchema(adapter.name, pluginNames);
     return c.json({ success: true, data: schema });
   } catch (error: any) {

--- a/packages/shared-docx/package.json
+++ b/packages/shared-docx/package.json
@@ -48,7 +48,8 @@
   "devDependencies": {
     "@types/node": "20.11.0",
     "tsup": "8.5.0",
-    "typescript": "5.3.3"
+    "typescript": "5.3.3",
+    "vscode-json-languageservice": "5.4.0"
   },
   "license": "MIT",
   "author": "Paolo Barbato",

--- a/packages/shared-docx/src/__tests__/name-completion-hints.test.ts
+++ b/packages/shared-docx/src/__tests__/name-completion-hints.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Component-name autocomplete must offer EVERY component legal at the cursor,
+ * not just the ones that happen to validate without `props`.
+ *
+ * Monaco / VS Code (vscode-json-languageservice) resolve value completions in
+ * an `anyOf` by keeping only branches that validate cleanly against the
+ * partially-typed node. While typing `{ "name": | }`, every branch requiring
+ * `props` fails, so its name const vanished from autocomplete — the playground
+ * suggested only `image`, `text-box`, `toc` inside a section.
+ *
+ * The exported schema restructures each name-discriminated union into the
+ * canonical if/then dispatch (see @json-to-office/shared discriminated-unions):
+ * `properties.name` lists every component, `allOf[].then` activates exactly
+ * the named branch. Completion offers everything; diagnostics report the one
+ * real problem instead of an arbitrary best-match branch's complaints.
+ *
+ * These tests drive the real language service (the same library Monaco embeds)
+ * against the real exported schema, so a regression in either the generator
+ * shape or the union restructuring turns them red.
+ */
+import { describe, it, expect } from 'vitest';
+import { Type } from '@sinclair/typebox';
+import { getLanguageService, TextDocument } from 'vscode-json-languageservice';
+import { generateUnifiedDocumentSchema } from '../schemas/generator';
+import { convertToJsonSchema } from '../schemas/export';
+import { getStandardComponent } from '../schemas/component-registry';
+
+function completionsAt(schema: Record<string, unknown>, text: string) {
+  const ls = getLanguageService({});
+  ls.configure({
+    allowComments: false,
+    schemas: [{ uri: 'test://doc', fileMatch: ['*.json'], schema }],
+  });
+  const doc = TextDocument.create('test://d.json', 'json', 1, text);
+  const jsonDoc = ls.parseJSONDocument(doc);
+  // cursor inside the last `"name": ""` value — the discriminator being typed
+  const offset = text.lastIndexOf('{"name":"') + '{"name":"'.length;
+  return ls
+    .doComplete(doc, doc.positionAt(offset), jsonDoc)
+    .then((list) => (list?.items ?? []).map((i) => i.label.replace(/"/g, '')));
+}
+
+const standardSchema = convertToJsonSchema(
+  generateUnifiedDocumentSchema({ customComponents: [] })
+) as Record<string, unknown>;
+
+describe('component name autocomplete', () => {
+  it('offers every allowed component inside section children', async () => {
+    const labels = await completionsAt(
+      standardSchema,
+      '{"name":"docx","children":[{"name":"section","children":[{"name":""}]}]}'
+    );
+    const allowed = getStandardComponent('section')!.allowedChildren!;
+    for (const name of allowed) expect(labels).toContain(name);
+    // narrowing still applies: bare sections don't nest
+    expect(labels).not.toContain('section');
+    expect(labels).not.toContain('docx');
+  });
+
+  it('offers section plus content components at the document root', async () => {
+    const labels = await completionsAt(
+      standardSchema,
+      '{"name":"docx","children":[{"name":""}]}'
+    );
+    expect(labels).toContain('section');
+    expect(labels).toContain('heading');
+    expect(labels).toContain('paragraph');
+    expect(labels).not.toContain('docx');
+  });
+
+  it('offers plugin components, including versioned ones requiring props', async () => {
+    const weatherProps = Type.Object(
+      { city: Type.String() },
+      { additionalProperties: false }
+    );
+    const pluginSchema = convertToJsonSchema(
+      generateUnifiedDocumentSchema({
+        customComponents: [
+          {
+            name: 'weather',
+            propsSchema: weatherProps,
+            description: 'Weather component',
+            versionedProps: [
+              { version: '1.0.0', propsSchema: weatherProps },
+              { version: '2.0.0', propsSchema: weatherProps },
+            ],
+          },
+        ],
+      })
+    ) as Record<string, unknown>;
+    const labels = await completionsAt(
+      pluginSchema,
+      '{"name":"docx","children":[{"name":"section","children":[{"name":""}]}]}'
+    );
+    expect(labels).toContain('weather');
+    expect(labels).toContain('heading');
+  });
+
+  it('keeps validation strict: props still required where demanded', async () => {
+    const diagnostics = await diagnosticsFor(
+      '{"name":"docx","children":[{"name":"section","children":[{"name":"heading"}]}]}'
+    );
+    expect(diagnostics).toEqual(['Missing property "props".']);
+  });
+
+  it('reports only the discriminator error while name is empty or wrong', async () => {
+    for (const name of ['', 'bogus']) {
+      const diagnostics = await diagnosticsFor(
+        `{"name":"docx","children":[{"name":"section","children":[{"name":"${name}"}]}]}`
+      );
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]).toMatch(/Value is not accepted. Valid values:/);
+      expect(diagnostics[0]).toContain('"heading"');
+      expect(diagnostics[0]).toContain('"paragraph"');
+    }
+  });
+
+  it('reports only the missing discriminator on an empty component', async () => {
+    const diagnostics = await diagnosticsFor(
+      '{"name":"docx","children":[{"name":"section","children":[{}]}]}'
+    );
+    expect(diagnostics).toEqual(['Missing property "name".']);
+  });
+
+  it('accepts valid documents, propless components included', async () => {
+    const diagnostics = await diagnosticsFor(
+      '{"name":"docx","children":[{"name":"section","children":[{"name":"toc"},{"name":"heading","props":{"text":"Hi"}}]}]}'
+    );
+    expect(diagnostics).toEqual([]);
+  });
+});
+
+async function diagnosticsFor(text: string): Promise<string[]> {
+  const ls = getLanguageService({});
+  const doc = TextDocument.create('test://d.json', 'json', 1, text);
+  const diagnostics = await ls.doValidation(
+    doc,
+    ls.parseJSONDocument(doc),
+    {},
+    standardSchema as never
+  );
+  return diagnostics.map((d) => d.message);
+}

--- a/packages/shared-docx/src/__tests__/optional-props-schema.test.ts
+++ b/packages/shared-docx/src/__tests__/optional-props-schema.test.ts
@@ -18,6 +18,7 @@ import { Value } from '@sinclair/typebox/value';
 import { generateUnifiedDocumentSchema } from '../schemas/generator';
 import { convertToJsonSchema } from '../schemas/export';
 import { validateStrict } from '../validation/unified';
+import { unionBranches } from '@json-to-office/shared';
 
 const exported = generateUnifiedDocumentSchema({ customComponents: [] });
 
@@ -28,12 +29,14 @@ function inSection(child: Record<string, unknown>) {
 
 function variantRequired(name: string): string[] {
   const json = convertToJsonSchema(exported) as Record<string, any>;
-  const variants = json.definitions.ComponentDefinition.anyOf;
+  // Exported unions are restructured into if/then dispatch — iterate the
+  // branch objects shape-agnostically.
+  const variants = unionBranches(json.definitions.ComponentDefinition);
   const variant = variants.find(
     (v: any) => v?.properties?.name?.const === name
   );
   expect(variant, `no exported variant for "${name}"`).toBeDefined();
-  return variant.required ?? [];
+  return (variant as any).required ?? [];
 }
 
 // Props schemas with no required field: a bare `{ name }` is a valid node.

--- a/packages/shared-docx/src/__tests__/root-children-schema.test.ts
+++ b/packages/shared-docx/src/__tests__/root-children-schema.test.ts
@@ -12,14 +12,16 @@ import { Value } from '@sinclair/typebox/value';
 import { generateUnifiedDocumentSchema } from '../schemas/generator';
 import { convertToJsonSchema } from '../schemas/export';
 import { getStandardComponent } from '../schemas/component-registry';
+import { unionBranches } from '@json-to-office/shared';
 
 function rootChildNames(): string[] {
   const json = convertToJsonSchema(
     generateUnifiedDocumentSchema({ customComponents: [] })
   ) as Record<string, any>;
   const items = json.properties.children.items;
-  const variants = items.anyOf ?? items.oneOf ?? [items];
-  return variants
+  const variants = unionBranches(items);
+  const branches = variants.length > 0 ? variants : [items];
+  return branches
     .map((v: any) => v?.properties?.name?.const)
     .filter(Boolean) as string[];
 }

--- a/packages/shared-docx/src/__tests__/visual-schema-export.test.ts
+++ b/packages/shared-docx/src/__tests__/visual-schema-export.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { convertToJsonSchema } from '@json-to-office/shared';
+import { convertToJsonSchema, unionBranches } from '@json-to-office/shared';
 import { generateUnifiedDocumentSchema } from '../schemas/generator';
 
 function collectRefs(value: unknown, refs: string[] = []): string[] {
@@ -24,7 +24,11 @@ describe('visual JSON Schema export', () => {
       Record<string, unknown>
     >;
     const slideContent = definitions.PptxSlideContent;
-    const variants = slideContent.anyOf as Array<Record<string, unknown>>;
+    // Exported unions are restructured into if/then dispatch — iterate the
+    // branch objects shape-agnostically.
+    const variants = unionBranches(slideContent) as Array<
+      Record<string, unknown>
+    >;
 
     expect(
       Object.keys(definitions).filter((name) => name === 'PptxSlideContent')

--- a/packages/shared-docx/src/schemas/component-registry.ts
+++ b/packages/shared-docx/src/schemas/component-registry.ts
@@ -352,7 +352,10 @@ export function createComponentSchemaObject(
       : Type.Optional(Type.Array(childrenType));
   }
 
-  return Type.Object(schema, { additionalProperties: false });
+  return Type.Object(schema, {
+    additionalProperties: false,
+    description: component.description,
+  });
 }
 
 /**

--- a/packages/shared-docx/src/schemas/export.ts
+++ b/packages/shared-docx/src/schemas/export.ts
@@ -6,6 +6,7 @@
  */
 
 import { TSchema } from '@sinclair/typebox';
+import { restructureNameDiscriminatedUnions } from '@json-to-office/shared';
 import { getContainerComponents } from './component-registry';
 
 /**
@@ -180,6 +181,9 @@ export function convertToJsonSchema(
 
   // Fix any remaining recursive references
   fixSchemaReferences(jsonSchema);
+
+  // Canonical if/then dispatch for `name`-discriminated unions (editor UX)
+  restructureNameDiscriminatedUnions(jsonSchema);
 
   return jsonSchema;
 }

--- a/packages/shared-pptx/src/schemas/component-registry.ts
+++ b/packages/shared-pptx/src/schemas/component-registry.ts
@@ -153,7 +153,10 @@ export function createPptxComponentSchemaObject(
     );
   }
 
-  return Type.Object(schema, { additionalProperties: false });
+  return Type.Object(schema, {
+    additionalProperties: false,
+    description: component.description,
+  });
 }
 
 export function createAllPptxComponentSchemas(

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -36,6 +36,10 @@ export {
   exportSchemaToFile,
 } from './schemas/schema-utils';
 export type { ComponentSchemaConfig } from './schemas/schema-utils';
+export {
+  restructureNameDiscriminatedUnions,
+  unionBranches,
+} from './schemas/discriminated-unions';
 
 // Validation - unified system
 export {

--- a/packages/shared/src/schemas/__tests__/discriminated-unions.test.ts
+++ b/packages/shared/src/schemas/__tests__/discriminated-unions.test.ts
@@ -91,6 +91,19 @@ describe('restructureNameDiscriminatedUnions', () => {
     expect(conflicting.properties.name).toEqual({ type: 'string' });
   });
 
+  it('skips unions with a sibling additionalProperties', () => {
+    // With no sibling `properties`, `additionalProperties: false` rejects
+    // every key — declaring `name` in the rewrite would start allowing it.
+    const schema: any = {
+      anyOf: [branch('heading'), branch('image')],
+      additionalProperties: false,
+    };
+    restructureNameDiscriminatedUnions(schema);
+    expect(schema.anyOf).toBeDefined();
+    expect(schema.allOf).toBeUndefined();
+    expect(schema.properties).toBeUndefined();
+  });
+
   it('recurses into nested children unions and is idempotent', () => {
     const inner = { anyOf: [branch('heading'), branch('image')] };
     const section = branch('section', {

--- a/packages/shared/src/schemas/__tests__/discriminated-unions.test.ts
+++ b/packages/shared/src/schemas/__tests__/discriminated-unions.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import {
+  restructureNameDiscriminatedUnions,
+  unionBranches,
+} from '../discriminated-unions';
+
+function branch(name: string, extra: Record<string, unknown> = {}) {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: { name: { const: name, type: 'string' } },
+    required: ['name', 'props'],
+    ...extra,
+  };
+}
+
+describe('restructureNameDiscriminatedUnions', () => {
+  it('rewrites a name union into the if/then dispatch shape', () => {
+    const heading = branch('heading', { description: 'Heading element' });
+    const image = branch('image');
+    const schema: any = { items: { anyOf: [heading, image] } };
+    restructureNameDiscriminatedUnions(schema);
+
+    const items = schema.items;
+    expect(items.anyOf).toBeUndefined();
+    expect(items.type).toBe('object');
+    expect(items.required).toEqual(['name']);
+    expect(items.properties.name.anyOf).toEqual([
+      { const: 'heading', type: 'string', description: 'Heading element' },
+      { const: 'image', type: 'string' },
+    ]);
+    expect(items.allOf).toEqual([
+      {
+        if: { properties: { name: { const: 'heading' } }, required: ['name'] },
+        then: heading,
+      },
+      {
+        if: { properties: { name: { const: 'image' } }, required: ['name'] },
+        then: image,
+      },
+    ]);
+  });
+
+  it('groups versioned plugin branches under one then, preferring the un-versioned description', () => {
+    const v1 = branch('weather', { description: 'weather v1.0.0 — legacy' });
+    (v1.properties as any).version = { const: '1.0.0', type: 'string' };
+    const fallback = branch('weather', {
+      description: 'weather (latest: v2.0.0) — mock',
+    });
+    const schema: any = { anyOf: [v1, fallback, branch('heading')] };
+    restructureNameDiscriminatedUnions(schema);
+
+    expect(schema.properties.name.anyOf).toEqual([
+      {
+        const: 'weather',
+        type: 'string',
+        description: 'weather (latest: v2.0.0) — mock',
+      },
+      { const: 'heading', type: 'string' },
+    ]);
+    expect(schema.allOf).toHaveLength(2);
+    expect(schema.allOf[0].then).toEqual({ anyOf: [v1, fallback] });
+    expect(schema.allOf[1].then.properties.name.const).toBe('heading');
+  });
+
+  it('skips unions with $ref, free-form branches, or name not required', () => {
+    const withRef: any = {
+      anyOf: [branch('heading'), { $ref: '#/definitions/ComponentDefinition' }],
+    };
+    const withPlain: any = { anyOf: [branch('heading'), { type: 'string' }] };
+    const optionalName: any = {
+      anyOf: [branch('heading'), { ...branch('image'), required: [] }],
+    };
+    for (const s of [withRef, withPlain, optionalName]) {
+      restructureNameDiscriminatedUnions(s);
+      expect(s.anyOf).toBeDefined();
+      expect(s.allOf).toBeUndefined();
+    }
+  });
+
+  it('skips single-branch unions and nodes with conflicting keywords', () => {
+    const single: any = { anyOf: [branch('heading')] };
+    const conflicting: any = {
+      anyOf: [branch('heading'), branch('image')],
+      properties: { name: { type: 'string' } },
+    };
+    restructureNameDiscriminatedUnions(single);
+    restructureNameDiscriminatedUnions(conflicting);
+    expect(single.allOf).toBeUndefined();
+    expect(conflicting.anyOf).toBeDefined();
+    expect(conflicting.properties.name).toEqual({ type: 'string' });
+  });
+
+  it('recurses into nested children unions and is idempotent', () => {
+    const inner = { anyOf: [branch('heading'), branch('image')] };
+    const section = branch('section', {
+      properties: {
+        name: { const: 'section', type: 'string' },
+        children: { type: 'array', items: inner },
+      },
+      required: ['name'],
+    });
+    const schema: any = { anyOf: [section, branch('paragraph')] };
+    restructureNameDiscriminatedUnions(schema);
+    restructureNameDiscriminatedUnions(schema);
+
+    expect(schema.allOf).toHaveLength(2);
+    const sectionThen = schema.allOf[0].then;
+    const nested = sectionThen.properties.children.items;
+    expect(nested.anyOf).toBeUndefined();
+    expect(nested.allOf).toHaveLength(2);
+    expect(nested.properties.name.anyOf.map((e: any) => e.const)).toEqual([
+      'heading',
+      'image',
+    ]);
+  });
+
+  it('preserves node-level description and discriminator', () => {
+    const schema: any = {
+      description: 'Component definition',
+      discriminator: { propertyName: 'name' },
+      anyOf: [branch('heading'), branch('image')],
+    };
+    restructureNameDiscriminatedUnions(schema);
+    expect(schema.description).toBe('Component definition');
+    expect(schema.discriminator).toEqual({ propertyName: 'name' });
+  });
+});
+
+describe('unionBranches', () => {
+  it('iterates branches in both the flat and restructured shapes', () => {
+    const flat: any = { anyOf: [branch('heading'), branch('image')] };
+    const restructured: any = {
+      anyOf: [branch('heading'), branch('weather'), branch('weather')],
+    };
+    restructureNameDiscriminatedUnions(restructured);
+
+    expect(unionBranches(flat)).toHaveLength(2);
+    const names = unionBranches(restructured).map(
+      (b: any) => b.properties.name.const
+    );
+    expect(names).toEqual(['heading', 'weather', 'weather']);
+    expect(unionBranches({ type: 'string' })).toEqual([]);
+  });
+});

--- a/packages/shared/src/schemas/discriminated-unions.ts
+++ b/packages/shared/src/schemas/discriminated-unions.ts
@@ -1,0 +1,195 @@
+/**
+ * Canonical `if/then` restructuring for name-discriminated component unions.
+ *
+ * The generators export component unions as a flat `anyOf`. Schema-driven
+ * editors (Monaco, VS Code — vscode-json-languageservice) resolve a partially
+ * typed node against an `anyOf` by picking the single best-matching branch:
+ * while typing `{ "name": | }`, every branch requiring `props` fails
+ * validation, so its name const never reached autocomplete, and diagnostics
+ * reported one arbitrary branch's complaints ("Value must be \"heading\"",
+ * "Missing property \"props\"") instead of the real problem.
+ *
+ * This transform rewrites each such union — at JSON-Schema export time only,
+ * the runtime TypeBox validators are untouched — into the standard
+ * discriminated-union dispatch:
+ *
+ *   {
+ *     type: "object",
+ *     required: ["name"],
+ *     properties: { name: { anyOf: [{ const, description }, …] } },
+ *     allOf: [
+ *       { if: { properties: { name: { const } }, required: ["name"] },
+ *         then: <branch> },
+ *       …
+ *     ]
+ *   }
+ *
+ * The accepted set of documents is exactly the same — `properties.name` is
+ * the enum the branches already imply, and each `then` is the original
+ * branch — but editors now behave deterministically:
+ * - completing `name` offers every component, with its description
+ * - an empty object reports only `Missing property "name"`
+ * - a wrong name reports only `Value is not accepted. Valid values: …`
+ * - a valid name activates exactly its branch for keys, props and errors
+ *
+ * Standard draft-07 keywords only, so ajv and every schema-aware editor
+ * agree. Versioned plugin branches share a name; they stay grouped in a
+ * small `anyOf` inside their `then`, containing best-match ambiguity to the
+ * component's own versions.
+ */
+
+interface SchemaNode {
+  [key: string]: unknown;
+}
+
+interface NameConstEntry {
+  const: string;
+  type: 'string';
+  description?: string;
+}
+
+/** A union branch shaped `{ properties: { name: { const: "..." } } }`. */
+function branchNameConst(branch: unknown): string | undefined {
+  if (typeof branch !== 'object' || branch === null || Array.isArray(branch))
+    return undefined;
+  const name = ((branch as SchemaNode).properties as SchemaNode | undefined)
+    ?.name as SchemaNode | undefined;
+  return typeof name?.const === 'string' ? name.const : undefined;
+}
+
+/** True when the branch also discriminates on a `version` const (plugins). */
+function isVersionedBranch(branch: SchemaNode): boolean {
+  const version = (branch.properties as SchemaNode | undefined)?.version as
+    | SchemaNode
+    | undefined;
+  return typeof version?.const === 'string';
+}
+
+function branchRequiresName(branch: SchemaNode): boolean {
+  return Array.isArray(branch.required) && branch.required.includes('name');
+}
+
+/** Group branches by their name const, preserving union order. */
+function groupByName(branches: SchemaNode[]): Map<string, SchemaNode[]> {
+  const groups = new Map<string, SchemaNode[]>();
+  for (const branch of branches) {
+    const name = branchNameConst(branch)!;
+    const group = groups.get(name);
+    if (group) group.push(branch);
+    else groups.set(name, [branch]);
+  }
+  return groups;
+}
+
+function nameEntry(name: string, group: SchemaNode[]): NameConstEntry {
+  // Versioned plugins repeat the same name across version branches; the
+  // un-versioned fallback carries the cleanest component description.
+  const source =
+    group.find(
+      (b) => !isVersionedBranch(b) && typeof b.description === 'string'
+    ) ?? group.find((b) => typeof b.description === 'string');
+  return {
+    const: name,
+    type: 'string',
+    ...(source ? { description: source.description as string } : {}),
+  };
+}
+
+/**
+ * Walk a JSON Schema and restructure every `anyOf` union whose branches are
+ * all name-discriminated objects into the `if/then` dispatch shape above.
+ *
+ * Mutates in place. Conservative by design — a union is only restructured
+ * when the rewrite is provably equivalent:
+ * - every branch is an object with a `name` const that lists `name` as
+ *   required (unions containing `$ref` or free-form branches are left alone;
+ *   a `$ref`'s target union is restructured where it is defined)
+ * - the node declares no `properties`, `allOf`, `if`, `required` or `type`
+ *   of its own that the rewrite would have to merge with
+ * - at least two distinct names; single-name unions (a versioned plugin's
+ *   variants) validate and complete fine as a plain anyOf
+ */
+export function restructureNameDiscriminatedUnions(schema: unknown): void {
+  const visited = new WeakSet<object>();
+
+  function walk(node: unknown): void {
+    if (typeof node !== 'object' || node === null) return;
+    if (visited.has(node)) return;
+    visited.add(node);
+
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+
+    const obj = node as SchemaNode;
+    const anyOf = obj.anyOf;
+    const isCandidate =
+      Array.isArray(anyOf) &&
+      anyOf.length >= 2 &&
+      anyOf.every(
+        (b) => branchNameConst(b) !== undefined && branchRequiresName(b)
+      ) &&
+      obj.properties === undefined &&
+      obj.allOf === undefined &&
+      obj.if === undefined &&
+      obj.required === undefined &&
+      (obj.type === undefined || obj.type === 'object');
+    // Dispatch needs at least two distinct names. Same-name groups (a
+    // versioned plugin's variants) stay a plain anyOf — restructuring them
+    // would recurse forever on the group it just created.
+    const groups = isCandidate ? groupByName(anyOf as SchemaNode[]) : undefined;
+    if (groups && groups.size >= 2) {
+      obj.type = 'object';
+      obj.required = ['name'];
+      obj.properties = {
+        name: {
+          anyOf: [...groups.entries()].map(([name, group]) =>
+            nameEntry(name, group)
+          ),
+        },
+      };
+      obj.allOf = [...groups.entries()].map(([name, group]) => ({
+        if: {
+          properties: { name: { const: name } },
+          required: ['name'],
+        },
+        then: group.length === 1 ? group[0] : { anyOf: group },
+      }));
+      delete obj.anyOf;
+    }
+
+    for (const value of Object.values(obj)) walk(value);
+  }
+
+  walk(schema);
+}
+
+/**
+ * Iterate the component branches of an exported union, whichever shape it is
+ * in — the flat `anyOf` the generators emit, or the `if/then` dispatch this
+ * module rewrites it into. For consumers that post-process branch objects
+ * (description enhancement, theme-name injection, …).
+ */
+export function unionBranches(schema: unknown): SchemaNode[] {
+  if (typeof schema !== 'object' || schema === null) return [];
+  const obj = schema as SchemaNode;
+  if (Array.isArray(obj.anyOf)) {
+    return obj.anyOf.filter(
+      (b): b is SchemaNode => typeof b === 'object' && b !== null
+    );
+  }
+  if (Array.isArray(obj.allOf)) {
+    return obj.allOf.flatMap((entry): SchemaNode[] => {
+      const then = (entry as SchemaNode | null)?.then;
+      if (typeof then !== 'object' || then === null) return [];
+      const inner = (then as SchemaNode).anyOf;
+      return Array.isArray(inner)
+        ? inner.filter(
+            (b): b is SchemaNode => typeof b === 'object' && b !== null
+          )
+        : [then as SchemaNode];
+    });
+  }
+  return [];
+}

--- a/packages/shared/src/schemas/discriminated-unions.ts
+++ b/packages/shared/src/schemas/discriminated-unions.ts
@@ -104,8 +104,9 @@ function nameEntry(name: string, group: SchemaNode[]): NameConstEntry {
  * - every branch is an object with a `name` const that lists `name` as
  *   required (unions containing `$ref` or free-form branches are left alone;
  *   a `$ref`'s target union is restructured where it is defined)
- * - the node declares no `properties`, `allOf`, `if`, `required` or `type`
- *   of its own that the rewrite would have to merge with
+ * - the node declares no `properties`, `allOf`, `if`, `required`,
+ *   `additionalProperties` or `type` of its own that the rewrite would have
+ *   to merge with
  * - at least two distinct names; single-name unions (a versioned plugin's
  *   variants) validate and complete fine as a plain anyOf
  */
@@ -134,6 +135,10 @@ export function restructureNameDiscriminatedUnions(schema: unknown): void {
       obj.allOf === undefined &&
       obj.if === undefined &&
       obj.required === undefined &&
+      // A sibling `additionalProperties` evaluates against the node's own
+      // (absent) `properties`; declaring `name` here would change what it
+      // rejects, so such unions are left alone.
+      obj.additionalProperties === undefined &&
       (obj.type === undefined || obj.type === 'object');
     // Dispatch needs at least two distinct names. Same-name groups (a
     // versioned plugin's variants) stay a plain anyOf — restructuring them

--- a/packages/shared/src/schemas/schema-utils.ts
+++ b/packages/shared/src/schemas/schema-utils.ts
@@ -1,4 +1,5 @@
 import { Type, TSchema } from '@sinclair/typebox';
+import { restructureNameDiscriminatedUnions } from './discriminated-unions';
 import type { ComponentDefinition } from '../types/components';
 
 export interface ComponentSchemaConfig {
@@ -61,8 +62,11 @@ export function fixSchemaReferences(
           schemaValue.items &&
           typeof schemaValue.items === 'object' &&
           '$ref' in schemaValue.items &&
-          typeof (schemaValue.items as Record<string, unknown>).$ref === 'string' &&
-          /^T\d+$/.test((schemaValue.items as Record<string, unknown>).$ref as string)
+          typeof (schemaValue.items as Record<string, unknown>).$ref ===
+            'string' &&
+          /^T\d+$/.test(
+            (schemaValue.items as Record<string, unknown>).$ref as string
+          )
         ) {
           schemaValue.items = {
             $ref: `#/definitions/${rootDefinitionName}`,
@@ -178,6 +182,7 @@ export function convertToJsonSchema(
   }
 
   fixSchemaReferences(jsonSchema);
+  restructureNameDiscriminatedUnions(jsonSchema);
 
   return jsonSchema;
 }

--- a/packages/shared/src/schemas/slide-content.ts
+++ b/packages/shared/src/schemas/slide-content.ts
@@ -106,7 +106,7 @@ function createSlideContentComponentSchema<
       ),
       props: component.propsSchema,
     },
-    { additionalProperties: false }
+    { additionalProperties: false, description: component.description }
   );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,6 +562,9 @@ importers:
       typescript:
         specifier: 5.3.3
         version: 5.3.3
+      vscode-json-languageservice:
+        specifier: 5.4.0
+        version: 5.4.0
 
   packages/shared-pptx:
     dependencies:
@@ -2659,6 +2662,9 @@ packages:
 
   '@vitest/utils@1.6.1':
     resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
+  '@vscode/l10n@0.0.18':
+    resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
 
   '@vue/compiler-core@3.5.41':
     resolution: {integrity: sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==}
@@ -5611,6 +5617,18 @@ packages:
       jsdom:
         optional: true
 
+  vscode-json-languageservice@5.4.0:
+    resolution: {integrity: sha512-NCkkCr63OHVkE4lcb0xlUAaix6vE5gHQW4NrswbLEh3ArXj81lrGuFTsGEYEUXlNHdnc53vWPcjeSy/nMTrfXg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.18.0:
+    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
   vue@3.5.41:
     resolution: {integrity: sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==}
     peerDependencies:
@@ -7850,6 +7868,8 @@ snapshots:
       estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+
+  '@vscode/l10n@0.0.18': {}
 
   '@vue/compiler-core@3.5.41':
     dependencies:
@@ -11222,6 +11242,20 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vscode-json-languageservice@5.4.0:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      jsonc-parser: 3.3.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+      vscode-uri: 3.1.0
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.18.0: {}
+
+  vscode-uri@3.1.0: {}
 
   vue@3.5.41(typescript@5.3.3):
     dependencies:


### PR DESCRIPTION
## Summary

Component-name autocomplete in schema-driven editors (playground Monaco, VS Code) offered only the props-optional components (`image`, `text-box`, `toc`) inside a section, and validation reported an arbitrary branch's complaints (`Value must be "heading"` + `Missing property "props"`) while typing.

**Root cause:** vscode-json-languageservice resolves a partially-typed node against a flat `anyOf` by keeping the single best-matching branch — every branch with `required: ["props"]` fails `{ "name": | }` and vanishes from completion and diagnostics. (Regression surfaced when `props` became optional for some components in #131-era changes: before that, all branches failed *equally* and got merged.)

**Fix:** `restructureNameDiscriminatedUnions` (new in `@json-to-office/shared`, applied in both `convertToJsonSchema` impls — every JSON-schema producer funnels through one of them; runtime TypeBox validation untouched) rewrites each name-discriminated union into the canonical dispatch:

```jsonc
{
  "type": "object",
  "required": ["name"],
  "properties": { "name": { "anyOf": [/* every component const + description */] } },
  "allOf": [ { "if": { "properties": { "name": { "const": "heading" } }, "required": ["name"] }, "then": { /* heading branch */ } } /* … */ ]
}
```

Accepted-document set is provably identical (parity tests + ajv over all shipped templates). Editor behavior becomes deterministic:

| state | before | after |
|---|---|---|
| `{ }` | Missing name + Missing props | `Missing property "name"` |
| `"name": ""`/wrong | Missing props + `Value must be "heading"` | `Value is not accepted. Valid values: …` (one error) |
| valid name | branch errors | branch errors (unchanged) |
| name completion | 3 names | all names, with registry descriptions |

Also included:
- `unionBranches()` helper to iterate exported union branches shape-agnostically (used by client theme injection and tests)
- Standard component branches now carry their registry `description` (completion docs + hovers)
- Plugin toggles round-trip exactly: client always sends explicit `plugins=` (empty ⇒ none); discovery endpoint no longer treats an empty selection as "all registered plugins" (missing param still defaults to all)
- Same-name version groups (versioned plugins) stay a small `anyOf` inside their `then` — dispatch requires ≥2 distinct names (restructuring a group would self-recurse; guarded + tested)

## Reviewer notes

- Export-time transform only: `generateUnifiedDocumentSchema`, runtime validators (`validateStrict`, deep-validator) and TypeBox schemas are untouched.
- New regression tests drive the **real** vscode-json-languageservice (devDep in shared-docx) against the real exported schema — completion labels *and* exact diagnostics.
- Verified end-to-end in the playground: 11 suggestions inside a section (was 3), single precise validation error, plugin toggle on/off updates schema per selection.
- `schemas/` output dir is gitignored; regenerate via `pnpm build && pnpm generate:schemas`.

## Checklist

- [x] Added a changeset (`pnpm changeset`)
- [x] Tests pass (`pnpm check`)
- [ ] Docs updated (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved component-name autocomplete and validation in generated schemas.
  * Added clearer component descriptions and diagnostics, including support for versioned and propless components.
  * Plugin selection now supports explicitly requesting no plugins; omitted selections continue to include all plugins.
  * Added utilities for working with component schema variants.

* **Bug Fixes**
  * Preserved schema descriptions across nested component structures.
  * Improved schema handling across document and presentation formats.

* **Tests**
  * Expanded coverage for autocomplete, validation, plugin selection, and schema variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->