### PR TITLE
fix(docx): rasterize the fallback image inline svg ships

### DIFF
--- a/.changeset/docx-svg-raster-fallback.md
+++ b/.changeset/docx-svg-raster-fallback.md
@@ -1,0 +1,23 @@
+---
+'@json-to-office/core-docx': patch
+---
+
+Rasterize the fallback image an inline `svg` ships for readers that cannot draw
+the vector.
+
+A `w:drawing` for an SVG carries two payloads: the vector, which Word 2016+
+renders, and a raster fallback for everything older. `createTypedImageRun` was
+filling that fallback with the SVG bytes under a `png` type, so Word before
+2016 — and any other consumer of the package — resolved the fallback and drew
+a broken image. The TODO above it had acknowledged this since the function was
+written.
+
+The fallback is now a real PNG rendered with resvg, sized for the placed box at
+roughly 288 DPI and capped at 4096px on the long edge. When rasterization is
+unavailable or the markup will not parse, the run keeps the historical bytes
+and reports an `IMAGE_SVG_RASTER_FAILED` warning: no worse than before for
+Word 2016+, and never a failed render.
+
+Warnings raised deep in the render now reach the caller's collector through a
+scope alongside the existing base-directory and generation-date scopes, rather
+than each intermediate signature having to carry a sink.

--- a/packages/core-docx/package.json
+++ b/packages/core-docx/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@json-to-office/shared": "workspace:^",
     "@json-to-office/shared-docx": "workspace:^",
+    "@resvg/resvg-js": "2.6.2",
     "@sinclair/typebox": "0.34.38",
     "adm-zip": "0.5.16",
     "date-fns": "3.6.0",

