### PR TITLE
feat(docx): heading numbering, [@id] cross-references, text-box shape rendering

### DIFF
--- a/.changeset/heading-numbering-crossrefs-shape-textbox.md
+++ b/.changeset/heading-numbering-crossrefs-shape-textbox.md
@@ -1,0 +1,27 @@
+---
+'@json-to-office/shared-docx': minor
+'@json-to-office/core-docx': minor
+---
+
+Apply `heading.props.numbering`, which the schema has always accepted and the
+renderer always ignored. `true` binds the heading to one shared multilevel
+definition — 1., 1.1., 1.1.1., with each level linked to its `Heading1`–`Heading6`
+style — so Word renders the number and keeps it right when sections move. Turn
+it on document-wide through `componentDefaults.heading.numbering`; `false` opts
+a single heading out. A numbered heading's number also joins its cached TOC
+entry, which is what keeps the cached copy and Word's own refresh in agreement.
+
+Add `[@id]` cross-references to numbered headings and list items, alongside the
+prerequisite per-item `id` on `list` items (which also makes an item an
+internal-link target). `[@id]` writes a hyperlinked Word `REF` field carrying the
+number as a cached value, so the PDF path — headless LibreOffice, which never
+updates fields — shows it too; `:no_context`, `:full_context` and `:none` select
+the other switches. A reference to an unknown id renders as literal text with a
+warning rather than as Word's "Error! Reference source not found".
+
+Add `text-box` `renderAs: 'shape'`, which emits a native Word text box (a WPS
+DrawingML shape) instead of the default borderless one-cell table: real wrap
+modes and z-order, at the cost of autofit, per-side borders and lazily-resolved
+percentage sizes. `'table'` remains the default and is unchanged. Shape mode
+falls back to the table rendering, with a warning, for content a shape cannot
+hold (a nested `columns`) or a missing `width`/`height`.

