### PR TITLE
fix(playground): load requested plugins on demand for schema generation

### DIFF
--- a/.changeset/schema-plugins-on-demand.md
+++ b/.changeset/schema-plugins-on-demand.md
@@ -1,0 +1,17 @@
+---
+'@json-to-office/jto': patch
+---
+
+Plugin components reliably reach editor schemas: the document-schema endpoint
+loads requested plugins on demand instead of depending on the playground's
+bootstrap `POST /load-plugins` having run first.
+
+The playground fires that bootstrap POST and the first schema fetch in
+parallel on page load. When the schema request won the race — or the POST
+failed — the plugin registry was empty, the requested plugins were silently
+dropped, and Monaco kept (and cached) a plugin-less schema: enabled components
+neither completed under `name` nor validated, until a plugin toggle forced a
+refetch. `/discovery/schemas/document` now ensures the requested plugins are
+registered before generating (in-flight-guarded discover-and-load; the
+registry's load fingerprint makes repeats a no-op), so any schema request is
+correct regardless of client bootstrap order.

--- a/packages/jto/src/server/routes/__tests__/discovery-schema.test.ts
+++ b/packages/jto/src/server/routes/__tests__/discovery-schema.test.ts
@@ -1,0 +1,70 @@
+/**
+ * `/discovery/schemas/document` must be self-sufficient: the playground fires
+ * the bootstrap `POST /load-plugins` and the first schema fetch in parallel,
+ * and when the schema request won the race (or the POST failed) the registry
+ * was empty — requested plugins were silently dropped and Monaco kept a
+ * plugin-less schema until a toggle forced a refetch. Enabled components
+ * neither completed nor validated.
+ *
+ * These tests hit the route with a cleared registry and no prior
+ * load-plugins call, exactly the lost-race state.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Hono } from 'hono';
+import { discoveryRouter } from '../discovery';
+import { Container } from '../../container';
+import { DocxFormatAdapter, PluginRegistry } from '@json-to-office/jto-cli';
+import { unionBranches } from '@json-to-office/shared';
+
+// Discovery resolves the workspace root from cwd, so the example plugins
+// under packages/core-docx are reachable from this package's test run.
+
+function componentNames(schema: any): string[] {
+  return unionBranches(schema.definitions.ComponentDefinition)
+    .map((b: any) => b?.properties?.name?.const)
+    .filter(Boolean);
+}
+
+describe('/api/discovery/schemas/document', () => {
+  let app: Hono;
+
+  beforeAll(() => {
+    Container.initialize(new DocxFormatAdapter());
+    PluginRegistry.cleanup();
+    app = new Hono();
+    app.route('/discovery', discoveryRouter as any);
+  });
+
+  afterAll(() => {
+    PluginRegistry.cleanup();
+  });
+
+  it('includes requested plugins with an empty registry (no prior load-plugins)', async () => {
+    expect(PluginRegistry.getInstance().hasPlugins()).toBe(false);
+
+    const res = await app.request(
+      '/discovery/schemas/document?plugins=columnsLayout,weather'
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    const names = componentNames(body.data);
+
+    expect(names).toContain('weather');
+    expect(names).toContain('columnsLayout');
+    expect(names).toContain('heading');
+    // only the requested plugins, not everything discovered
+    expect(names).not.toContain('eldermoor-census');
+  });
+
+  it('keeps an explicit empty selection plugin-free', async () => {
+    // registry is populated from the previous request; selection still wins
+    const res = await app.request('/discovery/schemas/document?plugins=');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    const names = componentNames(body.data);
+
+    expect(names).toContain('heading');
+    expect(names).not.toContain('weather');
+    expect(names).not.toContain('columnsLayout');
+  });
+});

--- a/packages/jto/src/server/routes/discovery.ts
+++ b/packages/jto/src/server/routes/discovery.ts
@@ -29,6 +29,46 @@ function cleanupTypeBoxIds(schema: any): void {
   });
 }
 
+/**
+ * Schema generation must not depend on the client having POSTed
+ * `/load-plugins` first. The playground fires that bootstrap POST and the
+ * first schema fetch in parallel on page load; when the schema request won
+ * the race (or the POST failed), the registry was empty, the requested
+ * plugins were silently dropped, and Monaco kept a plugin-less schema —
+ * enabled components neither completed nor validated until a toggle forced a
+ * refetch. Requests that need plugins now load them on demand; the
+ * registry's load fingerprint makes a repeat discover-and-load a no-op.
+ */
+let pluginLoadInFlight: Promise<void> | null = null;
+
+async function ensurePluginsRegistered(
+  format: 'docx' | 'pptx',
+  pluginNames?: string[]
+): Promise<void> {
+  const registry = PluginRegistry.getInstance();
+  const satisfied = pluginNames
+    ? pluginNames.every((name) => registry.getPlugin(name))
+    : registry.hasPlugins();
+  if (satisfied) return;
+
+  if (!pluginLoadInFlight) {
+    registry.setFormat(format);
+    pluginLoadInFlight = registry
+      .discoverAndLoad()
+      .then(() => undefined)
+      .catch((error: any) => {
+        // Schema generation falls back to standard components only.
+        logger.warn('On-demand plugin load for schema generation failed', {
+          error: error?.message,
+        });
+      })
+      .finally(() => {
+        pluginLoadInFlight = null;
+      });
+  }
+  await pluginLoadInFlight;
+}
+
 function getSelectedPlugins(pluginNames?: string[]) {
   const registry = PluginRegistry.getInstance();
   if (!registry.hasPlugins()) return [];
@@ -55,6 +95,7 @@ async function generateDocumentSchema(
   format: string,
   pluginNames?: string[]
 ): Promise<any> {
+  await ensurePluginsRegistered(format as 'docx' | 'pptx', pluginNames);
   const selected = getSelectedPlugins(pluginNames);
 
   if (format === 'docx') {


### PR DESCRIPTION
## Summary

**Regression report:** with plugins enabled (2/5), component-name autocomplete and validation listed only the 11 standard components — `columnsLayout`/`weather` neither completed nor validated.

**Root cause (not the union restructure itself, but what it exposed):** `/discovery/schemas/document` resolved plugin names against the `PluginRegistry`, which is populated only by the playground's bootstrap `POST /load-plugins`. Page load fires that POST and the first schema fetch **in parallel**; when the schema fetch won the race — or the POST failed — `getSelectedPlugins()` silently dropped every requested name and returned a plugin-less schema, which the client then cached (5-min TTL) and applied. Nothing retried until a manual plugin toggle. Before #167 this state was largely invisible (plugin names never appeared in `name` completion anyway, due to the anyOf best-match bug); now the "Valid values: …" list makes the missing plugins obvious.

**Fix:** the endpoint is now self-sufficient — `ensurePluginsRegistered()` runs before schema generation: if any requested plugin (or, on the no-param default path, any plugin at all) is missing from the registry, it runs an in-flight-guarded `registry.discoverAndLoad()`. The registry's load fingerprint makes repeat loads a no-op, so steady-state cost is one `getPlugin` lookup per name. Explicit-empty (`?plugins=`) still means "no plugins" and triggers no discovery.

## Verified

- Route regression test hits the endpoint with a **cleared registry and no prior load-plugins call** (the lost-race state) and asserts both requested plugins land in the schema — and that `?plugins=` stays plugin-free.
- Live playground, persisted 2/5 selection + fresh reload: typing `w` inside a section suggests `"weather"` (with description); the invalid-name error lists `…, "columnsLayout", "weather"`.
- Full build/test/typecheck/lint green for `@json-to-office/jto`.

## Reviewer notes

- A requested name that doesn't exist on disk re-triggers a discovery walk per schema fetch (fingerprint keeps it cheap); acceptable at human toggle frequency.
- No client changes needed: the mount-race fetch now returns a correct schema by itself.

## Checklist

- [x] Added a changeset (`pnpm changeset`)
- [x] Tests pass (`pnpm check`)
- [ ] Docs updated (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Document schemas now load requested plugins on demand, even when prior plugin initialization was interrupted or unavailable.
  * Prevented requested plugins from being omitted due to concurrent or failed setup requests.
  * Explicitly selecting no plugins continues to return a schema containing only standard components.

* **Tests**
  * Added coverage for on-demand plugin loading and empty plugin selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->