--- a/packages/core-docx/src/core/content.ts
+++ b/packages/core-docx/src/core/content.ts
@@ -943,7 +943,7 @@ export async function createImage(
     const imageType = detectImageType(imagePath, responseContentType);
 
     // Create ImageRun based on image type
-    const imageRun = createTypedImageRun({
+    const imageRun = await createTypedImageRun({
       type: imageType,
       data: imageBuffer,
       transformation: { width: dimensions.width, height: dimensions.height },
@@ -1966,7 +1966,7 @@ export async function createTable(
           );
 
           const imgType = detectImageType(imageSource, imageResult.contentType);
-          const imageRun = createTypedImageRun({
+          const imageRun = await createTypedImageRun({
             type: imgType,
             data: imageResult.buffer,
             transformation: {
@@ -2591,7 +2591,7 @@ export async function createMixedContentParagraph(
       );
 
       const imgType = detectImageType(imagePath, imageResult.contentType);
-      const imageRun = createTypedImageRun({
+      const imageRun = await createTypedImageRun({
         type: imgType,
         data: imageResult.buffer,
         transformation: { width: dimensions.width, height: dimensions.height },
@@ -2744,7 +2744,7 @@ export async function createHeaderFooterTable(
                       imageSource,
                       imageResult.contentType
                     );
-                    const imageRun = createTypedImageRun({
+                    const imageRun = await createTypedImageRun({
                       type: imgType,
                       data: imageResult.buffer,
                       transformation: {

--- a/packages/core-docx/src/core/generator.ts
+++ b/packages/core-docx/src/core/generator.ts
@@ -204,6 +204,7 @@ async function generateDocumentWithCustomThemes(
     bypassCache: false,
     services,
     baseDir,
+    warnings,
     ...(visualFonts.length > 0 && { visualFonts }),
   });
 

--- a/packages/core-docx/src/core/render.ts
+++ b/packages/core-docx/src/core/render.ts
@@ -91,8 +91,10 @@ import { globalNoteRegistry } from '../utils/noteRegistry';
 import {
   runWithGenerationDate,
   runWithBaseDir,
+  runWithWarnings,
   getBaseDir,
 } from '../utils/generationContext';
+import type { GenerationWarning } from '@json-to-office/shared';
 import { prerasterizeVisuals } from './prerasterizeVisuals';
 import { computeSectionOrdinals } from './sectionOrdinals';
 import { collectTocHeadings } from './collectTocHeadings';
@@ -114,6 +116,11 @@ interface RenderDocumentOptions {
    * `resolveDocumentFonts` via `toRasterizeFontFaces`.
    */
   visualFonts?: RasterizeFontFace[];
+  /**
+   * Collector for warnings raised while rendering, such as an inline SVG the
+   * rasterizer could not turn into a fallback. Absent → `console.warn`.
+   */
+  warnings?: GenerationWarning[];
 }
 
 /**
@@ -185,20 +192,22 @@ export async function renderDocument(
   options?: RenderDocumentOptions
 ): Promise<Document> {
   return runWithGenerationDate(structure.metadata.date, () =>
-    runWithBaseDir(options?.baseDir, () =>
-      globalBookmarkRegistry.runScoped(() =>
-        globalRevisionIdRegistry.runScoped(() =>
-          globalNumberingRegistry.runScoped(() =>
-            globalSectionBookmarkRegistry.runScoped(() =>
-              // Comment ids are a separate OOXML namespace from w:ins/w:del,
-              // but they need the same per-render isolation: outside this nest
-              // concurrent generations would interleave counters and an anchor
-              // would point at another document's comment body.
-              globalCommentRegistry.runScoped(() =>
-                // Footnote ids are document-scoped too: a reference resolved
-                // against another render's counter points at the wrong body.
-                globalNoteRegistry.runScoped(() =>
-                  renderDocumentScoped(structure, layout, options)
+    runWithWarnings(options?.warnings, () =>
+      runWithBaseDir(options?.baseDir, () =>
+        globalBookmarkRegistry.runScoped(() =>
+          globalRevisionIdRegistry.runScoped(() =>
+            globalNumberingRegistry.runScoped(() =>
+              globalSectionBookmarkRegistry.runScoped(() =>
+                // Comment ids are a separate OOXML namespace from w:ins/w:del,
+                // but they need the same per-render isolation: outside this nest
+                // concurrent generations would interleave counters and an anchor
+                // would point at another document's comment body.
+                globalCommentRegistry.runScoped(() =>
+                  // Footnote ids are document-scoped too: a reference resolved
+                  // against another render's counter points at the wrong body.
+                  globalNoteRegistry.runScoped(() =>
+                    renderDocumentScoped(structure, layout, options)
+                  )
                 )
               )
             )
@@ -545,7 +554,7 @@ async function renderHeaderFooterComponents(
 
         const imageType = detectImageType(imageSource, responseContentType);
 
-        const imageRun = createTypedImageRun({
+        const imageRun = await createTypedImageRun({
           type: imageType,
           data: imageBuffer,
           transformation: {

--- a/packages/core-docx/src/plugin/createDocumentGenerator.ts
+++ b/packages/core-docx/src/plugin/createDocumentGenerator.ts
@@ -625,6 +625,7 @@ function createBuilderImpl<
         services: state.services,
         bypassCache: !state.enableCache,
         baseDir: options?.baseDir ?? state.baseDir,
+        warnings,
         ...(visualFonts.length > 0 && { visualFonts }),
       });
 

--- a/packages/core-docx/src/utils/__tests__/svgRasterFallback.test.ts
+++ b/packages/core-docx/src/utils/__tests__/svgRasterFallback.test.ts
@@ -1,0 +1,114 @@
+/**
+ * An SVG `ImageRun` carries a raster `fallback` for readers that cannot draw
+ * the vector — Word before 2016, and anything else consuming the package.
+ * That fallback used to be the SVG bytes relabelled `png`, which those readers
+ * render as a broken image.
+ */
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import probe from 'probe-image-size';
+import type { GenerationWarning } from '@json-to-office/shared';
+import { generateBufferFromJson } from '../../core/generator';
+import type { ReportComponentDefinition } from '../../types';
+
+const SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="#3C44E3"/></svg>';
+
+const toDataUri = (markup: string) =>
+  `data:image/svg+xml;base64,${Buffer.from(markup, 'utf-8').toString('base64')}`;
+
+/** Minimal 1x1 transparent PNG. */
+const PNG_1X1_URI =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+function doc(imageProps: Record<string, unknown>): ReportComponentDefinition {
+  return {
+    name: 'docx',
+    props: { theme: 'minimal' },
+    children: [{ name: 'image', props: imageProps }],
+  } as ReportComponentDefinition;
+}
+
+interface Media {
+  path: string;
+  data: Buffer;
+}
+
+async function mediaOf(buffer: Buffer): Promise<Media[]> {
+  const zip = await JSZip.loadAsync(buffer);
+  const media: Media[] = [];
+  for (const [path, entry] of Object.entries(zip.files)) {
+    if (entry.dir || !path.startsWith('word/media/')) continue;
+    media.push({ path, data: await entry.async('nodebuffer') });
+  }
+  return media.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+const isSvgBytes = (data: Buffer) =>
+  data.subarray(0, 512).toString('utf-8').includes('<svg');
+
+describe('inline SVG raster fallback', () => {
+  it('ships a real PNG next to the vector instead of relabelled SVG bytes', async () => {
+    const warnings: GenerationWarning[] = [];
+    const buffer = await generateBufferFromJson(
+      doc({ base64: toDataUri(SVG), width: 200 }),
+      { warnings }
+    );
+
+    const media = await mediaOf(buffer);
+    const svg = media.filter((part) => isSvgBytes(part.data));
+    const raster = media.filter((part) => !isSvgBytes(part.data));
+
+    // The vector still ships for Word 2016+.
+    expect(svg).toHaveLength(1);
+    expect(svg[0].data.toString('utf-8')).toContain('<circle');
+
+    // ...and the fallback is now a decodable PNG, not the same markup again.
+    expect(raster).toHaveLength(1);
+    const size = probe.sync(raster[0].data);
+    expect(size?.mime).toBe('image/png');
+    // 200px placed at 3x = 600px, within rounding of the placed aspect.
+    expect(size!.width).toBeGreaterThanOrEqual(596);
+    expect(size!.width).toBeLessThanOrEqual(604);
+
+    expect(
+      warnings.filter(
+        (entry) => entry.context?.code === 'IMAGE_SVG_RASTER_FAILED'
+      )
+    ).toEqual([]);
+  });
+
+  it('warns and keeps the document renderable when the SVG cannot be parsed', async () => {
+    const warnings: GenerationWarning[] = [];
+    const buffer = await generateBufferFromJson(
+      doc({
+        base64: toDataUri('<svg xmlns="http://www.w3.org/2000/svg"><unclosed'),
+        width: 200,
+      }),
+      { warnings }
+    );
+
+    expect(buffer.byteLength).toBeGreaterThan(0);
+    expect(warnings.map((entry) => entry.context?.code)).toContain(
+      'IMAGE_SVG_RASTER_FAILED'
+    );
+
+    // Degraded, not broken: the historical bytes still ship, so Word 2016+
+    // renders exactly as it did before this pass existed.
+    const media = await mediaOf(buffer);
+    expect(media.some((part) => isSvgBytes(part.data))).toBe(true);
+  });
+
+  it('leaves a raster image untouched', async () => {
+    const warnings: GenerationWarning[] = [];
+    const buffer = await generateBufferFromJson(
+      doc({ base64: PNG_1X1_URI, width: 100 }),
+      { warnings }
+    );
+
+    const media = await mediaOf(buffer);
+    expect(media).toHaveLength(1);
+    expect(probe.sync(media[0].data)?.width).toBe(1);
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/core-docx/src/utils/generationContext.ts
+++ b/packages/core-docx/src/utils/generationContext.ts
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { isAbsolute, resolve } from 'node:path';
+import type { GenerationWarning } from '@json-to-office/shared';
 
 const generationDateStorage = new AsyncLocalStorage<Date>();
 
@@ -44,4 +45,41 @@ export function resolveFromBaseDir(filePath: string): string {
   const base = baseDirStorage.getStore();
   if (!base || isAbsolute(filePath)) return filePath;
   return resolve(base, filePath);
+}
+
+const warningsStorage = new AsyncLocalStorage<GenerationWarning[]>();
+
+/**
+ * Scope a warning collector for a render, so leaf utilities can report
+ * without every intermediate signature carrying a sink. No collector → plain
+ * callback, and `reportWarning` falls back to `console.warn` as before.
+ */
+export function runWithWarnings<T>(
+  warnings: GenerationWarning[] | undefined,
+  callback: () => T
+): T {
+  return warnings === undefined
+    ? callback()
+    : warningsStorage.run(warnings, callback);
+}
+
+/** Record a render-time warning against the active collector, if any. */
+export function reportWarning(
+  component: string,
+  code: string,
+  message: string,
+  context?: Record<string, unknown>
+): void {
+  const warnings = warningsStorage.getStore();
+  if (warnings) {
+    warnings.push({
+      component,
+      message,
+      severity: 'warning',
+      context: { code, ...context },
+    });
+    return;
+  }
+  // eslint-disable-next-line no-console
+  console.warn(`[json-to-docx] [${code}] ${message}`);
 }

--- a/packages/core-docx/src/utils/imageUtils.ts
+++ b/packages/core-docx/src/utils/imageUtils.ts
@@ -1,8 +1,77 @@
 import { readFileSync } from 'fs';
 import probe from 'probe-image-size';
-import { resolveFromBaseDir } from './generationContext';
+import { reportWarning, resolveFromBaseDir } from './generationContext';
 import { ImageRun, IFloating } from 'docx';
 import { parsePercentageStringToFraction } from './widthUtils';
+
+type ResvgModule = typeof import('@resvg/resvg-js');
+
+/** 3x of Word's 96 DPI baseline — ~288 DPI, sharp in print and on retina. */
+const SVG_RASTER_SCALE = 3;
+const SVG_MAX_EDGE_PX = 4096;
+const SVG_MIN_EDGE_PX = 16;
+
+let resvgModule: Promise<ResvgModule> | undefined;
+
+function loadResvg(): Promise<ResvgModule> {
+  resvgModule ??= import('@resvg/resvg-js');
+  return resvgModule;
+}
+
+function toRasterPx(px: number): number {
+  return Math.min(
+    SVG_MAX_EDGE_PX,
+    Math.max(SVG_MIN_EDGE_PX, Math.round(px * SVG_RASTER_SCALE))
+  );
+}
+
+/**
+ * Rasterize inline SVG for the `fallback` slot of an SVG `ImageRun`.
+ *
+ * Word 2016+ draws the vector, but every older Word and non-SVG consumer
+ * renders the fallback instead — so shipping the SVG bytes under a `png` type
+ * gave those readers a broken image. Returns `undefined` when rasterization is
+ * unavailable or fails; the caller then keeps the historical bytes, which is
+ * no worse than before and never fails the render.
+ */
+async function rasterizeSvgFallback(
+  svg: Buffer,
+  transformation: { width: number; height: number }
+): Promise<Buffer | undefined> {
+  let Resvg: ResvgModule['Resvg'];
+  try {
+    ({ Resvg } = await loadResvg());
+  } catch (error) {
+    reportWarning(
+      'image',
+      'IMAGE_SVG_RASTER_FAILED',
+      `Could not load the SVG rasterizer, so inline SVG keeps a fallback that only Word 2016+ can draw: ${String(error)}`
+    );
+    return undefined;
+  }
+
+  try {
+    const markup = svg.toString('utf-8');
+    const probeImage = new Resvg(markup);
+    // resvg scales uniformly, so pick the axis that makes the bitmap cover
+    // the placed box on both — matching the box aspect is not enough.
+    const wide =
+      probeImage.width / probeImage.height >
+      transformation.width / transformation.height;
+    const fitTo = wide
+      ? { mode: 'height' as const, value: toRasterPx(transformation.height) }
+      : { mode: 'width' as const, value: toRasterPx(transformation.width) };
+
+    return Buffer.from(new Resvg(markup, { fitTo }).render().asPng());
+  } catch (error) {
+    reportWarning(
+      'image',
+      'IMAGE_SVG_RASTER_FAILED',
+      `Could not rasterize inline SVG, so its fallback only renders in Word 2016+: ${String(error)}`
+    );
+    return undefined;
+  }
+}
 
 export interface ImageDimensions {
   width: number;
@@ -210,25 +279,30 @@ export function detectImageType(
 
 /**
  * Create an ImageRun with correct type handling, including SVG fallback.
- * TODO: SVG fallback uses raw SVG as PNG — works in Word 2016+ which renders
- * SVG natively; fallback won't render correctly in older versions.
+ *
+ * An SVG run carries a raster `fallback` for readers that cannot draw the
+ * vector — Word before 2016, and anything else consuming the package. That
+ * fallback is rasterized here; if rasterization is unavailable the run keeps
+ * the SVG bytes, which renders in Word 2016+ and reports a warning for the
+ * rest rather than failing the document.
  */
-export function createTypedImageRun(opts: {
+export async function createTypedImageRun(opts: {
   type: 'jpg' | 'png' | 'gif' | 'bmp' | 'svg';
   data: Buffer;
   transformation: { width: number; height: number };
   floating?: IFloating;
-}): ImageRun {
+}): Promise<ImageRun> {
   const base = {
     data: opts.data,
     transformation: opts.transformation,
     ...(opts.floating && { floating: opts.floating }),
   };
   if (opts.type === 'svg') {
+    const raster = await rasterizeSvgFallback(opts.data, opts.transformation);
     return new ImageRun({
       type: 'svg',
       ...base,
-      fallback: { type: 'png', data: opts.data },
+      fallback: { type: 'png', data: raster ?? opts.data },
     });
   }
   return new ImageRun({ type: opts.type, ...base });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@json-to-office/shared-docx':
         specifier: workspace:^
         version: link:../shared-docx
+      '@resvg/resvg-js':
+        specifier: 2.6.2
+        version: 2.6.2
       '@sinclair/typebox':
         specifier: 0.34.38
         version: 0.34.38


### PR DESCRIPTION
## Summary

The Word-side twin of #198, flagged as follow-up there.

A `w:drawing` for an SVG carries two payloads: the vector, which Word 2016+ renders, and a raster fallback for everything older. `createTypedImageRun` was filling that fallback with the **SVG bytes under a `png` type**, so Word before 2016 — and any other consumer of the package — resolved the fallback and drew a broken image. The `TODO` above the function had acknowledged this since it was written:

```
TODO: SVG fallback uses raw SVG as PNG — works in Word 2016+ which renders
SVG natively; fallback won't render correctly in older versions.
```

The fallback is now a real PNG rendered with resvg, sized for the placed box at ~288 DPI and capped at 4096px. Verified end to end: a 240px-wide inline SVG now emits a 720×360 PNG alongside the vector, and the extracted part decodes and renders as the actual artwork rather than markup.

Unlike #198 this needs no package surgery — `docx` accepts a real fallback directly, so the fix is at the source.

## Two things worth a reviewer's attention

**1. `createTypedImageRun` became `async`.** resvg loads through a dynamic `import()` (core-docx builds ESM-only, resvg ships CJS), so rasterization cannot happen in a sync function. All five call sites were already inside `async` functions, so this is an `await` at each and no signature churn upward. The function is internal — not exported from the package index — so no public API changed.

**2. There was no warning sink to write to.** `createTypedImageRun` is a leaf utility and none of its five call sites had `addWarning` or a `warnings` array in scope. Rather than grow a sink parameter on five call chains, `runWithWarnings`/`reportWarning` join the existing `runWithBaseDir` / `runWithGenerationDate` `AsyncLocalStorage` scopes in `generationContext.ts`, wired once into the `renderDocument` nest. Both `renderDocument` callers already had a `warnings` array to hand. Absent a collector it falls back to `console.warn` in the same `[json-to-docx] [CODE] message` format used elsewhere.

## Notes

- **Degrades, never fails.** A missing native binding or unparseable markup keeps the historical bytes and reports `IMAGE_SVG_RASTER_FAILED` — Word 2016+ renders exactly as before, and no document fails to build.
- **Bump is `patch`, deliberately** — and it differs from #198 for a real reason. There, `warnings` was a new field on an exported interface that three public option types inherit, so that went `minor`. Here `GenerationOptions.warnings` already existed and neither the scope helpers nor `renderDocument` are exported from the package index, so the public surface is unchanged.
- **The main test fails against the old code** — pre-fix it finds two SVG-byte media parts (the vector plus the relabelled "PNG"); post-fix, one vector and one decodable PNG. Confirmed by reverting the one line and re-running.
- **Sizing mirrors `core-pptx`'s pass**, including the axis-selection rule: resvg scales uniformly, so the bitmap must be sized on the axis that makes it *cover* the placed box, not the one that matches its aspect.
- `@resvg/resvg-js@2.6.2` was already in the lockfile from #198, so this adds 3 lines there — the `core-docx` importer entry.

## Checklist

- [x] Added a changeset (`pnpm changeset`)
- [x] Tests pass (`pnpm check`) — core-docx 749 passed; repo-wide typecheck 15/15, test 15/15
- [x] Docs updated (if applicable) — no user-facing surface changed; the behaviour note lives in the changeset