--- a/docs/guide/writing-docx.md
+++ b/docs/guide/writing-docx.md
@@ -107,6 +107,10 @@ Once a heading is numbered, `[@id]` in any text references it: the number is wri
 [
   {
     "name": "heading",
+    "props": { "text": "Field study", "level": 1, "numbering": true }
+  },
+  {
+    "name": "heading",
     "id": "methods",
     "props": { "text": "Methods", "level": 2, "numbering": true }
   },
@@ -118,6 +122,8 @@ Once a heading is numbered, `[@id]` in any text references it: the number is wri
   }
 ]
 ```
+
+"Field study" numbers `1.` and "Methods" numbers `1.1.`, so the paragraph reads "Sampling is described in 1.1 (Methods)." A heading numbered before any heading of the level above it fills the missing places with zeros — `0.1` — exactly as Word does.
 
 See [cross-references](/reference/docx/components#cross-references) for the other switches and the caveats about cached values.
 

--- a/docs/guide/writing-docx.md
+++ b/docs/guide/writing-docx.md
@@ -62,6 +62,7 @@ jto docx generate report.docx.json -o report.docx
 - `**bold**` or `__bold__`, `*italic*` or `_italic_`, `***bold italic***`
 - `\n` for line breaks within one paragraph
 - `[link text](https://example.com)` for hyperlinks
+- `[@id]` for a cross-reference to a numbered heading or list item
 - `{PLACEHOLDER}` for dynamic content
 
 The built-in placeholders are `{PAGE}` (current page number), `{TOTAL_PAGES}`, `{DATE}`, `{DATETIME}`, and `{YEAR}`. Unknown placeholders are left in the text as-is, so stray braces will not break a render.
@@ -95,6 +96,30 @@ A hyperlink whose URL starts with `#` becomes an internal bookmark link. The tar
   }
 ]
 ```
+
+### Numbered headings and cross-references
+
+`"numbering": true` on a heading puts it in the document's `1.` / `1.1.` / `1.1.1.` sequence — Word renders the number, so it stays right when sections move. Turn it on for every heading through the theme's `componentDefaults.heading.numbering`, and set `"numbering": false` on the odd heading that should stay unnumbered.
+
+Once a heading is numbered, `[@id]` in any text references it: the number is written as a hyperlinked Word `REF` field. Headings take the `id` from their node `id`, or from a slug of their text; list items take one written on the item. `[@id:none]` references the target's text instead of its number.
+
+```json
+[
+  {
+    "name": "heading",
+    "id": "methods",
+    "props": { "text": "Methods", "level": 2, "numbering": true }
+  },
+  {
+    "name": "paragraph",
+    "props": {
+      "text": "Sampling is described in [@methods] ([@methods:none])."
+    }
+  }
+]
+```
+
+See [cross-references](/reference/docx/components#cross-references) for the other switches and the caveats about cached values.
 
 Paragraphs also accept `font` (a partial font override: family, size, color, bold, `fontWeight`, italic, underline, ...), `themeStyle` (a named style from the theme's `styles` map), `boldColor` (a color applied only to `**bold**` segments), `spacing`, `keepNext`/`keepLines`, and page/column breaks. Headings take `level` 1–6 (default 1) and feed the table of contents automatically.
 
@@ -188,7 +213,7 @@ Column widths are points, or `"%"` strings relative to the table width; columns 
 
 ## Lists
 
-The `items` array accepts plain strings or objects with a `level` (0–8) for nesting. By default you get bullets; `format` switches level 0 to numbering, and `levels` gives full per-level control:
+The `items` array accepts plain strings or objects with a `level` (0–8) for nesting and an optional `id` that bookmarks the item, so `[jump](#id)` links to it and `[@id]` [cross-references](/reference/docx/components#cross-references) its number. By default you get bullets; `format` switches level 0 to numbering, and `levels` gives full per-level control:
 
 ```json
 {
@@ -314,6 +339,8 @@ Each child fills the next column. Columns accept nearly everything a section doe
   ]
 }
 ```
+
+By default the box is a borderless one-cell table, which auto-fits its height and lets Word resolve percentage widths. Set `"renderAs": "shape"` to emit a native Word text box instead, when you need real text wrapping or z-order; it needs an explicit `width` and `height`, and takes a single uniform border. See [renderAs](/reference/docx/components#renderas-table-or-shape) for the full trade.
 
 Both colors in that `style` block — `border.<side>.color` and `shading.fill` — take a `#`-prefixed hex or a theme color name (`"primary"`, `"accent"`, ...), and both are checked against that pattern at validation. A digit-leading bare hex such as `"0F0FDF"` fails validation outright. A letter-leading one such as `"F0FDF4"` is indistinguishable from a theme color name under that pattern, so it passes validation — and resolves as hex at render, since no theme color name is six hex characters. Write `"#F0FDF4"` anyway: it is the form the schema is built around, and the only one that works for both leading digits and letters.
 

--- a/docs/reference/docx/components.md
+++ b/docs/reference/docx/components.md
@@ -54,8 +54,14 @@ Different Word constructs use different native units; json-to-office keeps each 
 
 A heading's `id` is its explicit node `id` if it has one, otherwise a slug of its text (`"Data Sources"` → `data-sources`, disambiguated with `-1`, `-2` on collision). List items take the `id` written on the item.
 
+A reference renders the bare number — `1.1` — while the heading itself renders `1.1.`: the trailing period belongs to the heading's numbering, and Word's reference switches drop it.
+
 ```json
 [
+  {
+    "name": "heading",
+    "props": { "text": "Field study", "level": 1, "numbering": true }
+  },
   {
     "name": "heading",
     "id": "methods",
@@ -70,7 +76,7 @@ A heading's `id` is its explicit node `id` if it has one, otherwise a slug of it
 ]
 ```
 
-renders as "Sampling is described in 2.1 (Methods)."
+"Field study" is the document's first level-1 heading, so it numbers `1.` and "Methods" numbers `1.1.` — the paragraph renders as "Sampling is described in 1.1 (Methods)."
 
 Two caveats:
 
@@ -485,12 +491,18 @@ The default `'table'` renders the box as a borderless one-cell table. `'shape'` 
 | Height                         | Auto-fits the content                               | Fixed; `width` **and** `height` are required, content that overflows clips |
 | Text wrapping                  | Table float clearances only                         | Real wrap modes (`square`, `topAndBottom`, `none`, …)                      |
 | Z-order / behind text          | Not available                                       | `floating.zIndex`, `floating.behindDocument`                               |
-| Borders                        | Per side, each with its own style, width and colour | One uniform outline; dash patterns render solid                            |
+| Borders                        | Per side, each with its own style, width and colour | One uniform `solid` outline                                                |
 | Border **and** fill together   | Both                                                | Fill only — see below                                                      |
 | `width` / `height` percentages | Resolved by Word, so they follow the page           | Resolved at generation time against the current content box                |
 | Children                       | Anything, including nested `columns`                | Paragraph-producing components only                                        |
 
-Shape mode degrades to the table rendering, with a warning, when the request cannot be honoured: non-paragraph content (a nested `columns`, which renders as a table), or a missing `width` or `height`. Two more warnings report a downgrade inside shape mode: per-side borders that disagree (the first declared side of top/left/bottom/right wins), and a percentage size being frozen.
+Shape mode degrades to the table rendering, with a warning, when the request cannot be honoured:
+
+- a missing `width` or `height`;
+- a `dashed`, `dotted` or `double` border — a shape outline has no dash pattern, and drawing it solid would silently change the design, so the box goes back to the table path that renders it properly;
+- non-paragraph content (a nested `columns`, which renders as a table).
+
+Two further warnings report a downgrade inside shape mode rather than a fallback: per-side borders that disagree (the first declared side of top/left/bottom/right wins), and a percentage size being frozen.
 
 A shape cannot carry both `style.shading.fill` and `style.border`: docx 9.7.1 writes the two fill groups in an order Word rejects, so when both are given the fill is kept, the border dropped, and a warning raised. Use one or the other, or stay on the table path.
 

--- a/docs/reference/docx/components.md
+++ b/docs/reference/docx/components.md
@@ -39,7 +39,43 @@ Different Word constructs use different native units; json-to-office keeps each 
 
 ### Shared text features
 
-`heading` and `paragraph` text supports inline markdown (`**bold**`, `*italic*`, `***bold italic***`, `_underscore variants_`), `\n` line breaks, `[text](url)` hyperlinks (internal bookmark links when the URL starts with `#`), and the placeholders `{PAGE}`, `{TOTAL_PAGES}`, `{DATE}`, `{DATETIME}`, `{YEAR}`. Unknown placeholders are kept as literal text. All text is Unicode NFC-normalized. Image and visual captions support the bold/italic subset.
+`heading` and `paragraph` text supports inline markdown (`**bold**`, `*italic*`, `***bold italic***`, `_underscore variants_`), `\n` line breaks, `[text](url)` hyperlinks (internal bookmark links when the URL starts with `#`), `[@id]` cross-references (below), and the placeholders `{PAGE}`, `{TOTAL_PAGES}`, `{DATE}`, `{DATETIME}`, `{YEAR}`. Unknown placeholders are kept as literal text. All text is Unicode NFC-normalized. Image and visual captions support the bold/italic subset.
+
+#### Cross-references
+
+`[@id]` inserts a Word `REF` field pointing at a [numbered heading](#heading-numbering) or a [list item](#list) that declares an `id`. It renders as the target's number and hyperlinks to it, so the number follows the target when sections are reordered.
+
+| Token                | Word switch | Renders                                                     |
+| -------------------- | ----------- | ----------------------------------------------------------- |
+| `[@id]`              | `\r`        | The number relative to where the reference sits (default)   |
+| `[@id:no_context]`   | `\n`        | Only the target's own level counter — `3` for heading 2.1.3 |
+| `[@id:full_context]` | `\w`        | The whole number — `2.1.3`                                  |
+| `[@id:none]`         | —           | The target's text instead of its number                     |
+
+A heading's `id` is its explicit node `id` if it has one, otherwise a slug of its text (`"Data Sources"` → `data-sources`, disambiguated with `-1`, `-2` on collision). List items take the `id` written on the item.
+
+```json
+[
+  {
+    "name": "heading",
+    "id": "methods",
+    "props": { "text": "Methods", "level": 2, "numbering": true }
+  },
+  {
+    "name": "paragraph",
+    "props": {
+      "text": "Sampling is described in [@methods] ([@methods:none])."
+    }
+  }
+]
+```
+
+renders as "Sampling is described in 2.1 (Methods)."
+
+Two caveats:
+
+- **The number is cached at generation time.** Word recomputes every field on open (the document sets `updateFields`), but headless LibreOffice — and therefore the PDF export — shows the cached value, so a `[@id]` in a PDF reflects the document as generated. `[@id]` (relative) is the approximation: its true value depends on where the reference sits, which only Word resolves.
+- **A reference the pre-pass cannot resolve degrades rather than breaking.** An unknown id renders as the literal `[@id]` text with a warning — never as Word's "Error! Reference source not found". A target that exists but carries no number (a bullet-list item, an unnumbered heading) gets a real field with no cached value: blank until the reader updates fields, and a warning suggesting `:none`.
 
 The `font` prop, where present, is a partial font override with the same fields as a theme font definition: `family`, `size` (8–72), `color`, `bold`, `fontWeight` (100–900, wins over `bold`), `italic`, `underline`, `lineSpacing`, `spacing`, `characterSpacing` (`{ type: 'condensed' | 'expanded', value }`).
 
@@ -62,7 +98,7 @@ A document heading. Headings feed the [table of contents](#toc) and Word's navig
 | `lineSpacing`  | `number` \| `{ type: 'single'\|'atLeast'\|'exactly'\|'double'\|'multiple', value? }` | no       | theme               |                                                                       |
 | `pageBreak`    | `boolean`                                                                            | no       | —                   | Page break before the heading                                         |
 | `columnBreak`  | `boolean`                                                                            | no       | —                   | Column break before the heading                                       |
-| `numbering`    | `boolean`                                                                            | no       | —                   | Accepted by the schema but not currently applied by the renderer      |
+| `numbering`    | `boolean`                                                                            | no       | —                   | Auto-number this heading (see below)                                  |
 | `keepNext`     | `boolean`                                                                            | no       | —                   | Keep with the next paragraph                                          |
 | `keepLines`    | `boolean`                                                                            | no       | —                   | Keep all lines on one page                                            |
 | `revision`     | `Revision`                                                                           | no       | —                   | Tracked-change segments (see [Revisions](#revisions-tracked-changes)) |
@@ -71,9 +107,17 @@ A document heading. Headings feed the [table of contents](#toc) and Word's navig
 ```json
 {
   "name": "heading",
-  "props": { "text": "2. Methodology", "level": 2, "keepNext": true }
+  "props": { "text": "Methodology", "level": 2, "keepNext": true }
 }
 ```
+
+### Heading numbering
+
+`numbering: true` puts the heading in the document's multilevel heading numbering — `1.`, `1.1.`, `1.1.1.`, one continuous sequence across the whole document, with the number rendered by Word rather than typed into `text`. The definition binds each level to the matching `Heading1`–`Heading6` style, so Word's own "Continue numbering" UI, the TOC refresh, and `[@id]` cross-references all agree with it.
+
+Turn it on for the whole document through the theme's `componentDefaults.heading.numbering`, and set `numbering: false` on a single heading to opt that one out (an unnumbered appendix title, say). A heading whose level appears before any heading of the level above it numbers with zeros — `2.0.1` — exactly as Word does.
+
+Only numbered headings advance the counters: an unnumbered heading in the middle of a numbered document does not consume a number.
 
 ## `paragraph`
 
@@ -278,18 +322,18 @@ Note the conventions differ between the two color families: `borderColor` (table
 
 Bulleted or numbered lists with up to nine nesting levels and fully configurable numbering.
 
-| Prop        | Type                                                | Required | Default        | Description                                                              |
-| ----------- | --------------------------------------------------- | -------- | -------------- | ------------------------------------------------------------------------ |
-| `items`     | `(string \| { text, level?, revision? })[]` (min 1) | **yes**  | —              | `level` is 0–8                                                           |
-| `reference` | `string`                                            | no       | auto-generated | Numbering configuration ID (share it to continue numbering across lists) |
-| `levels`    | `Level[]` (1–9 items)                               | no       | —              | Per-level configuration (see below)                                      |
-| `format`    | LevelFormat \| `'numbered'` \| `'none'`             | no       | bullets        | Shorthand for the level-0 format                                         |
-| `bullet`    | `string`                                            | no       | —              | Custom bullet character                                                  |
-| `start`     | `number` (≥ 1)                                      | no       | `1`            | Level-0 starting number (applies with or without `levels`)               |
-| `spacing`   | `{ before?, after?, item? }` (points)               | no       | —              | `item` = spacing between items                                           |
-| `alignment` | `'left'` \| `'center'` \| `'right'` \| `'justify'`  | no       | —              |                                                                          |
-| `indent`    | `number` \| `{ left?, hanging? }`                   | no       | —              |                                                                          |
-| `comment`   | `Comment`                                           | no       | —              | Review comment spanning the whole list (see [Comments](#comments))       |
+| Prop        | Type                                                     | Required | Default        | Description                                                              |
+| ----------- | -------------------------------------------------------- | -------- | -------------- | ------------------------------------------------------------------------ |
+| `items`     | `(string \| { text, level?, id?, revision? })[]` (min 1) | **yes**  | —              | `level` is 0–8; `id` bookmarks the item (see below)                      |
+| `reference` | `string`                                                 | no       | auto-generated | Numbering configuration ID (share it to continue numbering across lists) |
+| `levels`    | `Level[]` (1–9 items)                                    | no       | —              | Per-level configuration (see below)                                      |
+| `format`    | LevelFormat \| `'numbered'` \| `'none'`                  | no       | bullets        | Shorthand for the level-0 format                                         |
+| `bullet`    | `string`                                                 | no       | —              | Custom bullet character                                                  |
+| `start`     | `number` (≥ 1)                                           | no       | `1`            | Level-0 starting number (applies with or without `levels`)               |
+| `spacing`   | `{ before?, after?, item? }` (points)                    | no       | —              | `item` = spacing between items                                           |
+| `alignment` | `'left'` \| `'center'` \| `'right'` \| `'justify'`       | no       | —              |                                                                          |
+| `indent`    | `number` \| `{ left?, hanging? }`                        | no       | —              |                                                                          |
+| `comment`   | `Comment`                                                | no       | —              | Review comment spanning the whole list (see [Comments](#comments))       |
 
 **Level**
 
@@ -326,6 +370,8 @@ Bulleted or numbered lists with up to nine nesting levels and fully configurable
   }
 }
 ```
+
+**Item ids.** An item written as an object may carry an `id`, which bookmarks that item: `[jump](#id)` links to it, and `[@id]` [cross-references](#cross-references) it — rendering its counter (`3`, `c`, `iv`) for a numbered level, or its text with `[@id:none]`. Two lists sharing a `reference` share one counter, so an item in the second list numbers on from the first.
 
 ## `toc`
 
@@ -396,14 +442,15 @@ Inside a `text-box`, a nested `columns` renders as a multi-column table.
 
 A bordered, padded box — callouts, sidebars, cover-page blocks. Allowed children: `heading`, `paragraph`, `image`.
 
-| Prop            | Type                                                                                | Required | Default | Description                                                                            |
-| --------------- | ----------------------------------------------------------------------------------- | -------- | ------- | -------------------------------------------------------------------------------------- |
-| `width`         | `number` (px, ≥ 1) \| `"%"` string                                                  | no       | —       | Relative to content width                                                              |
-| `height`        | `number` (px, ≥ 1) \| `"%"` string                                                  | no       | —       |                                                                                        |
-| `floating`      | floating object                                                                     | no       | —       | Identical schema to [`image`](#image) — one shared floating schema for both components |
-| `style.padding` | `{ top?, right?, bottom?, left? }` (≥ 0)                                            | no       | —       | Inner padding                                                                          |
-| `style.border`  | per-side `{ style: 'solid'\|'dashed'\|'dotted'\|'double'\|'none', width?, color? }` | no       | —       | `color` takes `#`-prefixed hex or a theme color name                                   |
-| `style.shading` | `{ fill?: color }`                                                                  | no       | —       | Background fill. `fill` takes the same color type as `style.border.*.color`            |
+| Prop            | Type                                                                                | Required | Default   | Description                                                                            |
+| --------------- | ----------------------------------------------------------------------------------- | -------- | --------- | -------------------------------------------------------------------------------------- |
+| `renderAs`      | `'table'` \| `'shape'`                                                              | no       | `'table'` | Rendering strategy (see below)                                                         |
+| `width`         | `number` (px, ≥ 1) \| `"%"` string                                                  | no       | —         | Relative to content width                                                              |
+| `height`        | `number` (px, ≥ 1) \| `"%"` string                                                  | no       | —         |                                                                                        |
+| `floating`      | floating object                                                                     | no       | —         | Identical schema to [`image`](#image) — one shared floating schema for both components |
+| `style.padding` | `{ top?, right?, bottom?, left? }` (≥ 0)                                            | no       | —         | Inner padding                                                                          |
+| `style.border`  | per-side `{ style: 'solid'\|'dashed'\|'dotted'\|'double'\|'none', width?, color? }` | no       | —         | `color` takes `#`-prefixed hex or a theme color name                                   |
+| `style.shading` | `{ fill?: color }`                                                                  | no       | —         | Background fill. `fill` takes the same color type as `style.border.*.color`            |
 
 `style.shading.fill` and every `style.border.*.color` share one color type — `#RRGGBB` hex or a theme color name — enforced by the schema rather than at render time. Malformed values (`#F0F`, `#GGGGGG`, `rgb(240, 253, 244)`, `light green`, a digit-leading bare hex such as `0F0FDF`, the empty string) are rejected at validation. A letter-leading bare hex such as `F0FDF4` is indistinguishable from a theme color name under that pattern, so it passes validation — and resolves as hex at render, since no theme color name is six hex characters. Write `#F0FDF4` anyway; it is the only form that works whether the value starts with a digit or a letter.
 
@@ -428,6 +475,24 @@ A bordered, padded box — callouts, sidebars, cover-page blocks. Allowed childr
   ]
 }
 ```
+
+### `renderAs`: table or shape
+
+The default `'table'` renders the box as a borderless one-cell table. `'shape'` renders a native Word text box (a `wps:wsp` DrawingML shape) instead — the thing Word's own Insert → Text Box produces. The two trade different capabilities:
+
+| Capability                     | `'table'` (default)                                 | `'shape'`                                                                  |
+| ------------------------------ | --------------------------------------------------- | -------------------------------------------------------------------------- |
+| Height                         | Auto-fits the content                               | Fixed; `width` **and** `height` are required, content that overflows clips |
+| Text wrapping                  | Table float clearances only                         | Real wrap modes (`square`, `topAndBottom`, `none`, …)                      |
+| Z-order / behind text          | Not available                                       | `floating.zIndex`, `floating.behindDocument`                               |
+| Borders                        | Per side, each with its own style, width and colour | One uniform outline; dash patterns render solid                            |
+| Border **and** fill together   | Both                                                | Fill only — see below                                                      |
+| `width` / `height` percentages | Resolved by Word, so they follow the page           | Resolved at generation time against the current content box                |
+| Children                       | Anything, including nested `columns`                | Paragraph-producing components only                                        |
+
+Shape mode degrades to the table rendering, with a warning, when the request cannot be honoured: non-paragraph content (a nested `columns`, which renders as a table), or a missing `width` or `height`. Two more warnings report a downgrade inside shape mode: per-side borders that disagree (the first declared side of top/left/bottom/right wins), and a percentage size being frozen.
+
+A shape cannot carry both `style.shading.fill` and `style.border`: docx 9.7.1 writes the two fill groups in an order Word rejects, so when both are given the fill is kept, the border dropped, and a warning raised. Use one or the other, or stay on the table path.
 
 ## `highcharts`
 

--- a/packages/core-docx/src/__tests__/heading-numbering.test.ts
+++ b/packages/core-docx/src/__tests__/heading-numbering.test.ts
@@ -255,8 +255,11 @@ describe('TOC cached entries with numbering', () => {
       { name: 'heading', props: { text: 'Beta', level: 2, numbering: true } },
     ]);
 
-    expect(document).toContain('1 Alpha');
-    expect(document).toContain('1.1 Beta');
+    // The trailing period is part of the number Word draws (lvlText is `%1.`),
+    // so the cached entry has to carry it or the field visibly shifts on the
+    // reader's first refresh.
+    expect(document).toContain('1. Alpha');
+    expect(document).toContain('1.1. Beta');
   });
 
   it('leaves unnumbered headings unprefixed', async () => {

--- a/packages/core-docx/src/__tests__/heading-numbering.test.ts
+++ b/packages/core-docx/src/__tests__/heading-numbering.test.ts
@@ -1,0 +1,270 @@
+/**
+ * `heading.props.numbering` used to be accepted by the schema and ignored by
+ * the renderer. It now binds the heading to one shared multilevel definition
+ * (1., 1.1., 1.1.1.) whose levels carry `w:pStyle`, so Word treats it as its
+ * own built-in heading numbering — which is what makes the `\r` cross-reference
+ * switch and the TOC's own refresh agree with what we cache.
+ */
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { generateBufferFromJson } from '../core/generator';
+import { collectDocumentOutline } from '../core/collectTocHeadings';
+import type { SectionLayout } from '../core/layout';
+import { minimalTheme } from '../templates/themes';
+import type { ThemeConfig } from '../styles';
+
+async function pack(
+  children: unknown[],
+  options?: { customThemes: { [key: string]: ThemeConfig }; theme: string }
+): Promise<{ document: string; numbering: string }> {
+  const buf = await generateBufferFromJson(
+    {
+      name: 'docx',
+      props: { theme: options?.theme ?? 'minimal' },
+      children,
+    } as never,
+    options && { customThemes: options.customThemes }
+  );
+  const zip = await JSZip.loadAsync(buf);
+  return {
+    document: await zip.file('word/document.xml')!.async('string'),
+    numbering: (await zip.file('word/numbering.xml')?.async('string')) ?? '',
+  };
+}
+
+/** The abstract numbering whose levels bind the Heading styles. */
+function headingAbstractNum(numbering: string): string {
+  const block = (
+    numbering.match(/<w:abstractNum\b[\s\S]*?<\/w:abstractNum>/g) ?? []
+  ).find((b) => b.includes('<w:pStyle w:val="Heading1"/>'));
+  if (!block) throw new Error('no heading abstractNum in numbering.xml');
+  return block;
+}
+
+/** The concrete numId the heading definition resolves to in this document. */
+function headingNumId(numbering: string): string {
+  const abstractId = headingAbstractNum(numbering).match(
+    /w:abstractNumId="(\d+)"/
+  )?.[1];
+  const num = numbering.match(
+    new RegExp(
+      `<w:num w:numId="(\\d+)"><w:abstractNumId w:val="${abstractId}"/>`
+    )
+  );
+  if (!num) throw new Error('heading abstractNum has no concrete w:num');
+  return num[1];
+}
+
+/** Paragraph properties blocks, in document order. */
+function paragraphProps(document: string): string[] {
+  return document.match(/<w:pPr>[\s\S]*?<\/w:pPr>/g) ?? [];
+}
+
+function propsForStyle(document: string, styleId: string): string[] {
+  return paragraphProps(document).filter((p) =>
+    p.includes(`<w:pStyle w:val="${styleId}"/>`)
+  );
+}
+
+function layoutOf(components: unknown[]): SectionLayout[] {
+  return [
+    {
+      components,
+      properties: {},
+    } as unknown as SectionLayout,
+  ];
+}
+
+describe('heading numbering', () => {
+  it('binds a numbered heading to the shared definition at its own level', async () => {
+    const { document, numbering } = await pack([
+      { name: 'heading', props: { text: 'Alpha', level: 1, numbering: true } },
+      { name: 'heading', props: { text: 'Beta', level: 2, numbering: true } },
+    ]);
+
+    const numId = headingNumId(numbering);
+    expect(propsForStyle(document, 'Heading1')[0]).toContain(
+      `<w:numPr><w:ilvl w:val="0"/><w:numId w:val="${numId}"/></w:numPr>`
+    );
+    expect(propsForStyle(document, 'Heading2')[0]).toContain(
+      `<w:numPr><w:ilvl w:val="1"/><w:numId w:val="${numId}"/></w:numPr>`
+    );
+  });
+
+  it('registers the definition once however many headings use it', async () => {
+    const { numbering } = await pack(
+      Array.from({ length: 5 }, (_, i) => ({
+        name: 'heading',
+        props: { text: `H${i}`, level: 1, numbering: true },
+      }))
+    );
+
+    const withHeadingStyles = (
+      numbering.match(/<w:abstractNum\b[\s\S]*?<\/w:abstractNum>/g) ?? []
+    ).filter((b) => b.includes('<w:pStyle w:val="Heading1"/>'));
+    expect(withHeadingStyles).toHaveLength(1);
+  });
+
+  it('writes six decimal levels bound to Heading1..6, flush left', async () => {
+    const { numbering } = await pack([
+      { name: 'heading', props: { text: 'Alpha', level: 1, numbering: true } },
+    ]);
+    const abstract = headingAbstractNum(numbering);
+
+    for (let level = 0; level < 6; level++) {
+      const lvl = abstract.match(
+        new RegExp(`<w:lvl w:ilvl="${level}"[^>]*>[\\s\\S]*?</w:lvl>`)
+      )?.[0];
+      expect(lvl, `level ${level} missing`).toBeDefined();
+      expect(lvl).toContain('<w:numFmt w:val="decimal"/>');
+      expect(lvl).toContain('<w:suff w:val="space"/>');
+      expect(lvl).toContain(`<w:pStyle w:val="Heading${level + 1}"/>`);
+      expect(lvl).toContain('<w:ind w:left="0" w:hanging="0"/>');
+      const text = Array.from(
+        { length: level + 1 },
+        (_, i) => `%${i + 1}`
+      ).join('.');
+      expect(lvl).toContain(`<w:lvlText w:val="${text}."/>`);
+    }
+    // Word supports nine list levels but only six heading styles.
+    expect(abstract).not.toContain('<w:lvl w:ilvl="6"');
+  });
+
+  it('emits the numId-0 opt-out for numbering: false', async () => {
+    const { document } = await pack([
+      { name: 'heading', props: { text: 'Plain', level: 2, numbering: false } },
+    ]);
+
+    expect(propsForStyle(document, 'Heading2')[0]).toContain(
+      '<w:numPr><w:ilvl w:val="0"/><w:numId w:val="0"/></w:numPr>'
+    );
+  });
+
+  it('leaves w:numPr off entirely when numbering is absent', async () => {
+    const { document } = await pack([
+      { name: 'heading', props: { text: 'Plain', level: 1 } },
+    ]);
+
+    expect(propsForStyle(document, 'Heading1')[0]).not.toContain('<w:numPr>');
+  });
+
+  it('numbers every heading from componentDefaults, minus the opted-out one', async () => {
+    const { document, numbering } = await pack(
+      [
+        { name: 'heading', props: { text: 'Alpha', level: 1 } },
+        { name: 'heading', props: { text: 'Beta', level: 2 } },
+        {
+          name: 'heading',
+          props: { text: 'Aside', level: 2, numbering: false },
+        },
+      ],
+      {
+        theme: 'numbered',
+        customThemes: {
+          numbered: {
+            ...minimalTheme,
+            componentDefaults: {
+              ...minimalTheme.componentDefaults,
+              heading: { numbering: true },
+            },
+          },
+        },
+      }
+    );
+
+    const numId = headingNumId(numbering);
+    const level2 = propsForStyle(document, 'Heading2');
+    expect(propsForStyle(document, 'Heading1')[0]).toContain(
+      `<w:numId w:val="${numId}"/>`
+    );
+    expect(level2[0]).toContain(`<w:numId w:val="${numId}"/>`);
+    expect(level2[1]).toContain('<w:numId w:val="0"/>');
+  });
+});
+
+describe('heading numbering outline', () => {
+  it('numbers a heading sequence the way Word does', () => {
+    const outline = collectDocumentOutline(
+      layoutOf(
+        [
+          ['Alpha', 1],
+          ['Beta', 2],
+          ['Gamma', 2],
+          ['Delta', 1],
+          ['Epsilon', 3],
+        ].map(([text, level]) => ({
+          name: 'heading',
+          props: { text, level, numbering: true },
+        }))
+      )
+    );
+
+    expect(outline.entries.map((e) => e.number)).toEqual([
+      '1',
+      '1.1',
+      '1.2',
+      '2',
+      // A level-3 heading with no level-2 above it: Word writes the zeros too.
+      '2.0.1',
+    ]);
+  });
+
+  it('does not advance the counter for an opted-out heading', () => {
+    const outline = collectDocumentOutline(
+      layoutOf([
+        {
+          name: 'heading',
+          props: { text: 'Alpha', level: 1, numbering: true },
+        },
+        {
+          name: 'heading',
+          props: { text: 'Aside', level: 1, numbering: false },
+        },
+        { name: 'heading', props: { text: 'Beta', level: 1, numbering: true } },
+      ])
+    );
+
+    expect(outline.entries.map((e) => e.number)).toEqual(['1', undefined, '2']);
+  });
+
+  it('skips disabled headings', () => {
+    const outline = collectDocumentOutline(
+      layoutOf([
+        {
+          name: 'heading',
+          props: { text: 'Alpha', level: 1, numbering: true },
+        },
+        {
+          name: 'heading',
+          enabled: false,
+          props: { text: 'Dropped', level: 1, numbering: true },
+        },
+        { name: 'heading', props: { text: 'Beta', level: 1, numbering: true } },
+      ])
+    );
+
+    expect(outline.entries.map((e) => e.number)).toEqual(['1', '2']);
+  });
+});
+
+describe('TOC cached entries with numbering', () => {
+  it('prefixes the cached title with the heading number', async () => {
+    const { document } = await pack([
+      { name: 'toc', props: { title: 'Contents' } },
+      { name: 'heading', props: { text: 'Alpha', level: 1, numbering: true } },
+      { name: 'heading', props: { text: 'Beta', level: 2, numbering: true } },
+    ]);
+
+    expect(document).toContain('1 Alpha');
+    expect(document).toContain('1.1 Beta');
+  });
+
+  it('leaves unnumbered headings unprefixed', async () => {
+    const { document } = await pack([
+      { name: 'toc', props: { title: 'Contents' } },
+      { name: 'heading', props: { text: 'Alpha', level: 1 } },
+    ]);
+
+    expect(document).toContain('>Alpha<');
+  });
+});

--- a/packages/core-docx/src/components/__tests__/cross-reference.test.ts
+++ b/packages/core-docx/src/components/__tests__/cross-reference.test.ts
@@ -1,0 +1,331 @@
+/**
+ * `[@id]` cross-references: Word REF fields pointing at a numbered heading or
+ * list item, carrying the number as a cached value so the PDF path (headless
+ * LibreOffice, which never updates fields) shows it too.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import JSZip from 'jszip';
+import { generateBufferFromJson } from '../../core/generator';
+
+async function documentXml(children: unknown[]): Promise<string> {
+  const buf = await generateBufferFromJson({
+    name: 'docx',
+    props: { theme: 'minimal' },
+    children,
+  } as never);
+  const zip = await JSZip.loadAsync(buf);
+  return zip.file('word/document.xml')!.async('string');
+}
+
+/**
+ * Every `w:fldSimple` in the document, in order. A field with no cached value
+ * is self-closing, so both shapes have to match.
+ */
+function fields(xml: string): string[] {
+  return (
+    xml.match(/<w:fldSimple\b[^>]*(?:\/>|>[\s\S]*?<\/w:fldSimple>)/g) ?? []
+  );
+}
+
+const numberedHeadings = [
+  { name: 'heading', props: { text: 'Approach', level: 1, numbering: true } },
+  {
+    name: 'heading',
+    id: 'methods',
+    props: { text: 'Methods', level: 2, numbering: true },
+  },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('cross-references to headings', () => {
+  it('emits a REF field with the relative switch and the cached number', async () => {
+    const xml = await documentXml([
+      ...numberedHeadings,
+      { name: 'paragraph', props: { text: 'See [@methods] for detail.' } },
+    ]);
+
+    const field = fields(xml).find((f) => f.includes('REF methods'));
+    expect(field).toBeDefined();
+    expect(field).toContain('w:instr="REF methods \\h \\r"');
+    expect(field).toContain('>1.1<');
+  });
+
+  it('caches the item number alone for :no_context', async () => {
+    const xml = await documentXml([
+      ...numberedHeadings,
+      { name: 'paragraph', props: { text: '[@methods:no_context]' } },
+    ]);
+
+    const field = fields(xml)[0];
+    expect(field).toContain('w:instr="REF methods \\h \\n"');
+    expect(field).toContain('>1<');
+  });
+
+  it('caches the whole number for :full_context', async () => {
+    const xml = await documentXml([
+      ...numberedHeadings,
+      { name: 'paragraph', props: { text: '[@methods:full_context]' } },
+    ]);
+
+    const field = fields(xml)[0];
+    expect(field).toContain('w:instr="REF methods \\h \\w"');
+    expect(field).toContain('>1.1<');
+  });
+
+  it('references the target text for :none', async () => {
+    const xml = await documentXml([
+      ...numberedHeadings,
+      { name: 'paragraph', props: { text: '[@methods:none]' } },
+    ]);
+
+    const field = fields(xml)[0];
+    expect(field).toContain('w:instr="REF methods \\h"');
+    expect(field).toContain('>Methods<');
+  });
+
+  it('resolves a heading whose id is slugged from its text', async () => {
+    const xml = await documentXml([
+      {
+        name: 'heading',
+        props: { text: 'Data Sources', level: 1, numbering: true },
+      },
+      { name: 'paragraph', props: { text: 'See [@data-sources].' } },
+    ]);
+
+    expect(fields(xml)[0]).toContain('w:instr="REF data-sources \\h \\r"');
+  });
+
+  it('predicts the same dedupe render applies to a colliding slug', async () => {
+    // The paragraph claims "results" first, so the heading's slug has to
+    // become "results-1" — in the pre-pass exactly as in the render, or the
+    // reference points at a bookmark that is never written.
+    const xml = await documentXml([
+      { name: 'paragraph', props: { id: 'results', text: 'Summary.' } },
+      {
+        name: 'heading',
+        props: { text: 'Results', level: 1, numbering: true },
+      },
+      { name: 'paragraph', props: { text: 'See [@results-1].' } },
+    ]);
+
+    expect(xml).toContain('w:name="results-1"');
+    expect(fields(xml)[0]).toContain('>1<');
+  });
+
+  it('resolves a forward reference to a heading further down', async () => {
+    const xml = await documentXml([
+      { name: 'paragraph', props: { text: 'Later: [@methods].' } },
+      ...numberedHeadings,
+    ]);
+
+    expect(fields(xml)[0]).toContain('>1.1<');
+  });
+
+  it('works from a heading and from a list item, not only a paragraph', async () => {
+    const xml = await documentXml([
+      ...numberedHeadings,
+      { name: 'heading', props: { text: 'Recap of [@methods]', level: 2 } },
+      { name: 'list', props: { items: ['Per [@methods]'] } },
+    ]);
+
+    expect(fields(xml).filter((f) => f.includes('REF methods'))).toHaveLength(
+      2
+    );
+  });
+});
+
+describe('cross-references to list items', () => {
+  it('bookmarks an item that declares an id and caches its decimal counter', async () => {
+    const xml = await documentXml([
+      {
+        name: 'list',
+        props: {
+          format: 'numbered',
+          items: [
+            'First',
+            'Second',
+            { text: 'Third', id: 'clause-three' },
+            'Fourth',
+          ],
+        },
+      },
+      { name: 'paragraph', props: { text: 'See [@clause-three].' } },
+    ]);
+
+    const bookmark = xml.match(
+      /<w:bookmarkStart w:name="clause-three" w:id="(\d+)"\/><w:r><w:t[^>]*>Third<\/w:t><\/w:r><w:bookmarkEnd w:id="\1"\/>/
+    );
+    expect(
+      bookmark,
+      'item runs are not wrapped in the bookmark'
+    ).not.toBeNull();
+    const field = fields(xml)[0];
+    expect(field).toContain('w:instr="REF clause-three \\h \\r"');
+    expect(field).toContain('>3<');
+  });
+
+  it('caches the level format the item actually renders with', async () => {
+    const xml = await documentXml([
+      {
+        name: 'list',
+        props: {
+          levels: [{ level: 0, format: 'lowerLetter', text: '%1.' }],
+          items: ['One', 'Two', { text: 'Three', id: 'sub-c' }],
+        },
+      },
+      { name: 'paragraph', props: { text: '[@sub-c]' } },
+    ]);
+
+    expect(fields(xml)[0]).toContain('>c<');
+  });
+
+  it('continues the count across lists sharing a reference', async () => {
+    const xml = await documentXml([
+      {
+        name: 'list',
+        props: {
+          reference: 'clauses',
+          format: 'numbered',
+          items: ['One', 'Two'],
+        },
+      },
+      { name: 'paragraph', props: { text: 'Interlude.' } },
+      {
+        name: 'list',
+        props: {
+          reference: 'clauses',
+          format: 'numbered',
+          items: [{ text: 'Three', id: 'clause-three' }],
+        },
+      },
+      { name: 'paragraph', props: { text: '[@clause-three]' } },
+    ]);
+
+    expect(fields(xml)[0]).toContain('>3<');
+  });
+
+  it('restarts the count for lists with auto-generated references', async () => {
+    const xml = await documentXml([
+      { name: 'list', props: { format: 'numbered', items: ['One', 'Two'] } },
+      {
+        name: 'list',
+        props: {
+          format: 'numbered',
+          items: [{ text: 'Fresh', id: 'fresh-one' }],
+        },
+      },
+      { name: 'paragraph', props: { text: '[@fresh-one]' } },
+    ]);
+
+    expect(fields(xml)[0]).toContain('>1<');
+  });
+
+  it('honours props.start and skips empty items', async () => {
+    const xml = await documentXml([
+      {
+        name: 'list',
+        props: {
+          format: 'numbered',
+          start: 5,
+          items: ['One', '  ', { text: 'Two', id: 'second' }],
+        },
+      },
+      { name: 'paragraph', props: { text: '[@second]' } },
+    ]);
+
+    expect(fields(xml)[0]).toContain('>6<');
+  });
+
+  it('bookmarks a tracked-change item too', async () => {
+    const xml = await documentXml([
+      {
+        name: 'list',
+        props: {
+          items: [
+            {
+              text: '',
+              id: 'inserted-clause',
+              revision: {
+                author: 'A',
+                date: '2026-01-01T00:00:00Z',
+                segments: [{ type: 'insert', text: 'New clause' }],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(xml).toMatch(
+      /<w:bookmarkStart w:name="inserted-clause" w:id="(\d+)"\/><w:ins\b[\s\S]*?<\/w:ins><w:bookmarkEnd w:id="\1"\/>/
+    );
+  });
+
+  it('resolves an internal link to a bookmarked item', async () => {
+    const xml = await documentXml([
+      {
+        name: 'list',
+        props: { items: [{ text: 'Anchored', id: 'anchor-me' }] },
+      },
+      { name: 'paragraph', props: { text: '[jump](#anchor-me)' } },
+    ]);
+
+    expect(xml).toContain('w:anchor="anchor-me"');
+  });
+});
+
+describe('unresolvable cross-references', () => {
+  it('renders an unknown id as literal text and warns', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const xml = await documentXml([
+      ...numberedHeadings,
+      { name: 'paragraph', props: { text: 'See [@nope] here.' } },
+    ]);
+
+    expect(fields(xml)).toHaveLength(0);
+    expect(xml).toContain('[@nope]');
+    expect(warn.mock.calls.flat().join(' ')).toContain('[@nope]');
+  });
+
+  it('writes an uncached field for an unnumbered target and warns', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const xml = await documentXml([
+      { name: 'list', props: { items: [{ text: 'Bullet', id: 'a-bullet' }] } },
+      { name: 'paragraph', props: { text: '[@a-bullet]' } },
+    ]);
+
+    const field = fields(xml)[0];
+    expect(field).toContain('w:instr="REF a-bullet \\h \\r"');
+    // Self-closing: docx omits the cached run when there is no value.
+    expect(field).toMatch(
+      /<w:fldSimple[^>]*\/>|<w:fldSimple[^>]*><\/w:fldSimple>/
+    );
+    expect(warn.mock.calls.flat().join(' ')).toContain('unnumbered list-item');
+  });
+
+  it('still resolves the text of an unnumbered target with :none', async () => {
+    const xml = await documentXml([
+      { name: 'list', props: { items: [{ text: 'Bullet', id: 'a-bullet' }] } },
+      { name: 'paragraph', props: { text: '[@a-bullet:none]' } },
+    ]);
+
+    expect(fields(xml)[0]).toContain('>Bullet<');
+  });
+
+  it('leaves markdown links alone', async () => {
+    const xml = await documentXml([
+      {
+        name: 'paragraph',
+        props: { text: 'A [link](https://example.com) and text.' },
+      },
+    ]);
+
+    expect(xml).toContain('and text.');
+    expect(fields(xml)).toHaveLength(0);
+  });
+});

--- a/packages/core-docx/src/components/__tests__/cross-reference.test.ts
+++ b/packages/core-docx/src/components/__tests__/cross-reference.test.ts
@@ -329,3 +329,36 @@ describe('unresolvable cross-references', () => {
     expect(fields(xml)).toHaveLength(0);
   });
 });
+
+describe('cross-reference id grammar', () => {
+  // `id` is a free string in the schema, so the token grammar has to accept
+  // whatever an author can legally write on a list item or a node.
+  it.each(['item.1', 'step_2', 'fig-3a', 'Ref4'])(
+    'resolves the id %s',
+    async (id) => {
+      const xml = await documentXml([
+        {
+          name: 'list',
+          props: { format: 'numbered', items: [{ text: 'First', id }] },
+        },
+        { name: 'paragraph', props: { text: `See [@${id}].` } },
+      ]);
+
+      const field = fields(xml).find((f) => f.includes(`REF ${id}`));
+      expect(field).toBeDefined();
+      expect(field).toContain('>1<');
+    }
+  );
+
+  it('does not swallow a sentence when a token is left unclosed', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const xml = await documentXml([
+      { name: 'paragraph', props: { text: 'An [@unclosed reference here.' } },
+    ]);
+
+    expect(fields(xml)).toHaveLength(0);
+    expect(xml).toContain('reference here.');
+    expect(warn.mock.calls.flat().join(' ')).not.toContain('has no target');
+  });
+});

--- a/packages/core-docx/src/components/__tests__/text-box-shape.test.ts
+++ b/packages/core-docx/src/components/__tests__/text-box-shape.test.ts
@@ -290,4 +290,49 @@ describe('text-box renderAs shape fallbacks', () => {
       'requires paragraph-only content'
     );
   });
+
+  it.each(['dashed', 'dotted', 'double'])(
+    'falls back to the table path for a %s border rather than drawing it solid',
+    async (style) => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await render(
+        textBox({
+          renderAs: 'shape',
+          width: 200,
+          height: 100,
+          style: { border: { top: { style, width: 2, color: '#16A34A' } } },
+        })
+      );
+
+      expect(result[0]).toBeInstanceOf(Table);
+      expect(warn.mock.calls.flat().join(' ')).toContain(
+        `cannot draw a ${style} border`
+      );
+    }
+  );
+
+  it('renders each child exactly once when falling back', async () => {
+    // A child rendered twice registers its bookmark twice, and the registry
+    // reports that as a duplicate — the observable symptom of a fallback that
+    // re-renders content the shape attempt already built.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await documentXml([
+      textBox({ renderAs: 'shape', width: 200, height: 100 }, [
+        {
+          name: 'columns',
+          props: { columns: 2 },
+          children: [
+            { name: 'heading', id: 'boxed-heading', props: { text: 'Boxed' } },
+            { name: 'paragraph', props: { text: 'Right' } },
+          ],
+        },
+      ]),
+    ]);
+
+    expect(warn.mock.calls.flat().join(' ')).not.toContain(
+      'Duplicate bookmark ID'
+    );
+  });
 });

--- a/packages/core-docx/src/components/__tests__/text-box-shape.test.ts
+++ b/packages/core-docx/src/components/__tests__/text-box-shape.test.ts
@@ -1,0 +1,293 @@
+/**
+ * `text-box` with `renderAs: 'shape'` emits a native Word text box (a WPS
+ * shape) instead of the default borderless one-cell table. It gains real wrap
+ * modes and z-order and loses autofit, per-side borders and lazy percentages —
+ * so anything it cannot express falls back to the table path with a warning
+ * rather than emitting a shape that clips its own content.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import JSZip from 'jszip';
+import { Paragraph, Table } from 'docx';
+import { generateBufferFromJson } from '../../core/generator';
+import { renderTextBoxComponent } from '../text-box';
+import { minimalTheme } from '../../templates/themes';
+import { getAvailableWidthTwips } from '../../utils/widthUtils';
+import type { TextBoxComponentDefinition, RenderContext } from '../../types';
+
+const context: RenderContext = {
+  theme: { name: 'minimal', colors: {}, fonts: {}, spacing: {} },
+  fullTheme: minimalTheme,
+  document: { title: 'Test', date: new Date() },
+  section: { currentLayout: 'single', columnCount: 1, pageNumber: 1 },
+  utils: {
+    formatDate: (date: Date) => date.toISOString(),
+    parseText: (text: string) => [{ text }],
+    getStyle: (name: string) => ({ name }),
+  },
+  depth: 0,
+} as unknown as RenderContext;
+
+const paragraphChild = {
+  name: 'paragraph',
+  props: { text: 'Boxed text.' },
+};
+
+function textBox(
+  props: Record<string, unknown>,
+  children: unknown[] = [paragraphChild]
+): TextBoxComponentDefinition {
+  return {
+    name: 'text-box',
+    props,
+    children,
+  } as unknown as TextBoxComponentDefinition;
+}
+
+function render(component: TextBoxComponentDefinition) {
+  return renderTextBoxComponent(component, minimalTheme, 'minimal', context);
+}
+
+async function documentXml(children: unknown[]): Promise<string> {
+  const buf = await generateBufferFromJson({
+    name: 'docx',
+    props: { theme: 'minimal' },
+    children,
+  } as never);
+  const zip = await JSZip.loadAsync(buf);
+  return zip.file('word/document.xml')!.async('string');
+}
+
+function shapeXml(xml: string): string {
+  const match = xml.match(/<wps:wsp>[\s\S]*?<\/wps:wsp>/);
+  expect(match, 'no wps:wsp in document.xml').not.toBeNull();
+  return match![0];
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('text-box renderAs default', () => {
+  it('still renders a table when renderAs is absent', async () => {
+    const result = await render(textBox({ width: 200 }));
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeInstanceOf(Table);
+  });
+
+  it('still renders a table for an explicit renderAs: table', async () => {
+    const result = await render(textBox({ renderAs: 'table', width: 200 }));
+    expect(result[0]).toBeInstanceOf(Table);
+  });
+});
+
+describe('text-box renderAs shape', () => {
+  it('hosts the shape in a single paragraph', async () => {
+    const result = await render(
+      textBox({ renderAs: 'shape', width: 200, height: 100 })
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeInstanceOf(Paragraph);
+  });
+
+  it('writes a text box shape sized in EMU', async () => {
+    const xml = await documentXml([
+      textBox({ renderAs: 'shape', width: 200, height: 100 }),
+    ]);
+
+    const shape = shapeXml(xml);
+    expect(shape).toContain('<wps:cNvSpPr txBox="1"/>');
+    expect(shape).toContain('<a:ext cx="1905000" cy="952500"/>');
+    expect(shape).toContain('<wps:txbx><w:txbxContent>');
+    expect(shape).toContain('Boxed text.');
+  });
+
+  it('maps shading.fill to a solid fill', async () => {
+    const xml = await documentXml([
+      textBox({
+        renderAs: 'shape',
+        width: 200,
+        height: 100,
+        style: { shading: { fill: '#F0FDF4' } },
+      }),
+    ]);
+
+    expect(shapeXml(xml)).toContain(
+      '<a:solidFill><a:srgbClr val="F0FDF4"/></a:solidFill>'
+    );
+  });
+
+  it('maps a border to a single outline in EMU', async () => {
+    const xml = await documentXml([
+      textBox({
+        renderAs: 'shape',
+        width: 200,
+        height: 100,
+        style: {
+          border: {
+            top: { style: 'solid', width: 2, color: '#16A34A' },
+            right: { style: 'solid', width: 2, color: '#16A34A' },
+            bottom: { style: 'solid', width: 2, color: '#16A34A' },
+            left: { style: 'solid', width: 2, color: '#16A34A' },
+          },
+        },
+      }),
+    ]);
+
+    expect(shapeXml(xml)).toContain(
+      '<a:ln w="19050"><a:solidFill><a:srgbClr val="16A34A"/></a:solidFill></a:ln>'
+    );
+  });
+
+  it('keeps the fill and drops the border when both are asked for', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const xml = await documentXml([
+      textBox({
+        renderAs: 'shape',
+        width: 200,
+        height: 100,
+        style: {
+          shading: { fill: '#F0FDF4' },
+          border: { left: { style: 'solid', width: 3, color: '#16A34A' } },
+        },
+      }),
+    ]);
+
+    const shape = shapeXml(xml);
+    expect(shape).toContain('<a:srgbClr val="F0FDF4"/>');
+    expect(shape).not.toContain('<a:ln');
+    expect(warn.mock.calls.flat().join(' ')).toContain(
+      'cannot carry a fill and a border at once'
+    );
+  });
+
+  it('warns and uses the first side when the borders differ', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const xml = await documentXml([
+      textBox({
+        renderAs: 'shape',
+        width: 200,
+        height: 100,
+        style: {
+          border: {
+            top: { style: 'solid', width: 1, color: '#111111' },
+            left: { style: 'solid', width: 4, color: '#222222' },
+          },
+        },
+      }),
+    ]);
+
+    expect(shapeXml(xml)).toContain('<a:srgbClr val="111111"/>');
+    expect(warn.mock.calls.flat().join(' ')).toContain(
+      'using the first declared border side and ignoring left'
+    );
+  });
+
+  it('drops the outline entirely for style: none', async () => {
+    const xml = await documentXml([
+      textBox({
+        renderAs: 'shape',
+        width: 200,
+        height: 100,
+        style: { border: { top: { style: 'none' } } },
+      }),
+    ]);
+
+    expect(shapeXml(xml)).not.toContain('<a:ln');
+  });
+
+  it('maps padding to body-property insets in EMU', async () => {
+    const xml = await documentXml([
+      textBox({
+        renderAs: 'shape',
+        width: 200,
+        height: 100,
+        style: { padding: { top: 6, right: 8, bottom: 6, left: 8 } },
+      }),
+    ]);
+
+    expect(shapeXml(xml)).toContain(
+      '<wps:bodyPr lIns="76200" rIns="76200" tIns="57150" bIns="57150"/>'
+    );
+  });
+
+  it('anchors a floating shape and inlines a non-floating one', async () => {
+    const inline = await documentXml([
+      textBox({ renderAs: 'shape', width: 200, height: 100 }),
+    ]);
+    expect(inline).toContain('<wp:inline');
+    expect(inline).not.toContain('<wp:anchor');
+
+    const floated = await documentXml([
+      textBox({
+        renderAs: 'shape',
+        width: 200,
+        height: 100,
+        floating: {
+          horizontalPosition: { relative: 'margin', align: 'right' },
+          verticalPosition: { relative: 'paragraph', offset: 720 },
+          wrap: { type: 'square' },
+        },
+      }),
+    ]);
+    expect(floated).toContain('<wp:anchor');
+    expect(floated).toContain('<wp:align>right</wp:align>');
+    // 720 twips = 457200 EMU
+    expect(floated).toContain('<wp:posOffset>457200</wp:posOffset>');
+    expect(floated).toContain('<wp:wrapSquare');
+  });
+
+  it('resolves a percentage width eagerly and warns', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const xml = await documentXml([
+      textBox({ renderAs: 'shape', width: '50%', height: 100 }),
+    ]);
+
+    // Half the page's content box, converted twips → px → EMU.
+    const halfContentPx = Math.round(
+      getAvailableWidthTwips(minimalTheme, 'minimal') / 2 / 15
+    );
+    expect(shapeXml(xml)).toContain(`cx="${halfContentPx * 9525}"`);
+    expect(warn.mock.calls.flat().join(' ')).toContain(
+      'resolves percentage sizes at generation time'
+    );
+  });
+});
+
+describe('text-box renderAs shape fallbacks', () => {
+  it('falls back to the table path when height is missing', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await render(textBox({ renderAs: 'shape', width: 200 }));
+
+    expect(result[0]).toBeInstanceOf(Table);
+    expect(warn.mock.calls.flat().join(' ')).toContain(
+      'needs an explicit width and height'
+    );
+  });
+
+  it('falls back to the table path for nested columns', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await render(
+      textBox({ renderAs: 'shape', width: 200, height: 100 }, [
+        {
+          name: 'columns',
+          props: { columns: 2 },
+          children: [
+            { name: 'paragraph', props: { text: 'Left' } },
+            { name: 'paragraph', props: { text: 'Right' } },
+          ],
+        },
+      ])
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeInstanceOf(Table);
+    expect(warn.mock.calls.flat().join(' ')).toContain(
+      'requires paragraph-only content'
+    );
+  });
+});

--- a/packages/core-docx/src/components/heading.ts
+++ b/packages/core-docx/src/components/heading.ts
@@ -8,6 +8,40 @@ import { ComponentDefinition, isHeadingComponent } from '../types';
 import { ThemeConfig } from '../styles';
 import { createHeading } from '../core/content';
 import { globalBookmarkRegistry } from '../utils/bookmarkRegistry';
+import {
+  globalNumberingRegistry,
+  createHeadingNumberingConfig,
+  HEADING_NUMBERING_REFERENCE,
+} from '../utils/numberingConfig';
+
+/** Word supports six heading levels; deeper input renders as Heading1. */
+const MAX_HEADING_LEVEL = 6;
+
+/**
+ * Paragraph-level numbering for this heading, or undefined to leave `w:numPr`
+ * off entirely.
+ *
+ * The shared definition is registered lazily, on the first numbered heading,
+ * so a document without one carries no extra `w:abstractNum`.
+ */
+function headingNumbering(
+  numbering: boolean | undefined,
+  level: number
+): { reference: string; level: number } | false | undefined {
+  // An explicit false is the per-heading opt-out from a numbering that
+  // componentDefaults turned on document-wide; docx writes it as numId 0.
+  if (numbering === false) return false;
+  if (numbering !== true) return undefined;
+
+  if (!globalNumberingRegistry.has(HEADING_NUMBERING_REFERENCE)) {
+    globalNumberingRegistry.register(createHeadingNumberingConfig());
+  }
+
+  // Mirrors getStyleIdForLevel: an out-of-range level renders as Heading1, so
+  // it must number as level 1 too.
+  const styleLevel = level >= 1 && level <= MAX_HEADING_LEVEL ? level : 1;
+  return { reference: HEADING_NUMBERING_REFERENCE, level: styleLevel - 1 };
+}
 
 /**
  * Render heading component
@@ -61,6 +95,8 @@ export function renderHeadingComponent(
       indent: config.indent,
       // Bookmark ID for internal linking
       bookmarkId: bookmarkId,
+      // Auto-numbering (1., 1.1., …) through the shared heading definition
+      numbering: headingNumbering(config.numbering, config.level || 1),
       // Tracked-change segments (rendered as native Word revisions)
       revision: config.revision,
       // Review comment anchored to this heading's text

--- a/packages/core-docx/src/components/list.ts
+++ b/packages/core-docx/src/components/list.ts
@@ -4,7 +4,7 @@
  */
 
 import { Paragraph } from 'docx';
-import { ComponentDefinition, isListComponent, ListProps } from '../types';
+import { ComponentDefinition, isListComponent } from '../types';
 import { ThemeConfig } from '../styles';
 import { createList } from '../core/content';
 import {
@@ -14,69 +14,8 @@ import {
   type ListLevelConfig,
   type ListMarkerFontConfig,
 } from '../utils/numberingConfig';
+import { resolveListLevels } from '../utils/listLevels';
 import { resolveColor } from '../styles/utils/colorUtils';
-
-/**
- * Convert simplified format to proper level configurations
- */
-function createLevelsFromSimplifiedProps(props: ListProps): ListLevelConfig[] {
-  const levels: ListLevelConfig[] = [];
-
-  // Determine format from simplified options
-  let format: string;
-  let text: string | undefined;
-
-  if (props.format) {
-    if (props.format === 'numbered') {
-      format = 'decimal';
-      text = '%1.';
-    } else if (props.format === 'none') {
-      format = 'none';
-      text = '';
-    } else {
-      format = props.format;
-    }
-  } else {
-    // Default to bullet
-    format = 'bullet';
-    text = props.bullet || '•';
-  }
-
-  // Create level 0 configuration
-  const level0: ListLevelConfig = {
-    level: 0,
-    format,
-    text,
-    alignment: 'left',
-    start: props.start,
-  };
-
-  // Add indent if specified
-  if (props.indent) {
-    if (typeof props.indent === 'number') {
-      level0.indent = { left: props.indent };
-    } else {
-      level0.indent = props.indent;
-    }
-  }
-
-  levels.push(level0);
-
-  // Add default sublevels for nested lists
-  if (format === 'bullet') {
-    levels.push(
-      { level: 1, format: 'bullet', text: '◦', alignment: 'left' },
-      { level: 2, format: 'bullet', text: '▪', alignment: 'left' }
-    );
-  } else if (format === 'decimal') {
-    levels.push(
-      { level: 1, format: 'lowerLetter', text: '%2.', alignment: 'left' },
-      { level: 2, format: 'lowerRoman', text: '%3.', alignment: 'left' }
-    );
-  }
-
-  return levels;
-}
 
 /**
  * Resolve a level's marker font against the theme.
@@ -100,98 +39,6 @@ function resolveMarkerFonts(
 }
 
 /**
- * Fold `props.start` into level 0.
- *
- * `start` is otherwise only read on the simplified path, so an explicit
- * `levels` array silently discarded it. A `start` declared on the level itself
- * is more specific and wins.
- */
-function applyListStart(
-  levels: ListLevelConfig[],
-  start: number | undefined
-): ListLevelConfig[] {
-  if (start === undefined) return levels;
-  return levels.map((level) =>
-    level.level === 0 && level.start === undefined ? { ...level, start } : level
-  );
-}
-
-/**
- * Get the maximum level used in list items
- */
-function getMaxLevelFromItems(
-  items: (string | { text: string; level?: number })[] | undefined
-): number {
-  if (!items || !Array.isArray(items)) {
-    return 0;
-  }
-
-  let maxLevel = 0;
-  for (const item of items) {
-    if (typeof item === 'object' && item.level !== undefined) {
-      maxLevel = Math.max(maxLevel, item.level);
-    }
-  }
-  return maxLevel;
-}
-
-/**
- * Fill in missing levels with default configurations
- */
-function fillMissingLevels(
-  levels: ListLevelConfig[],
-  maxLevel: number
-): ListLevelConfig[] {
-  // Create a map of existing levels
-  const levelMap = new Map<number, ListLevelConfig>();
-  for (const level of levels) {
-    levelMap.set(level.level, level);
-  }
-
-  // Get level 0 to determine the base format
-  const level0 = levelMap.get(0);
-  const baseFormat = level0?.format || 'bullet';
-
-  // Create default levels for any missing ones
-  const result: ListLevelConfig[] = [];
-  for (let i = 0; i <= maxLevel; i++) {
-    if (levelMap.has(i)) {
-      result.push(levelMap.get(i)!);
-    } else {
-      // Create default sublevel based on parent format
-      if (baseFormat === 'bullet') {
-        const bullets = ['•', '◦', '▪', '▫', '‣'];
-        result.push({
-          level: i,
-          format: 'bullet',
-          text: bullets[i % bullets.length],
-          alignment: 'left',
-        });
-      } else if (baseFormat === 'decimal' || baseFormat === 'numbered') {
-        const formats = ['decimal', 'lowerLetter', 'lowerRoman'];
-        const format = formats[i % formats.length];
-        result.push({
-          level: i,
-          format,
-          text: `%${i + 1}.`,
-          alignment: 'left',
-        });
-      } else {
-        // For other formats, continue with the same format
-        result.push({
-          level: i,
-          format: baseFormat,
-          text: `%${i + 1}.`,
-          alignment: 'left',
-        });
-      }
-    }
-  }
-
-  return result;
-}
-
-/**
  * Render list component
  */
 export function renderListComponent(
@@ -204,9 +51,6 @@ export function renderListComponent(
   // Props are pre-resolved by resolveComponentTree
   const resolvedConfig = component.props;
 
-  // Determine the maximum level needed from items
-  const maxLevel = getMaxLevelFromItems(resolvedConfig.items);
-
   // Generate or use provided reference ID
   const reference =
     resolvedConfig.reference ||
@@ -214,26 +58,9 @@ export function renderListComponent(
 
   // Build numbering configuration if not already registered
   if (!globalNumberingRegistry.has(reference)) {
-    let levels: ListLevelConfig[];
-
-    if (resolvedConfig.levels && resolvedConfig.levels.length > 0) {
-      // Use explicit level configurations, filling in missing levels
-      levels = fillMissingLevels(
-        applyListStart(
-          resolvedConfig.levels as ListLevelConfig[],
-          resolvedConfig.start
-        ),
-        maxLevel
-      );
-    } else {
-      // Build from simplified options
-      const baseLevels = createLevelsFromSimplifiedProps(resolvedConfig);
-      levels = fillMissingLevels(baseLevels, maxLevel);
-    }
-
     const config: NumberingConfig = {
       reference,
-      levels: resolveMarkerFonts(levels, theme),
+      levels: resolveMarkerFonts(resolveListLevels(resolvedConfig), theme),
     };
     const numberingConfig = createNumberingConfig(config);
     globalNumberingRegistry.register(numberingConfig);

--- a/packages/core-docx/src/components/text-box.ts
+++ b/packages/core-docx/src/components/text-box.ts
@@ -132,32 +132,53 @@ function mapTableFloatOptions(
   return opt;
 }
 
+/**
+ * Render a text box's children with the box itself as their parent — the link
+ * that makes a nested `columns` render as a table rather than as a
+ * section-level column layout.
+ */
+async function renderTextBoxChildren(
+  tb: TextBoxComponentDefinition,
+  theme: ThemeConfig,
+  themeName: string,
+  context: import('../types').RenderContext
+): Promise<(Paragraph | Table)[]> {
+  const childContext: import('../types').RenderContext = {
+    ...context,
+    parent: tb,
+  };
+
+  const rendered: (Paragraph | Table)[] = [];
+  for (const child of tb.children || []) {
+    rendered.push(
+      ...(await renderComponent(child, theme, themeName, childContext))
+    );
+  }
+  return rendered;
+}
+
+/**
+ * Render the text box as a borderless one-cell table — the default, and the
+ * only rendering with autofit, per-side borders and lazy percentage widths.
+ *
+ * `prerendered` carries the children a failed shape attempt already rendered:
+ * rendering them again would repeat their bookmark, comment and footnote
+ * registrations.
+ */
 async function renderTextBoxAsTable(
   tb: TextBoxComponentDefinition,
   theme: ThemeConfig,
   themeName: string,
-  _context: import('../types').RenderContext
+  _context: import('../types').RenderContext,
+  prerendered?: (Paragraph | Table)[]
 ): Promise<(Paragraph | Table)[]> {
   const isInline = !tb.props.floating;
-  const childComponents = tb.children || [];
 
   if (isInline) {
     // Inline: use a one-cell table container for multi-paragraph support
-    const cellChildren: (Paragraph | Table)[] = [];
-    // Create context with current text-box as parent
-    const childContext: import('../types').RenderContext = {
-      ..._context,
-      parent: tb,
-    };
-    for (const child of childComponents) {
-      const rendered = await renderComponent(
-        child,
-        theme,
-        themeName,
-        childContext
-      );
-      cellChildren.push(...rendered);
-    }
+    const cellChildren =
+      prerendered ??
+      (await renderTextBoxChildren(tb, theme, themeName, _context));
 
     const styleCfg = (tb.props as any).style as CellStyleConfig | undefined;
     const cellOpts = buildCellOptions(cellChildren, styleCfg, theme);
@@ -173,23 +194,9 @@ async function renderTextBoxAsTable(
   }
 
   // Always use a floating one-cell table container for multi-paragraph support
-
-  // If there is at least one table or image child, use a floating one-cell table container
-  const cellChildren: (Paragraph | Table)[] = [];
-  // Create context with current text-box as parent
-  const childContext: import('../types').RenderContext = {
-    ..._context,
-    parent: tb,
-  };
-  for (const child of childComponents) {
-    const rendered = await renderComponent(
-      child,
-      theme,
-      themeName,
-      childContext
-    );
-    cellChildren.push(...rendered);
-  }
+  const cellChildren =
+    prerendered ??
+    (await renderTextBoxChildren(tb, theme, themeName, _context));
 
   const styleCfg = (tb.props as any).style as CellStyleConfig | undefined;
   const cellOpts = buildCellOptions(cellChildren, styleCfg, theme);
@@ -291,9 +298,13 @@ function shapeColor(value: string, theme: ThemeConfig): string {
 function shapeOutline(
   style: TextBoxStyle | undefined,
   theme: ThemeConfig
-): { outline?: IWpsShapeOptions['outline']; ignoredSides: string[] } {
+): {
+  outline?: IWpsShapeOptions['outline'];
+  ignoredSides: string[];
+  unsupportedStyles: string[];
+} {
   const border = style?.border;
-  if (!border) return { ignoredSides: [] };
+  if (!border) return { ignoredSides: [], unsupportedStyles: [] };
 
   const order: (keyof NonNullable<TextBoxStyle['border']>)[] = [
     'top',
@@ -306,7 +317,27 @@ function shapeOutline(
     .filter((entry): entry is [(typeof order)[number], BorderSide] =>
       Boolean(entry[1])
     );
-  if (declared.length === 0) return { ignoredSides: [] };
+  if (declared.length === 0) return { ignoredSides: [], unsupportedStyles: [] };
+
+  // docx's OutlineOptions carries width, cap, compound and fill — there is no
+  // `a:prstDash`, so a dash pattern cannot be expressed at all, and the one
+  // `compoundLine` that could stand in for `double` is emitted as the enum key
+  // (`cmpd="DOUBLE"`) rather than the OOXML value. Drawing any of the three as
+  // a plain solid line would silently change the design, so the caller falls
+  // back to the table rendering, which supports all of them.
+  const unsupportedStyles = [
+    ...new Set(
+      declared
+        .map(([, config]) => config.style)
+        .filter(
+          (value): value is 'dashed' | 'dotted' | 'double' =>
+            value === 'dashed' || value === 'dotted' || value === 'double'
+        )
+    ),
+  ];
+  if (unsupportedStyles.length > 0) {
+    return { ignoredSides: [], unsupportedStyles };
+  }
 
   const [, used] = declared[0];
   const differs = ({ style: s, width, color }: BorderSide): boolean =>
@@ -316,7 +347,7 @@ function shapeOutline(
     .filter(([, config]) => differs(config))
     .map(([side]) => side);
 
-  if (used.style === 'none') return { ignoredSides };
+  if (used.style === 'none') return { ignoredSides, unsupportedStyles };
 
   return {
     outline: {
@@ -328,6 +359,7 @@ function shapeOutline(
       }),
     },
     ignoredSides,
+    unsupportedStyles,
   };
 }
 
@@ -352,55 +384,58 @@ function shapeBodyProperties(
 }
 
 /**
+ * A shape rendering, or the reason there is none — carrying back whatever the
+ * attempt already rendered so the table fallback can reuse it.
+ */
+type ShapeAttempt =
+  | { kind: 'shape'; paragraphs: Paragraph[] }
+  | { kind: 'fallback'; rendered?: (Paragraph | Table)[] };
+
+/**
  * Render the text box as a native Word text box (a `wps:wsp` shape).
  *
- * Returns undefined when the request cannot be honoured — non-paragraph
- * content, or a missing dimension — so the caller falls back to the table
- * rendering rather than emitting a shape that clips its own content.
+ * Everything a shape cannot express falls back to the table rendering rather
+ * than shipping a box that clips its content or quietly redraws its border.
+ * The checks that read props only run before the children render, so the
+ * common fallbacks cost nothing.
  */
 async function renderTextBoxAsShape(
   tb: TextBoxComponentDefinition,
   theme: ThemeConfig,
   themeName: string,
   context: import('../types').RenderContext
-): Promise<Paragraph[] | undefined> {
-  // Size is checked before the children render: a fallback after rendering
-  // would render them a second time on the table path, and child side effects
-  // (bookmark, comment, footnote registrations) must happen exactly once.
+): Promise<ShapeAttempt> {
   const width = resolveShapeSize(tb.props.width, 'width', theme, themeName);
   const height = resolveShapeSize(tb.props.height, 'height', theme, themeName);
   if (width.pixels === undefined || height.pixels === undefined) {
     console.warn(
       '[core-docx] text-box renderAs "shape" needs an explicit width and height (a shape has no autofit); falling back to table rendering.'
     );
-    return undefined;
+    return { kind: 'fallback' };
   }
 
-  const childContext: import('../types').RenderContext = {
-    ...context,
-    parent: tb,
-  };
-
-  const children: Paragraph[] = [];
-  for (const child of tb.children || []) {
-    const rendered = await renderComponent(
-      child,
-      theme,
-      themeName,
-      childContext
+  const style = tb.props.style;
+  const { outline, ignoredSides, unsupportedStyles } = shapeOutline(
+    style,
+    theme
+  );
+  if (unsupportedStyles.length > 0) {
+    console.warn(
+      `[core-docx] text-box renderAs "shape" cannot draw a ${unsupportedStyles.join('/')} border (a shape outline has no dash pattern); falling back to table rendering, which draws it.`
     );
-    for (const element of rendered) {
-      // `WpsShapeCoreOptions.children` is `readonly Paragraph[]`: a nested
-      // `columns` (which renders as a Table) has nowhere to go in a shape.
-      if (!(element instanceof Paragraph)) {
-        console.warn(
-          '[core-docx] text-box renderAs "shape" requires paragraph-only content; falling back to table rendering.'
-        );
-        return undefined;
-      }
-      children.push(element);
-    }
+    return { kind: 'fallback' };
   }
+
+  const rendered = await renderTextBoxChildren(tb, theme, themeName, context);
+  // `WpsShapeCoreOptions.children` is `readonly Paragraph[]`: a nested
+  // `columns` (which renders as a Table) has nowhere to go in a shape.
+  if (rendered.some((element) => !(element instanceof Paragraph))) {
+    console.warn(
+      '[core-docx] text-box renderAs "shape" requires paragraph-only content; falling back to table rendering.'
+    );
+    return { kind: 'fallback', rendered };
+  }
+  const children = rendered as Paragraph[];
 
   if (width.resolvedPercentage || height.resolvedPercentage) {
     console.warn(
@@ -408,9 +443,7 @@ async function renderTextBoxAsShape(
     );
   }
 
-  const style = tb.props.style;
   const fill = style?.shading?.fill;
-  const { outline, ignoredSides } = shapeOutline(style, theme);
   if (ignoredSides.length > 0) {
     console.warn(
       `[core-docx] text-box renderAs "shape" has one uniform outline; using the first declared border side and ignoring ${ignoredSides.join(', ')}.`
@@ -444,7 +477,12 @@ async function renderTextBoxAsShape(
     }),
   });
 
-  return [new Paragraph({ children: [run], spacing: { before: 0, after: 0 } })];
+  return {
+    kind: 'shape',
+    paragraphs: [
+      new Paragraph({ children: [run], spacing: { before: 0, after: 0 } }),
+    ],
+  };
 }
 
 export async function renderTextBoxComponent(
@@ -457,8 +495,15 @@ export async function renderTextBoxComponent(
   const tb = component as TextBoxComponentDefinition;
 
   if (tb.props.renderAs === 'shape') {
-    const shape = await renderTextBoxAsShape(tb, theme, themeName, context);
-    if (shape) return shape;
+    const attempt = await renderTextBoxAsShape(tb, theme, themeName, context);
+    if (attempt.kind === 'shape') return attempt.paragraphs;
+    return renderTextBoxAsTable(
+      tb,
+      theme,
+      themeName,
+      context,
+      attempt.rendered
+    );
   }
 
   return renderTextBoxAsTable(tb, theme, themeName, context);

--- a/packages/core-docx/src/components/text-box.ts
+++ b/packages/core-docx/src/components/text-box.ts
@@ -14,6 +14,8 @@ import {
   RelativeVerticalPosition,
   OverlapType,
   TableLayoutType,
+  WpsShapeRun,
+  type IWpsShapeOptions,
 } from 'docx';
 import {
   ComponentDefinition,
@@ -25,6 +27,8 @@ import { ThemeConfig } from '../styles';
 import { renderComponent } from '../core/render';
 import { NONE_BORDERS } from '../styles/utils/borderUtils';
 import { buildCellOptions, CellStyleConfig } from '../styles/utils/cellUtils';
+import { resolveColor } from '../styles/utils/colorUtils';
+import { mapFloatingOptions } from '../utils/docxImagePositioning';
 import {
   resolveOffsetTwips,
   getPageWidthTwips,
@@ -128,15 +132,12 @@ function mapTableFloatOptions(
   return opt;
 }
 
-export async function renderTextBoxComponent(
-  component: ComponentDefinition,
+async function renderTextBoxAsTable(
+  tb: TextBoxComponentDefinition,
   theme: ThemeConfig,
   themeName: string,
   _context: import('../types').RenderContext
 ): Promise<(Paragraph | Table)[]> {
-  if (!isTextBoxComponent(component)) return [];
-  const tb = component as TextBoxComponentDefinition;
-
   const isInline = !tb.props.floating;
   const childComponents = tb.children || [];
 
@@ -234,4 +235,231 @@ export async function renderTextBoxComponent(
     borders: NONE_BORDERS,
   });
   return [table];
+}
+
+/** 1 px at 96 DPI in EMU (914400 EMU/inch ÷ 96 px/inch). */
+const PIXELS_TO_EMU = 9525;
+/** 1 px at 96 DPI in twips (1440 twips/inch ÷ 96 px/inch). */
+const TWIPS_PER_PIXEL = 15;
+
+type TextBoxStyle = NonNullable<TextBoxComponentDefinition['props']['style']>;
+type BorderSide = NonNullable<NonNullable<TextBoxStyle['border']>['top']>;
+
+/**
+ * Resolve a `width`/`height` prop to whole pixels.
+ *
+ * A shape carries an absolute size in the file, so a percentage cannot stay
+ * lazy the way a table's `w:tblW` can: it is resolved here against the page's
+ * content box and frozen. Callers warn about that, once per text box.
+ */
+function resolveShapeSize(
+  value: number | string | undefined,
+  axis: 'width' | 'height',
+  theme: ThemeConfig,
+  themeName: string
+): { pixels?: number; resolvedPercentage: boolean } {
+  if (typeof value === 'number') {
+    return { pixels: Math.round(value), resolvedPercentage: false };
+  }
+  if (typeof value !== 'string') return { resolvedPercentage: false };
+
+  const fraction = parseFloat(value) / 100;
+  if (!Number.isFinite(fraction) || fraction <= 0) {
+    return { resolvedPercentage: false };
+  }
+  const availableTwips =
+    axis === 'width'
+      ? getAvailableWidthTwips(theme, themeName)
+      : getAvailableHeightTwips(theme, themeName);
+  return {
+    pixels: Math.round((availableTwips * fraction) / TWIPS_PER_PIXEL),
+    resolvedPercentage: true,
+  };
+}
+
+/** Hex without the leading '#', which DrawingML's `a:srgbClr` does not take. */
+function shapeColor(value: string, theme: ThemeConfig): string {
+  return resolveColor(value, theme).replace(/^#/, '');
+}
+
+/**
+ * Collapse the per-side border config into the single `a:ln` a shape has.
+ *
+ * Sides are considered in top/left/bottom/right order; when they disagree, the
+ * first one wins and the caller is told which.
+ */
+function shapeOutline(
+  style: TextBoxStyle | undefined,
+  theme: ThemeConfig
+): { outline?: IWpsShapeOptions['outline']; ignoredSides: string[] } {
+  const border = style?.border;
+  if (!border) return { ignoredSides: [] };
+
+  const order: (keyof NonNullable<TextBoxStyle['border']>)[] = [
+    'top',
+    'left',
+    'bottom',
+    'right',
+  ];
+  const declared = order
+    .map((side) => [side, border[side]] as const)
+    .filter((entry): entry is [(typeof order)[number], BorderSide] =>
+      Boolean(entry[1])
+    );
+  if (declared.length === 0) return { ignoredSides: [] };
+
+  const [, used] = declared[0];
+  const differs = ({ style: s, width, color }: BorderSide): boolean =>
+    s !== used.style || width !== used.width || color !== used.color;
+  const ignoredSides = declared
+    .slice(1)
+    .filter(([, config]) => differs(config))
+    .map(([side]) => side);
+
+  if (used.style === 'none') return { ignoredSides };
+
+  return {
+    outline: {
+      type: 'solidFill',
+      solidFillType: 'rgb',
+      value: used.color ? shapeColor(used.color, theme) : '000000',
+      ...(used.width !== undefined && {
+        width: Math.round(used.width * PIXELS_TO_EMU),
+      }),
+    },
+    ignoredSides,
+  };
+}
+
+/** `bodyPr` insets are EMU, like every other DrawingML length. */
+function shapeBodyProperties(
+  style: TextBoxStyle | undefined
+): IWpsShapeOptions['bodyProperties'] {
+  const padding = style?.padding;
+  if (!padding) return undefined;
+
+  const toEmu = (value: number | undefined) =>
+    value === undefined ? undefined : Math.round(value * PIXELS_TO_EMU);
+
+  return {
+    margins: {
+      ...(padding.top !== undefined && { top: toEmu(padding.top) }),
+      ...(padding.bottom !== undefined && { bottom: toEmu(padding.bottom) }),
+      ...(padding.left !== undefined && { left: toEmu(padding.left) }),
+      ...(padding.right !== undefined && { right: toEmu(padding.right) }),
+    },
+  };
+}
+
+/**
+ * Render the text box as a native Word text box (a `wps:wsp` shape).
+ *
+ * Returns undefined when the request cannot be honoured — non-paragraph
+ * content, or a missing dimension — so the caller falls back to the table
+ * rendering rather than emitting a shape that clips its own content.
+ */
+async function renderTextBoxAsShape(
+  tb: TextBoxComponentDefinition,
+  theme: ThemeConfig,
+  themeName: string,
+  context: import('../types').RenderContext
+): Promise<Paragraph[] | undefined> {
+  // Size is checked before the children render: a fallback after rendering
+  // would render them a second time on the table path, and child side effects
+  // (bookmark, comment, footnote registrations) must happen exactly once.
+  const width = resolveShapeSize(tb.props.width, 'width', theme, themeName);
+  const height = resolveShapeSize(tb.props.height, 'height', theme, themeName);
+  if (width.pixels === undefined || height.pixels === undefined) {
+    console.warn(
+      '[core-docx] text-box renderAs "shape" needs an explicit width and height (a shape has no autofit); falling back to table rendering.'
+    );
+    return undefined;
+  }
+
+  const childContext: import('../types').RenderContext = {
+    ...context,
+    parent: tb,
+  };
+
+  const children: Paragraph[] = [];
+  for (const child of tb.children || []) {
+    const rendered = await renderComponent(
+      child,
+      theme,
+      themeName,
+      childContext
+    );
+    for (const element of rendered) {
+      // `WpsShapeCoreOptions.children` is `readonly Paragraph[]`: a nested
+      // `columns` (which renders as a Table) has nowhere to go in a shape.
+      if (!(element instanceof Paragraph)) {
+        console.warn(
+          '[core-docx] text-box renderAs "shape" requires paragraph-only content; falling back to table rendering.'
+        );
+        return undefined;
+      }
+      children.push(element);
+    }
+  }
+
+  if (width.resolvedPercentage || height.resolvedPercentage) {
+    console.warn(
+      '[core-docx] text-box renderAs "shape" resolves percentage sizes at generation time, against the current page content box; the shape will not reflow if the page size changes.'
+    );
+  }
+
+  const style = tb.props.style;
+  const fill = style?.shading?.fill;
+  const { outline, ignoredSides } = shapeOutline(style, theme);
+  if (ignoredSides.length > 0) {
+    console.warn(
+      `[core-docx] text-box renderAs "shape" has one uniform outline; using the first declared border side and ignoring ${ignoredSides.join(', ')}.`
+    );
+  }
+
+  // docx 9.7.1 emits `a:noFill` + `a:ln` for an outline and then `a:solidFill`
+  // for the fill, which is two fill groups in the wrong order for
+  // CT_ShapeProperties — Word rejects it. Verified against the packed XML, so
+  // when both are asked for, the fill wins.
+  const dropOutline = Boolean(fill) && Boolean(outline);
+  if (dropOutline) {
+    console.warn(
+      '[core-docx] text-box renderAs "shape" cannot carry a fill and a border at once (docx emits invalid shape properties); keeping the fill and dropping the border.'
+    );
+  }
+
+  const bodyProperties = shapeBodyProperties(style);
+  const run = new WpsShapeRun({
+    type: 'wps',
+    children,
+    transformation: { width: width.pixels, height: height.pixels },
+    ...(fill && {
+      solidFill: { type: 'rgb', value: shapeColor(fill, theme) } as const,
+    }),
+    ...(outline && !dropOutline && { outline }),
+    ...(bodyProperties && { bodyProperties }),
+    // Absent `floating` makes it a `wp:inline` drawing.
+    ...(tb.props.floating && {
+      floating: mapFloatingOptions(tb.props.floating, theme, themeName),
+    }),
+  });
+
+  return [new Paragraph({ children: [run], spacing: { before: 0, after: 0 } })];
+}
+
+export async function renderTextBoxComponent(
+  component: ComponentDefinition,
+  theme: ThemeConfig,
+  themeName: string,
+  context: import('../types').RenderContext
+): Promise<(Paragraph | Table)[]> {
+  if (!isTextBoxComponent(component)) return [];
+  const tb = component as TextBoxComponentDefinition;
+
+  if (tb.props.renderAs === 'shape') {
+    const shape = await renderTextBoxAsShape(tb, theme, themeName, context);
+    if (shape) return shape;
+  }
+
+  return renderTextBoxAsTable(tb, theme, themeName, context);
 }

--- a/packages/core-docx/src/components/toc/index.ts
+++ b/packages/core-docx/src/components/toc/index.ts
@@ -93,7 +93,12 @@ function selectCachedEntries(
     if (entry.level < depthStart || entry.level > depthEnd) continue;
     // `page` is deliberately omitted: nothing in generation paginates, and
     // Word fills in real numbers the moment it refreshes the field.
-    entries.push({ title: entry.title, level: entry.level });
+    // A numbered heading shows its number in Word's own refresh, so the cached
+    // copy has to carry it too or the two disagree.
+    entries.push({
+      title: entry.number ? `${entry.number} ${entry.title}` : entry.title,
+      level: entry.level,
+    });
   }
 
   return entries;

--- a/packages/core-docx/src/components/toc/index.ts
+++ b/packages/core-docx/src/components/toc/index.ts
@@ -27,6 +27,7 @@ import type { TocProps } from '@json-to-office/shared-docx';
 import type { ThemeConfig } from '../../styles';
 import type { RenderContext } from '../../types';
 import type { TocHeadingEntry } from '../../core/collectTocHeadings';
+import { headingNumberLabel } from '../../utils/numberingConfig';
 
 export interface TocComponentDefinition {
   name: 'toc';
@@ -94,9 +95,11 @@ function selectCachedEntries(
     // `page` is deliberately omitted: nothing in generation paginates, and
     // Word fills in real numbers the moment it refreshes the field.
     // A numbered heading shows its number in Word's own refresh, so the cached
-    // copy has to carry it too or the two disagree.
+    // copy has to carry it too — in the same form, trailing period included.
     entries.push({
-      title: entry.number ? `${entry.number} ${entry.title}` : entry.title,
+      title: entry.number
+        ? `${headingNumberLabel(entry.number)} ${entry.title}`
+        : entry.title,
       level: entry.level,
     });
   }

--- a/packages/core-docx/src/core/cached-render.ts
+++ b/packages/core-docx/src/core/cached-render.ts
@@ -3,7 +3,7 @@
  * Provides caching layer for component rendering operations
  */
 
-import { Paragraph, Table, TableOfContents, Textbox } from 'docx';
+import { Paragraph, Table, TableOfContents } from 'docx';
 import { ComponentDefinition, RenderContext } from '../types';
 import { ThemeConfig } from '../styles';
 import {
@@ -215,7 +215,7 @@ export async function renderComponentWithCache(
   themeName: string,
   context: RenderContext,
   bypassCache = false
-): Promise<(Paragraph | Table | TableOfContents | Textbox)[]> {
+): Promise<(Paragraph | Table | TableOfContents)[]> {
   const bypassReason = componentBypassReason(component);
 
   // Initialize cache if needed
@@ -276,7 +276,7 @@ export async function renderComponentWithCache(
   if (cached) {
     // Cache hit - the cache internally tracks this as a hit
     // Return the rendered result from cache
-    return cached.result as (Paragraph | Table | TableOfContents | Textbox)[];
+    return cached.result as (Paragraph | Table | TableOfContents)[];
   }
 
   // Cache miss - render the component

--- a/packages/core-docx/src/core/collectTocHeadings.ts
+++ b/packages/core-docx/src/core/collectTocHeadings.ts
@@ -1,5 +1,7 @@
 /**
- * collectTocHeadings — per-document TOC entry pre-pass (#174).
+ * collectDocumentOutline — per-document pre-pass over the layout (#174, #177,
+ * #182). One walk, three outputs: TOC entries, heading numbers, and the
+ * cross-reference targets `[@id]` resolves against.
  *
  * `updateFields: true` asks Word to repopulate every TOC field on open, and
  * Word obliges. Headless LibreOffice does not, so a TOC field with no cached
@@ -32,6 +34,10 @@
  * `themeStyle` a TOC maps via `props.styles` (the `\t` switch). Collecting only
  * the first would make the cached entries disagree with Word's own refresh —
  * exactly the failure `cachedEntries` exists to prevent.
+ *
+ * The walk also owns the two counters render cannot keep itself: the heading
+ * numbering sequence (a cross-reference needs the number of a heading that may
+ * come later in the document) and each list's item counters.
  */
 
 import { getStandardComponent } from '@json-to-office/shared-docx';
@@ -40,6 +46,14 @@ import type { SectionLayout } from './layout';
 import { computeSectionOrdinals } from './sectionOrdinals';
 import { globalSectionBookmarkRegistry } from './sectionBookmarks';
 import { normalizeUnicodeText } from '../utils/unicode';
+import {
+  slugifyBookmarkText,
+  dedupeBookmarkId,
+} from '../utils/bookmarkRegistry';
+import type { NumberedItemInfo } from '../utils/numberedItemsRegistry';
+import { resolveListLevels } from '../utils/listLevels';
+import type { ListLevelConfig } from '../utils/numberingConfig';
+import { formatNumberForLevel } from '../utils/numberFormatting';
 
 export interface TocHeadingEntry {
   /** Rendered text, with markdown decorators stripped as `createHeading` does. */
@@ -53,7 +67,20 @@ export interface TocHeadingEntry {
   styleId?: string;
   /** Bookmark of the layout section this entry sits in, when inside one. */
   sectionBookmarkId?: string;
+  /** Multilevel number ("2.1") when heading numbering applies to this entry. */
+  number?: string;
 }
+
+export interface DocumentOutline {
+  entries: TocHeadingEntry[];
+  /** Cross-reference targets, keyed by the bookmark id render will emit. */
+  numberedItems: Map<string, NumberedItemInfo>;
+}
+
+/** Word supports six heading levels; deeper input collapses onto Heading1. */
+const MAX_HEADING_LEVEL = 6;
+/** Word supports nine list levels. */
+const MAX_LIST_LEVEL = 9;
 
 /**
  * Strip the inline decorators `createHeading` consumes, so a cached entry shows
@@ -92,15 +119,164 @@ function styleEntryKey(props: Record<string, unknown>): string | undefined {
   return themeStyle;
 }
 
+/** Item shape a `list` component's `items` array can hold. */
+type ListItem = {
+  text?: unknown;
+  level?: unknown;
+  revision?: unknown;
+  id?: unknown;
+};
+
+/** Per numbering reference: its level definitions and where each counter is. */
+interface ListCounterState {
+  levels: readonly ListLevelConfig[];
+  /** One slot per list level, already decremented to "before the start". */
+  counters: number[];
+}
+
+function levelStart(levels: readonly ListLevelConfig[], level: number): number {
+  return levels[level]?.start ?? 1;
+}
+
 /**
- * Collect every TOC-eligible entry in document order, tagged with the layout
- * section it belongs to so a section-scoped TOC can filter to its own.
+ * Walk the document once and derive everything render needs to know about it up
+ * front: the TOC entries, the heading numbers, and the cross-reference targets
+ * keyed by the bookmark ids render will produce.
+ *
+ * The id prediction is the delicate part. `renderHeadingComponent` slugs a
+ * heading's text and disambiguates it against bookmarks registered *so far*, so
+ * this walk must see the same ids in the same order — including the explicit
+ * `props.id` a paragraph registers — or a cross-reference resolves against an
+ * id that never gets written.
  */
-export function collectTocHeadings(
+export function collectDocumentOutline(
   sections: readonly SectionLayout[]
-): TocHeadingEntry[] {
+): DocumentOutline {
   const entries: TocHeadingEntry[] = [];
+  const numberedItems = new Map<string, NumberedItemInfo>();
   const ordinals = computeSectionOrdinals(sections);
+
+  // Bookmark ids already claimed, in walk order — the pre-pass mirror of the
+  // bookmark registry render fills as it goes.
+  const takenIds = new Set<string>();
+  const headingCounters = new Array<number>(MAX_HEADING_LEVEL).fill(0);
+  // Lists sharing an explicit `reference` share one numbering definition, so
+  // their counters continue. An auto-generated reference is unique per list, so
+  // such a list gets a fresh state that nothing else can reach.
+  const listCounters = new Map<string, ListCounterState>();
+
+  const visitHeading = (
+    component: ComponentDefinition,
+    props: Record<string, unknown>,
+    sectionBookmarkId: string | undefined
+  ): void => {
+    const text = typeof props.text === 'string' ? props.text : '';
+    const title = normalizeEntryTitle(text);
+    const level = typeof props.level === 'number' ? props.level : 1;
+    // Mirrors getStyleIdForLevel: an out-of-range level renders as Heading1.
+    const styleLevel = level >= 1 && level <= MAX_HEADING_LEVEL ? level : 1;
+
+    let full: string | undefined;
+    let own: string | undefined;
+    if (props.numbering === true) {
+      headingCounters[styleLevel - 1] += 1;
+      for (let deeper = styleLevel; deeper < MAX_HEADING_LEVEL; deeper++) {
+        headingCounters[deeper] = 0;
+      }
+      // A level-3 heading with no level-2 above it numbers "1.0.1", exactly as
+      // Word does; there is nothing to special-case.
+      full = headingCounters.slice(0, styleLevel).join('.');
+      own = String(headingCounters[styleLevel - 1]);
+    }
+
+    const explicitId = (component as { id?: unknown }).id;
+    const bookmarkId =
+      typeof explicitId === 'string' && explicitId
+        ? explicitId
+        : dedupeBookmarkId(slugifyBookmarkText(text), (id) => takenIds.has(id));
+    takenIds.add(bookmarkId);
+    numberedItems.set(bookmarkId, {
+      kind: 'heading',
+      text: title,
+      ...(full !== undefined && { full, own }),
+    });
+
+    if (title) {
+      entries.push({
+        title,
+        level,
+        sectionBookmarkId,
+        ...(full !== undefined && { number: full }),
+      });
+    }
+  };
+
+  const visitList = (props: Record<string, unknown>): void => {
+    const items = Array.isArray(props.items)
+      ? (props.items as (string | ListItem)[])
+      : [];
+    if (items.length === 0) return;
+
+    const reference =
+      typeof props.reference === 'string' && props.reference
+        ? props.reference
+        : undefined;
+
+    const freshState = (): ListCounterState => {
+      const levels = resolveListLevels(
+        props as Parameters<typeof resolveListLevels>[0]
+      );
+      return {
+        levels,
+        counters: Array.from(
+          { length: MAX_LIST_LEVEL },
+          (_, level) => levelStart(levels, level) - 1
+        ),
+      };
+    };
+
+    let state: ListCounterState;
+    if (reference === undefined) {
+      state = freshState();
+    } else {
+      state = listCounters.get(reference) ?? freshState();
+      listCounters.set(reference, state);
+    }
+
+    for (const item of items) {
+      const isObject = typeof item === 'object' && item !== null;
+      const raw = isObject ? item.text : item;
+      const text = typeof raw === 'string' ? raw : '';
+      // Same skip rule as createList: an empty item renders nothing and so
+      // never advances the counter.
+      if (!text.trim() && !(isObject && item.revision)) continue;
+
+      const rawLevel = isObject ? item.level : undefined;
+      const level =
+        typeof rawLevel === 'number' && rawLevel >= 0 ? rawLevel : 0;
+      if (level >= MAX_LIST_LEVEL) continue;
+
+      state.counters[level] += 1;
+      for (let deeper = level + 1; deeper < MAX_LIST_LEVEL; deeper++) {
+        state.counters[deeper] = levelStart(state.levels, deeper) - 1;
+      }
+
+      const id = isObject ? item.id : undefined;
+      if (typeof id !== 'string' || !id) continue;
+      takenIds.add(id);
+      // A single level's counter, not a "1.a.i" chain: Word's `\r` switch on a
+      // list item shows the item's own number.
+      const number = formatNumberForLevel(
+        state.counters[level],
+        state.levels[level]?.format
+      );
+      numberedItems.set(id, {
+        kind: 'list-item',
+        text: normalizeUnicodeText(text).trim(),
+        ...(number !== undefined && { full: number, own: number }),
+      });
+    }
+  };
 
   sections.forEach((section, index) => {
     // Ordinal 0 means a continuation chunk that appears before any opening
@@ -119,16 +295,15 @@ export function collectTocHeadings(
       const props = (component.props ?? {}) as Record<string, unknown>;
 
       if (component.name === 'heading') {
-        const text = typeof props.text === 'string' ? props.text : '';
-        const title = normalizeEntryTitle(text);
-        if (title) {
-          const level = typeof props.level === 'number' ? props.level : 1;
-          entries.push({ title, level, sectionBookmarkId });
-        }
+        visitHeading(component, props, sectionBookmarkId);
         return;
       }
 
       if (component.name === 'paragraph') {
+        // `props.id` is the bookmark a paragraph registers when it renders;
+        // claiming it here keeps a later heading slug dedupe in step.
+        if (typeof props.id === 'string' && props.id) takenIds.add(props.id);
+
         const styleId = styleEntryKey(props);
         const text = typeof props.text === 'string' ? props.text : '';
         const title = normalizeEntryTitle(text);
@@ -136,6 +311,11 @@ export function collectTocHeadings(
           // Level is decided by the TOC's own style mapping, not here.
           entries.push({ title, level: 1, styleId, sectionBookmarkId });
         }
+        return;
+      }
+
+      if (component.name === 'list') {
+        visitList(props);
         return;
       }
 
@@ -150,5 +330,15 @@ export function collectTocHeadings(
     section.components.forEach(visit);
   });
 
-  return entries;
+  return { entries, numberedItems };
+}
+
+/**
+ * Collect every TOC-eligible entry in document order, tagged with the layout
+ * section it belongs to so a section-scoped TOC can filter to its own.
+ */
+export function collectTocHeadings(
+  sections: readonly SectionLayout[]
+): TocHeadingEntry[] {
+  return collectDocumentOutline(sections).entries;
 }

--- a/packages/core-docx/src/core/content.ts
+++ b/packages/core-docx/src/core/content.ts
@@ -38,6 +38,7 @@ import { getThemeColors, getThemeFonts } from '../themes/defaults';
 import {
   parseTextWithDecorators,
   splitByNoProofWords,
+  hasCrossReference,
 } from '../utils/textParser';
 import {
   processTextWithPlaceholders,
@@ -163,6 +164,12 @@ export interface TextOptions {
   prependChildren?: any[];
   // Outline level for TOC
   outlineLevel?: number;
+  /**
+   * Paragraph-level numbering (`w:numPr`). `false` is the explicit opt-out
+   * docx writes as numId 0 — the only way a single heading escapes a numbering
+   * turned on for every heading through componentDefaults.
+   */
+  numbering?: { reference: string; level: number } | false;
   // Bookmark ID for internal linking
   bookmarkId?: string;
   // Floating frame properties
@@ -672,8 +679,12 @@ export function createHeading(
     children.push(...commentAnchor.start);
   }
 
-  // Check if text has decorators (bold/italic markers)
-  const hasDecorators = /(\*\*\*|___|(\*\*|__)|(\*|_))/.test(normalizedText);
+  // Anything the inline parser has to see: markdown decorators, or a `[@id]`
+  // cross-reference. Simple headings take the cheaper run builder below, which
+  // treats every character as literal text.
+  const hasInlineSyntax =
+    /(\*\*\*|___|(\*\*|__)|(\*|_))/.test(normalizedText) ||
+    hasCrossReference(normalizedText);
 
   // Headings default to theme.fonts.heading when no explicit family is given.
   // Resolve it so fontWeight can be aliased through the same path as body runs.
@@ -764,7 +775,7 @@ export function createHeading(
     // Wrap heading text in bookmark
     const headingTextChildren: (TextRun | any)[] = [];
 
-    if (hasDecorators) {
+    if (hasInlineSyntax) {
       // For headings with decorators, parse text runs first
       const textRuns = parseTextWithDecorators(normalizedText, baseTextStyle, {
         boldColor: options.boldColor
@@ -788,7 +799,7 @@ export function createHeading(
     );
   } else {
     // No bookmark, add text directly
-    if (hasDecorators) {
+    if (hasInlineSyntax) {
       // For headings with decorators, parse and add text runs
       const textRuns = parseTextWithDecorators(normalizedText, baseTextStyle, {
         boldColor: options.boldColor
@@ -817,6 +828,9 @@ export function createHeading(
     ...(options.keepNext !== undefined && { keepNext: options.keepNext }),
     ...(options.keepLines !== undefined && { keepLines: options.keepLines }),
     ...(options.indent && { indent: options.indent }),
+    // docx creates the concrete numbering instance for the reference itself,
+    // in ParagraphProperties.prepForXml.
+    ...(options.numbering !== undefined && { numbering: options.numbering }),
   });
 }
 
@@ -1041,7 +1055,10 @@ export function createStatistic(
  * Create a list of items using proper docx numbering
  */
 export function createList(
-  items: (string | { text: string; level?: number; revision?: Revision })[],
+  items: (
+    | string
+    | { text: string; level?: number; id?: string; revision?: Revision }
+  )[],
   _theme: ThemeConfig,
   _themeName: string,
   options: ListOptions = {}
@@ -1106,10 +1123,22 @@ export function createList(
       spacing.after = pointsToTwips(options.spacing.item);
     }
 
+    // A bookmarked item is a cross-reference target (`[@id]`) and an internal
+    // link target. The bookmark wraps the text runs only — the comment range
+    // stays outside it, as it does on a heading.
+    const itemId = typeof item === 'object' ? item.id : undefined;
+    let itemContent: ParagraphChild[] = textRuns;
+    if (itemId) {
+      globalBookmarkRegistry.register(itemId, itemText, 'list-item');
+      itemContent = [
+        new Bookmark({ id: itemId, children: textRuns as TextRun[] }),
+      ];
+    }
+
     // Create the paragraph with proper numbering reference
     const paragraphChildren: ParagraphChild[] = [
       ...(commentAnchor && index === firstRendered ? commentAnchor.start : []),
-      ...textRuns,
+      ...itemContent,
       ...(commentAnchor && index === lastRendered
         ? closeCommentRange(commentAnchor.ids)
         : []),

--- a/packages/core-docx/src/core/render.ts
+++ b/packages/core-docx/src/core/render.ts
@@ -14,7 +14,6 @@ import {
   AlignmentType,
   BookmarkStart,
   BookmarkEnd,
-  Textbox,
 } from 'docx';
 import {
   calculateImageDimensions,
@@ -97,8 +96,9 @@ import {
 import type { GenerationWarning } from '@json-to-office/shared';
 import { prerasterizeVisuals } from './prerasterizeVisuals';
 import { computeSectionOrdinals } from './sectionOrdinals';
-import { collectTocHeadings } from './collectTocHeadings';
+import { collectDocumentOutline } from './collectTocHeadings';
 import { globalSectionBookmarkRegistry } from './sectionBookmarks';
+import { globalNumberedItemsRegistry } from '../utils/numberedItemsRegistry';
 
 interface RenderDocumentOptions {
   cache?: MemoryCache;
@@ -206,7 +206,11 @@ export async function renderDocument(
                   // Footnote ids are document-scoped too: a reference resolved
                   // against another render's counter points at the wrong body.
                   globalNoteRegistry.runScoped(() =>
-                    renderDocumentScoped(structure, layout, options)
+                    // Cross-reference targets are keyed by bookmark id, which
+                    // is only unique within one document.
+                    globalNumberedItemsRegistry.runScoped(() =>
+                      renderDocumentScoped(structure, layout, options)
+                    )
                   )
                 )
               )
@@ -263,18 +267,21 @@ async function renderDocumentScoped(
     );
   }
 
-  // Collect TOC entries before rendering so a TOC field can carry cached
-  // content for readers that never refresh fields (#174). Same
-  // catch-and-degrade discipline as the visual pre-pass: a failure here costs
-  // the cached entries, never the document.
+  // Walk the outline before rendering so a TOC field can carry cached content
+  // for readers that never refresh fields (#174), headings know their number
+  // (#177), and a `[@id]` cross-reference can resolve a target that appears
+  // later in the document (#182). Same catch-and-degrade discipline as the
+  // visual pre-pass: a failure here costs the cached entries and the
+  // cross-reference values, never the document.
   try {
-    const tocHeadings = collectTocHeadings(layout.sections);
-    if (tocHeadings.length > 0) {
-      context.tocHeadings = tocHeadings;
+    const outline = collectDocumentOutline(layout.sections);
+    if (outline.entries.length > 0) {
+      context.tocHeadings = outline.entries;
     }
+    globalNumberedItemsRegistry.seed(outline.numberedItems);
   } catch (error) {
     console.warn(
-      '[core-docx] TOC entry collection failed; the TOC field will rely on the reader refreshing it:',
+      '[core-docx] Document outline collection failed; the TOC field will rely on the reader refreshing it:',
       error instanceof Error ? error.message : error
     );
   }
@@ -753,7 +760,7 @@ export async function renderComponent(
   theme: ThemeConfig,
   themeName: string,
   context: RenderContext
-): Promise<(Paragraph | Table | TableOfContents | Textbox)[]> {
+): Promise<(Paragraph | Table | TableOfContents)[]> {
   if (isHeadingComponent(component)) {
     return renderHeadingComponent(component, theme, themeName);
   } else if (isParagraphComponent(component)) {

--- a/packages/core-docx/src/templates/themes/apex.docx.theme.json
+++ b/packages/core-docx/src/templates/themes/apex.docx.theme.json
@@ -113,9 +113,6 @@
     },
     "section": {
       "pageBreak": false
-    },
-    "heading": {
-      "numbering": false
     }
   }
 }

--- a/packages/core-docx/src/templates/themes/corporate.docx.theme.json
+++ b/packages/core-docx/src/templates/themes/corporate.docx.theme.json
@@ -110,9 +110,6 @@
     },
     "section": {
       "pageBreak": false
-    },
-    "heading": {
-      "numbering": false
     }
   }
 }

--- a/packages/core-docx/src/templates/themes/devportal.docx.theme.json
+++ b/packages/core-docx/src/templates/themes/devportal.docx.theme.json
@@ -121,9 +121,6 @@
     },
     "section": {
       "pageBreak": false
-    },
-    "heading": {
-      "numbering": false
     }
   }
 }

--- a/packages/core-docx/src/templates/themes/minimal.docx.theme.json
+++ b/packages/core-docx/src/templates/themes/minimal.docx.theme.json
@@ -181,9 +181,6 @@
     },
     "section": {
       "pageBreak": false
-    },
-    "heading": {
-      "numbering": false
     }
   }
 }

--- a/packages/core-docx/src/utils/__tests__/numberFormatting.test.ts
+++ b/packages/core-docx/src/utils/__tests__/numberFormatting.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { formatNumberForLevel } from '../numberFormatting';
+
+describe('formatNumberForLevel', () => {
+  it('renders decimals', () => {
+    expect(formatNumberForLevel(1, 'decimal')).toBe('1');
+    expect(formatNumberForLevel(42, 'decimal')).toBe('42');
+  });
+
+  it('repeats the letter past z, as Word does', () => {
+    expect(formatNumberForLevel(1, 'lowerLetter')).toBe('a');
+    expect(formatNumberForLevel(26, 'lowerLetter')).toBe('z');
+    expect(formatNumberForLevel(27, 'lowerLetter')).toBe('aa');
+    expect(formatNumberForLevel(53, 'lowerLetter')).toBe('aaa');
+    expect(formatNumberForLevel(28, 'upperLetter')).toBe('BB');
+  });
+
+  it('renders roman numerals in both cases', () => {
+    const cases: [number, string][] = [
+      [1, 'i'],
+      [4, 'iv'],
+      [9, 'ix'],
+      [14, 'xiv'],
+      [40, 'xl'],
+      [90, 'xc'],
+      [400, 'cd'],
+      [900, 'cm'],
+      [1990, 'mcmxc'],
+    ];
+    for (const [value, expected] of cases) {
+      expect(formatNumberForLevel(value, 'lowerRoman')).toBe(expected);
+      expect(formatNumberForLevel(value, 'upperRoman')).toBe(
+        expected.toUpperCase()
+      );
+    }
+  });
+
+  it('returns undefined for formats with no unambiguous glyph sequence', () => {
+    expect(formatNumberForLevel(1, 'bullet')).toBeUndefined();
+    expect(formatNumberForLevel(1, 'none')).toBeUndefined();
+    expect(formatNumberForLevel(1, 'chineseCounting')).toBeUndefined();
+    expect(formatNumberForLevel(1, undefined)).toBeUndefined();
+  });
+
+  it('returns undefined below the first counter value', () => {
+    expect(formatNumberForLevel(0, 'decimal')).toBeUndefined();
+    expect(formatNumberForLevel(-1, 'lowerLetter')).toBeUndefined();
+  });
+});

--- a/packages/core-docx/src/utils/bookmarkRegistry.ts
+++ b/packages/core-docx/src/utils/bookmarkRegistry.ts
@@ -16,6 +16,38 @@ interface BookmarkState {
 }
 
 /**
+ * Slug a piece of text into a bookmark id candidate.
+ *
+ * Pure half of `generateId`: the document-outline pre-pass has to predict the
+ * ids render will produce before any registry state exists, so the algorithm
+ * cannot live inside the registry.
+ */
+export function slugifyBookmarkText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .substring(0, 40); // Limit length
+}
+
+/**
+ * Disambiguate a slug against ids already taken, appending `-1`, `-2`, … .
+ * Gives up after 100 attempts and returns the colliding id, exactly as
+ * `generateId` always has.
+ */
+export function dedupeBookmarkId(
+  base: string,
+  taken: (id: string) => boolean
+): string {
+  let id = base;
+  let attempt = 0;
+  while (taken(id) && attempt < 100) {
+    id = `${base}-${++attempt}`;
+  }
+  return id;
+}
+
+/**
  * Registry for managing document bookmarks
  * Used to track bookmark IDs and validate internal hyperlink targets
  */
@@ -49,21 +81,9 @@ export class BookmarkRegistry {
    * Converts text to a URL-friendly format
    */
   generateId(text: string, _type: string = 'bookmark'): string {
-    // Convert to lowercase, replace spaces with hyphens, remove special characters
-    const baseId = text
-      .toLowerCase()
-      .replace(/\s+/g, '-')
-      .replace(/[^a-z0-9-]/g, '')
-      .substring(0, 40); // Limit length
-
-    // Ensure uniqueness by appending counter if needed
-    let id = baseId;
-    let attempt = 0;
-    while (this.state.bookmarks.has(id) && attempt < 100) {
-      id = `${baseId}-${++attempt}`;
-    }
-
-    return id;
+    return dedupeBookmarkId(slugifyBookmarkText(text), (id) =>
+      this.state.bookmarks.has(id)
+    );
   }
 
   /**

--- a/packages/core-docx/src/utils/listLevels.ts
+++ b/packages/core-docx/src/utils/listLevels.ts
@@ -1,0 +1,196 @@
+/**
+ * Level derivation for `list` components.
+ *
+ * Shared by the renderer (which turns these into `w:abstractNum` levels) and by
+ * the document-outline pre-pass (which needs each level's format and start to
+ * predict the counter a cross-reference should cache). Keeping one definition
+ * is the point: a level the renderer numbers `a., b., c.` and a pre-pass that
+ * thinks it is decimal produce a field whose cached value Word overwrites on
+ * refresh — the silent disagreement cross-references exist to avoid.
+ */
+
+import type { ListLevelConfig } from './numberingConfig';
+
+/** The `list` props this module reads, structurally. */
+export interface ListLevelSource {
+  items?: readonly (string | { readonly level?: number })[];
+  levels?: readonly ListLevelConfig[];
+  format?: string;
+  bullet?: string;
+  start?: number;
+  indent?: number | { left?: number; hanging?: number };
+}
+
+/**
+ * Convert simplified format to proper level configurations
+ */
+function createLevelsFromSimplifiedProps(
+  props: ListLevelSource
+): ListLevelConfig[] {
+  const levels: ListLevelConfig[] = [];
+
+  // Determine format from simplified options
+  let format: string;
+  let text: string | undefined;
+
+  if (props.format) {
+    if (props.format === 'numbered') {
+      format = 'decimal';
+      text = '%1.';
+    } else if (props.format === 'none') {
+      format = 'none';
+      text = '';
+    } else {
+      format = props.format;
+    }
+  } else {
+    // Default to bullet
+    format = 'bullet';
+    text = props.bullet || '•';
+  }
+
+  // Create level 0 configuration
+  const level0: ListLevelConfig = {
+    level: 0,
+    format,
+    text,
+    alignment: 'left',
+    start: props.start,
+  };
+
+  // Add indent if specified
+  if (props.indent) {
+    if (typeof props.indent === 'number') {
+      level0.indent = { left: props.indent };
+    } else {
+      level0.indent = props.indent;
+    }
+  }
+
+  levels.push(level0);
+
+  // Add default sublevels for nested lists
+  if (format === 'bullet') {
+    levels.push(
+      { level: 1, format: 'bullet', text: '◦', alignment: 'left' },
+      { level: 2, format: 'bullet', text: '▪', alignment: 'left' }
+    );
+  } else if (format === 'decimal') {
+    levels.push(
+      { level: 1, format: 'lowerLetter', text: '%2.', alignment: 'left' },
+      { level: 2, format: 'lowerRoman', text: '%3.', alignment: 'left' }
+    );
+  }
+
+  return levels;
+}
+
+/**
+ * Fold `props.start` into level 0.
+ *
+ * `start` is otherwise only read on the simplified path, so an explicit
+ * `levels` array silently discarded it. A `start` declared on the level itself
+ * is more specific and wins.
+ */
+function applyListStart(
+  levels: readonly ListLevelConfig[],
+  start: number | undefined
+): ListLevelConfig[] {
+  if (start === undefined) return [...levels];
+  return levels.map((level) =>
+    level.level === 0 && level.start === undefined ? { ...level, start } : level
+  );
+}
+
+/**
+ * Get the maximum level used in list items
+ */
+export function getMaxLevelFromItems(
+  items: readonly (string | { readonly level?: number })[] | undefined
+): number {
+  if (!items || !Array.isArray(items)) {
+    return 0;
+  }
+
+  let maxLevel = 0;
+  for (const item of items) {
+    if (typeof item === 'object' && item.level !== undefined) {
+      maxLevel = Math.max(maxLevel, item.level);
+    }
+  }
+  return maxLevel;
+}
+
+/**
+ * Fill in missing levels with default configurations
+ */
+function fillMissingLevels(
+  levels: readonly ListLevelConfig[],
+  maxLevel: number
+): ListLevelConfig[] {
+  // Create a map of existing levels
+  const levelMap = new Map<number, ListLevelConfig>();
+  for (const level of levels) {
+    levelMap.set(level.level, level);
+  }
+
+  // Get level 0 to determine the base format
+  const level0 = levelMap.get(0);
+  const baseFormat = level0?.format || 'bullet';
+
+  // Create default levels for any missing ones
+  const result: ListLevelConfig[] = [];
+  for (let i = 0; i <= maxLevel; i++) {
+    if (levelMap.has(i)) {
+      result.push(levelMap.get(i)!);
+    } else {
+      // Create default sublevel based on parent format
+      if (baseFormat === 'bullet') {
+        const bullets = ['•', '◦', '▪', '▫', '‣'];
+        result.push({
+          level: i,
+          format: 'bullet',
+          text: bullets[i % bullets.length],
+          alignment: 'left',
+        });
+      } else if (baseFormat === 'decimal' || baseFormat === 'numbered') {
+        const formats = ['decimal', 'lowerLetter', 'lowerRoman'];
+        const format = formats[i % formats.length];
+        result.push({
+          level: i,
+          format,
+          text: `%${i + 1}.`,
+          alignment: 'left',
+        });
+      } else {
+        // For other formats, continue with the same format
+        result.push({
+          level: i,
+          format: baseFormat,
+          text: `%${i + 1}.`,
+          alignment: 'left',
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * The levels a list's numbering definition ends up with: explicit `levels` when
+ * given (with `props.start` folded in), otherwise the simplified shorthand —
+ * either way padded out to the deepest level the items actually use.
+ */
+export function resolveListLevels(props: ListLevelSource): ListLevelConfig[] {
+  const maxLevel = getMaxLevelFromItems(props.items);
+
+  if (props.levels && props.levels.length > 0) {
+    return fillMissingLevels(
+      applyListStart(props.levels, props.start),
+      maxLevel
+    );
+  }
+
+  return fillMissingLevels(createLevelsFromSimplifiedProps(props), maxLevel);
+}

--- a/packages/core-docx/src/utils/numberFormatting.ts
+++ b/packages/core-docx/src/utils/numberFormatting.ts
@@ -1,0 +1,70 @@
+/**
+ * Render a list counter the way Word renders it, for the cached value of a
+ * cross-reference field.
+ *
+ * Only the formats whose glyph sequence is unambiguous are supported. Anything
+ * else (bullets, CJK counting, `none`, an unknown string) returns undefined —
+ * the caller then emits a field with no cached value rather than guessing a
+ * number Word would disagree with on refresh.
+ */
+
+const ROMAN_NUMERALS: readonly (readonly [number, string])[] = [
+  [1000, 'm'],
+  [900, 'cm'],
+  [500, 'd'],
+  [400, 'cd'],
+  [100, 'c'],
+  [90, 'xc'],
+  [50, 'l'],
+  [40, 'xl'],
+  [10, 'x'],
+  [9, 'ix'],
+  [5, 'v'],
+  [4, 'iv'],
+  [1, 'i'],
+];
+
+function toRoman(value: number): string {
+  let remaining = value;
+  let out = '';
+  for (const [amount, glyph] of ROMAN_NUMERALS) {
+    while (remaining >= amount) {
+      out += glyph;
+      remaining -= amount;
+    }
+  }
+  return out;
+}
+
+/**
+ * Word's letter sequence repeats the glyph rather than carrying: a, …, z, aa,
+ * bb, …, zz, aaa. (`27` is "aa", not "ab".)
+ */
+function toLetters(value: number): string {
+  const index = (value - 1) % 26;
+  const repeats = Math.floor((value - 1) / 26) + 1;
+  return String.fromCharCode(97 + index).repeat(repeats);
+}
+
+export function formatNumberForLevel(
+  value: number,
+  format?: string
+): string | undefined {
+  if (!Number.isFinite(value) || value < 1) return undefined;
+  const n = Math.floor(value);
+
+  switch (format) {
+    case 'decimal':
+      return String(n);
+    case 'lowerLetter':
+      return toLetters(n);
+    case 'upperLetter':
+      return toLetters(n).toUpperCase();
+    case 'lowerRoman':
+      return toRoman(n);
+    case 'upperRoman':
+      return toRoman(n).toUpperCase();
+    default:
+      return undefined;
+  }
+}

--- a/packages/core-docx/src/utils/numberedItemsRegistry.ts
+++ b/packages/core-docx/src/utils/numberedItemsRegistry.ts
@@ -1,0 +1,71 @@
+/**
+ * Numbered Item Registry
+ *
+ * Cross-reference targets — numbered headings and list items — resolved by the
+ * document-outline pre-pass and read back while rendering inline text.
+ *
+ * It is a registry rather than a field on `RenderContext` because the consumer
+ * is `textParser`, which is reached through `createText`/`createHeading`/
+ * `createList` and never sees the context.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export interface NumberedItemInfo {
+  kind: 'heading' | 'list-item';
+  /** Rendered text of the target, for a `:none` (text) reference. */
+  text: string;
+  /** Full multilevel number ("2.1.3"), absent when the target is unnumbered. */
+  full?: string;
+  /** The target's own level counter ("3"), absent when unnumbered. */
+  own?: string;
+}
+
+interface NumberedItemsState {
+  items: Map<string, NumberedItemInfo>;
+  seeded: boolean;
+}
+
+export class NumberedItemsRegistry {
+  private readonly fallback: NumberedItemsState = {
+    items: new Map(),
+    seeded: false,
+  };
+  private readonly scopes = new AsyncLocalStorage<NumberedItemsState>();
+
+  private get state(): NumberedItemsState {
+    return this.scopes.getStore() ?? this.fallback;
+  }
+
+  /** Run work with an isolated registry that follows its async call chain. */
+  runScoped<T>(callback: () => T): T {
+    return this.scopes.run({ items: new Map(), seeded: false }, callback);
+  }
+
+  /** Replace the contents with the pre-pass result. */
+  seed(items: ReadonlyMap<string, NumberedItemInfo>): void {
+    const state = this.state;
+    state.items = new Map(items);
+    state.seeded = true;
+  }
+
+  /**
+   * False outside a render (a unit test calling `createText` directly). An
+   * unresolved reference is then expected rather than an authoring mistake, so
+   * the caller stays quiet about it.
+   */
+  isSeeded(): boolean {
+    return this.state.seeded;
+  }
+
+  get(id: string): NumberedItemInfo | undefined {
+    return this.state.items.get(id);
+  }
+
+  clear(): void {
+    this.state.items.clear();
+    this.state.seeded = false;
+  }
+}
+
+export const globalNumberedItemsRegistry = new NumberedItemsRegistry();

--- a/packages/core-docx/src/utils/numberingConfig.ts
+++ b/packages/core-docx/src/utils/numberingConfig.ts
@@ -345,6 +345,20 @@ export function createHeadingNumberingConfig(): {
 }
 
 /**
+ * The heading number as Word draws it in the document — the bare dotted number
+ * plus the trailing period `lvlText` ends with.
+ *
+ * A cached TOC entry has to reproduce that form exactly: Word rewrites the
+ * entry from the heading's own rendered text the first time it refreshes the
+ * field, and an entry cached as "1.1 Methods" would visibly shift to
+ * "1.1. Methods". Cross-references keep the bare number instead — Word's `\w`
+ * switch is defined as the paragraph number *without* trailing periods.
+ */
+export function headingNumberLabel(number: string): string {
+  return `${number}.`;
+}
+
+/**
  * Registry for managing numbering configurations
  */
 export class NumberingRegistry {

--- a/packages/core-docx/src/utils/numberingConfig.ts
+++ b/packages/core-docx/src/utils/numberingConfig.ts
@@ -3,7 +3,12 @@
  * Utilities for creating and managing docx numbering configurations
  */
 
-import { AlignmentType, convertInchesToTwip, LevelFormat } from 'docx';
+import {
+  AlignmentType,
+  convertInchesToTwip,
+  LevelFormat,
+  LevelSuffix,
+} from 'docx';
 import type { ILevelsOptions, IRunStylePropertiesOptions } from 'docx';
 import { AsyncLocalStorage } from 'node:async_hooks';
 
@@ -291,6 +296,52 @@ export function createNumberedListConfig(
       createDefaultLevel(2, LevelFormat.LOWER_ROMAN, '%3.'),
     ],
   };
+}
+
+/**
+ * The one multilevel definition every numbered heading in a document shares —
+ * shared so that 1., 1.1., 1.1.1. is a single continuous sequence rather than
+ * one restarting per heading.
+ */
+export const HEADING_NUMBERING_REFERENCE = 'jto-heading-numbering';
+
+/**
+ * Word's built-in heading numbering: decimal at every level, each level's text
+ * accumulating the ones above it, bound to `Heading1`..`Heading6` through
+ * `w:lvl/w:pStyle` so Word's own "restart/continue numbering" UI and the `\r`
+ * cross-reference switch recognise it.
+ *
+ * The levels are built here rather than through `createNumberingConfig`
+ * because that helper applies list indents; a numbered heading stays flush
+ * left and takes its indentation from the heading style.
+ */
+export function createHeadingNumberingConfig(): {
+  levels: ILevelsOptions[];
+  reference: string;
+} {
+  const levels: ILevelsOptions[] = [];
+
+  for (let level = 0; level < 6; level++) {
+    const text =
+      Array.from({ length: level + 1 }, (_, i) => `%${i + 1}`).join('.') + '.';
+
+    levels.push({
+      level,
+      format: LevelFormat.DECIMAL,
+      text,
+      alignment: AlignmentType.LEFT,
+      start: 1,
+      // A space, not the default tab: a tab would push the heading text to the
+      // next tab stop and misalign it against unnumbered headings.
+      suffix: LevelSuffix.SPACE,
+      style: {
+        paragraph: { indent: { left: 0, hanging: 0 } },
+        style: `Heading${level + 1}`,
+      },
+    });
+  }
+
+  return { reference: HEADING_NUMBERING_REFERENCE, levels };
 }
 
 /**

--- a/packages/core-docx/src/utils/placeholderProcessor.ts
+++ b/packages/core-docx/src/utils/placeholderProcessor.ts
@@ -10,6 +10,7 @@ import {
   InternalHyperlink,
   FootnoteReferenceRun,
   EndnoteReferenceRun,
+  SimpleField,
 } from 'docx';
 import {
   parseTextWithDecorators,
@@ -27,7 +28,9 @@ export type PlaceholderChild =
   | InternalHyperlink
   // A `[^id]` note marker resolves to a reference run mid-text.
   | FootnoteReferenceRun
-  | EndnoteReferenceRun;
+  | EndnoteReferenceRun
+  // A `[@id]` cross-reference resolves to a REF field (NumberedItemReference).
+  | SimpleField;
 
 /**
  * Placeholder handler function type

--- a/packages/core-docx/src/utils/textParser.ts
+++ b/packages/core-docx/src/utils/textParser.ts
@@ -4,6 +4,8 @@ import {
   InternalHyperlink,
   FootnoteReferenceRun,
   EndnoteReferenceRun,
+  NumberedItemReference,
+  NumberedItemReferenceFormat,
   Tab,
 } from 'docx';
 import {
@@ -12,6 +14,7 @@ import {
   type PlaceholderContext,
 } from './placeholderProcessor';
 import { normalizeUnicodeText } from './unicode';
+import { globalNumberedItemsRegistry } from './numberedItemsRegistry';
 
 export interface TextStyle {
   font?: string;
@@ -448,8 +451,106 @@ function splitNoteMarkers(
 }
 
 /**
- * Parse text with hyperlinks and decorators
- * Supports markdown-style links: [link text](url)
+ * Cross-reference to a numbered heading or list item: `[@id]`, optionally
+ * `[@id:relative|no_context|full_context|none]`.
+ *
+ * No collision with `[text](url)`: that syntax needs a `(…)` immediately after
+ * the bracket, and the alternation below tries it first anyway.
+ */
+const CROSS_REFERENCE_PATTERN =
+  '\\[@([A-Za-z0-9_-]+)(?::(relative|no_context|full_context|none))?\\]';
+
+/**
+ * One pass over both bracket syntaxes: parsing them separately would mean
+ * re-scanning the segments between one kind of token for the other kind, while
+ * the plain text between them still has to reach `parseTextWithDecorators`.
+ */
+const INLINE_TOKEN_REGEX = `\\[([^\\]]+)\\]\\(([^)]+)\\)|${CROSS_REFERENCE_PATTERN}`;
+
+/**
+ * True when the text carries a `[@id]` token. `createHeading` renders simple
+ * headings through a run builder that never reaches this parser, so it needs to
+ * know when a heading is not simple after all.
+ */
+export function hasCrossReference(text: string): boolean {
+  return new RegExp(CROSS_REFERENCE_PATTERN).test(text);
+}
+
+const REFERENCE_FORMATS = {
+  relative: NumberedItemReferenceFormat.RELATIVE,
+  no_context: NumberedItemReferenceFormat.NO_CONTEXT,
+  full_context: NumberedItemReferenceFormat.FULL_CONTEXT,
+  none: NumberedItemReferenceFormat.NONE,
+} as const;
+
+type ReferenceFormatKey = keyof typeof REFERENCE_FORMATS;
+
+/**
+ * Turn one `[@id]` token into a Word REF field.
+ *
+ * The cached value is what makes the reference readable outside Word: headless
+ * LibreOffice — and therefore the PDF export path — never updates fields, so an
+ * uncached REF exports blank. Word recomputes it on open (the document sets
+ * `updateFields`), so an approximate cached value is corrected there.
+ *
+ * An unresolvable id renders as its literal token text rather than as a field:
+ * a REF pointing at a bookmark that does not exist is exactly what makes Word
+ * show "Error! Reference source not found".
+ */
+function createCrossReference(
+  id: string,
+  format: ReferenceFormatKey,
+  token: string,
+  baseStyle: TextStyle,
+  options: TextDecoratorOptions
+): PlaceholderChild[] {
+  const info = globalNumberedItemsRegistry.get(id);
+
+  if (!info) {
+    // An unseeded registry means no render is in progress (a unit test calling
+    // the text primitives directly), so nothing has had the chance to declare
+    // the target and there is no authoring mistake to report.
+    if (globalNumberedItemsRegistry.isSeeded()) {
+      console.warn(
+        `[core-docx] Cross-reference ${token} has no target: no heading or list item declares the id "${id}". Rendering the token as literal text.`
+      );
+    }
+    return buildTextRuns(
+      token,
+      buildRunCommonProps(baseStyle, { boldColor: options.boldColor }),
+      { noProof: baseStyle.noProof, noProofWords: options.noProofWords }
+    );
+  }
+
+  if (format === 'none') {
+    return [
+      new NumberedItemReference(id, info.text, {
+        hyperlink: true,
+        referenceFormat: REFERENCE_FORMATS.none,
+      }),
+    ];
+  }
+
+  // `relative` caches the full number: Word resolves it against the reference's
+  // own position in the numbering, which generation does not know.
+  const cachedValue = format === 'no_context' ? info.own : info.full;
+  if (cachedValue === undefined) {
+    console.warn(
+      `[core-docx] Cross-reference ${token} targets an unnumbered ${info.kind} ("${id}"), so the field carries no cached number and reads blank until the reader updates fields. Use [@${id}:none] to reference its text instead.`
+    );
+  }
+
+  return [
+    new NumberedItemReference(id, cachedValue, {
+      hyperlink: true,
+      referenceFormat: REFERENCE_FORMATS[format],
+    }),
+  ];
+}
+
+/**
+ * Parse text with hyperlinks, cross-references and decorators
+ * Supports markdown-style links `[text](url)` and cross-references `[@id]`
  */
 function parseTextWithHyperlinks(
   text: string,
@@ -459,15 +560,15 @@ function parseTextWithHyperlinks(
   const normalizedText = normalizeUnicodeText(text);
   const runs: PlaceholderChild[] = [];
 
-  // Regex to match markdown-style links: [text](url)
-  // This regex handles nested brackets in the link text
-  const hyperlinkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+  // Fresh instance per call: a shared /g regex carries `lastIndex` between
+  // calls and would skip tokens.
+  const tokenRegex = new RegExp(INLINE_TOKEN_REGEX, 'g');
 
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
-  while ((match = hyperlinkRegex.exec(normalizedText)) !== null) {
-    // Add any text before the hyperlink
+  while ((match = tokenRegex.exec(normalizedText)) !== null) {
+    // Add any text before the token
     if (match.index > lastIndex) {
       const plainText = normalizedText.substring(lastIndex, match.index);
       if (plainText) {
@@ -478,6 +579,23 @@ function parseTextWithHyperlinks(
         });
         runs.push(...plainRuns);
       }
+    }
+
+    lastIndex = match.index + match[0].length;
+
+    // Group 1 is the hyperlink's text; absent means the cross-reference branch
+    // of the alternation matched.
+    if (match[1] === undefined) {
+      runs.push(
+        ...createCrossReference(
+          match[3],
+          (match[4] as ReferenceFormatKey | undefined) ?? 'relative',
+          match[0],
+          baseStyle,
+          options
+        )
+      );
+      continue;
     }
 
     const linkText = match[1];
@@ -511,11 +629,9 @@ function parseTextWithHyperlinks(
         })
       );
     }
-
-    lastIndex = match.index + match[0].length;
   }
 
-  // Add any remaining text after the last hyperlink
+  // Add any remaining text after the last token
   if (lastIndex < normalizedText.length) {
     const remainingText = normalizedText.substring(lastIndex);
     if (remainingText) {
@@ -527,7 +643,7 @@ function parseTextWithHyperlinks(
     }
   }
 
-  // If no hyperlinks were found, fall back to regular decorator parsing
+  // If no tokens were found, fall back to regular decorator parsing
   if (runs.length === 0 && normalizedText) {
     return parseTextWithDecorators(normalizedText, baseStyle, {
       ...options,

--- a/packages/core-docx/src/utils/textParser.ts
+++ b/packages/core-docx/src/utils/textParser.ts
@@ -454,11 +454,17 @@ function splitNoteMarkers(
  * Cross-reference to a numbered heading or list item: `[@id]`, optionally
  * `[@id:relative|no_context|full_context|none]`.
  *
+ * The id accepts every character a bookmark id can actually hold, rather than
+ * a narrower slug alphabet: `id` is a free string in the schema, so an author
+ * who writes `item.1` on a list item must be able to reference it. Whitespace
+ * ends the token (an unclosed `[@` cannot swallow a sentence) and `:` is
+ * reserved as the format separator.
+ *
  * No collision with `[text](url)`: that syntax needs a `(…)` immediately after
  * the bracket, and the alternation below tries it first anyway.
  */
 const CROSS_REFERENCE_PATTERN =
-  '\\[@([A-Za-z0-9_-]+)(?::(relative|no_context|full_context|none))?\\]';
+  '\\[@([^\\]\\s:]+)(?::(relative|no_context|full_context|none))?\\]';
 
 /**
  * One pass over both bracket syntaxes: parsing them separately would mean

--- a/packages/shared-docx/src/schemas/components/heading.ts
+++ b/packages/shared-docx/src/schemas/components/heading.ts
@@ -53,7 +53,8 @@ export const HeadingPropsSchema = Type.Object(
     ),
     numbering: Type.Optional(
       Type.Boolean({
-        description: 'Include in numbering',
+        description:
+          "Number this heading with the document's multilevel heading numbering (1., 1.1., 1.1.1.). Set globally via componentDefaults.heading.numbering; false opts a single heading out.",
       })
     ),
     keepNext: Type.Optional(

--- a/packages/shared-docx/src/schemas/components/list.ts
+++ b/packages/shared-docx/src/schemas/components/list.ts
@@ -169,6 +169,12 @@ export const ListPropsSchema = Type.Object(
                 description: 'Nesting level for this item',
               })
             ),
+            id: Type.Optional(
+              Type.String({
+                description:
+                  'Bookmark id for this item, targetable by internal links (#id) and cross-references ([@id])',
+              })
+            ),
             revision: Type.Optional(RevisionSchema),
           },
           { additionalProperties: false }

--- a/packages/shared-docx/src/schemas/components/text-box.ts
+++ b/packages/shared-docx/src/schemas/components/text-box.ts
@@ -54,6 +54,12 @@ export const TextBoxPropsSchema = Type.Object(
         }
       )
     ),
+    renderAs: Type.Optional(
+      Type.Union([Type.Literal('table'), Type.Literal('shape')], {
+        description:
+          "Rendering strategy. 'table' (default): borderless one-cell table — height auto-fits content, per-side borders and percentage widths resolve in Word. 'shape': native Word text box (WPS shape) — real wrap modes and z-order, but requires explicit width and height (no autofit), a single uniform border, and eagerly-resolved percentage sizes.",
+      })
+    ),
     floating: Type.Optional(FloatingPropertiesSchema),
     style: Type.Optional(
       Type.Object(


### PR DESCRIPTION
Closes #177, closes #182, closes #176.

Three docx features that share one pre-pass, shipped together.

## Heading numbering (#177)
`heading.props.numbering` (schema-accepted, renderer-ignored until now) is real: `true` numbers the heading through one shared multilevel definition (1., 1.1., … 6 levels, decimal), each level bound to its `Heading1`–`Heading6` style via `w:lvl/w:pStyle` so Word's own numbering UI and the `\r` cross-reference switch recognize it. Document-wide via `componentDefaults.heading.numbering: true`; `false` opts a single heading out (`numId 0`). Numbered headings carry their number into cached TOC entries, so headless-PDF output and Word's field refresh agree. The four bundled themes' inert `heading.numbering: false` defaults were removed — with `false` now meaningful, keeping them would have added opt-out `numPr` to every heading of every themed document.

## Cross-references to numbered items (#182)
New inline syntax in any rich text: `[@id]` → hyperlinked Word `REF` field showing the target's number (`:no_context`, `:full_context`, `:none` select the other switches; `:none` shows the target's text). Both prerequisites built here:
- list items accept `id` (bookmark target, also usable by `[text](#id)` links);
- a document-outline pre-pass (extending the #174 TOC walk — one walk, three outputs) computes heading numbers and list counters, and predicts auto-generated bookmark ids by mirroring render's slug+dedupe order.

Fields carry the computed number as `cachedValue`, so headless LibreOffice PDFs show real numbers; Word recomputes on open (`updateFields`). Unknown ids render as literal text with a warning — never Word's "Error! Reference source not found". Counter formats: decimal, letters (Word's aa/bb repeat sequence), roman; anything else emits the field uncached with a warning.

## text-box `renderAs: 'shape'` (#176)
Opt-in native WPS text box; `'table'` stays the default and is byte-identical to before (body extracted verbatim). Shape mode gains real wrap modes and z-order (reuses the image `IFloating` mapper), costs autofit (explicit `width`+`height` required — verified docx 9.7.1 cannot emit `spAutoFit`), a single uniform outline, and eagerly-resolved percentage sizes. Falls back to table rendering with a warning for non-paragraph content (nested `columns`) or missing size — size validated before children render so fallback never double-renders side effects. Verified upstream and worked around: docx 9.7.1 emits invalid `CT_ShapeProperties` when fill+outline are combined (`a:noFill`+`a:ln`+`a:solidFill`), so fill wins with a warning. Also deletes the provably-inert `| Textbox` union members (5 sites).

## Verification
`pnpm typecheck` 15/15 · `pnpm lint` 9/9 · `pnpm test` 15/15 (core-docx: 76 files, 784 tests) · `pnpm generate:schemas` clean. New suites: heading-numbering, cross-reference (end-to-end packed XML), text-box-shape, numberFormatting. No existing assertion changed; `text-box-nested-columns` passes untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic numbering for headings, with per-heading opt-out support.
  * Added `[`@id`]` cross-references to numbered headings and list items, including internal links and formatting options.
  * Added native Word shape rendering for text boxes through `renderAs: 'shape'`, with fallback support.
* **Documentation**
  * Expanded DOCX guidance and reference documentation for numbering, cross-references, list-item IDs, and text-box rendering modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->