### PR TITLE
fix(docx): reject unhonourable text-box shape requests at validation

### DIFF
--- a/.changeset/text-box-shape-validation.md
+++ b/.changeset/text-box-shape-validation.md
@@ -1,0 +1,21 @@
+---
+'@json-to-office/shared-docx': minor
+---
+
+Reject the two `text-box` `renderAs: "shape"` requests a shape can never honour
+at validation instead of quietly rendering a table.
+
+A shape carries an absolute size and has no autofit, and its outline carries no
+dash pattern — so a shape without both `width` and `height`, or with a
+`dashed`/`dotted`/`double` border, could only ever come back as the default
+one-cell table. That downgrade was reported with a `console.warn`, which is
+invisible in an editor that shows only the rendered result: the author asked for
+a shape, got a table, and was told nothing. Both cases are now validation errors
+naming the two ways out — fix the prop, or write `renderAs: "table"`, which
+auto-fits and draws every border style.
+
+The third fallback stays at render time: content that renders as a table rather
+than a paragraph (a nested `columns`) depends on what the children produce, not
+on the props, so no static check can see it coming.
+
+Documents relying on either fallback now fail validation.

--- a/docs/reference/docx/components.md
+++ b/docs/reference/docx/components.md
@@ -496,11 +496,14 @@ The default `'table'` renders the box as a borderless one-cell table. `'shape'` 
 | `width` / `height` percentages | Resolved by Word, so they follow the page           | Resolved at generation time against the current content box                |
 | Children                       | Anything, including nested `columns`                | Paragraph-producing components only                                        |
 
-Shape mode degrades to the table rendering, with a warning, when the request cannot be honoured:
+Two shape limits are **rejected at validation**, so a document that validates gets the shape it asked for:
 
-- a missing `width` or `height`;
-- a `dashed`, `dotted` or `double` border — a shape outline has no dash pattern, and drawing it solid would silently change the design, so the box goes back to the table path that renders it properly;
-- non-paragraph content (a nested `columns`, which renders as a table).
+- a missing `width` or `height` — a shape has no autofit, so its size cannot come from its content;
+- a `dashed`, `dotted` or `double` border — a shape outline carries no dash pattern.
+
+Both errors name the two ways out: fix the prop, or drop to `renderAs: 'table'`, which auto-fits and draws every border style.
+
+One limit stays a **render-time fallback**, because it depends on what the children render to rather than on the props: non-paragraph content (a nested `columns`, which renders as a table) degrades to the table rendering with a warning.
 
 Two further warnings report a downgrade inside shape mode rather than a fallback: per-side borders that disagree (the first declared side of top/left/bottom/right wins), and a percentage size being frozen.
 

--- a/packages/core-docx/src/components/text-box.ts
+++ b/packages/core-docx/src/components/text-box.ts
@@ -396,8 +396,12 @@ type ShapeAttempt =
  *
  * Everything a shape cannot express falls back to the table rendering rather
  * than shipping a box that clips its content or quietly redraws its border.
- * The checks that read props only run before the children render, so the
- * common fallbacks cost nothing.
+ *
+ * The two prop-only limits — a missing dimension and a dash-patterned border —
+ * are rejected by `collectTextBoxShapeConflicts` during validation, where the
+ * author can act on them. The guards below are the safety net for callers that
+ * render without validating; they run before the children do, so the fallback
+ * never renders a child twice.
  */
 async function renderTextBoxAsShape(
   tb: TextBoxComponentDefinition,

--- a/packages/shared-docx/src/__tests__/text-box-shape-conflict.test.ts
+++ b/packages/shared-docx/src/__tests__/text-box-shape-conflict.test.ts
@@ -1,0 +1,168 @@
+/**
+ * `renderAs: 'shape'` asks for a WPS DrawingML shape, and two of its limits are
+ * decidable before anything renders: a shape has no autofit, so it needs an
+ * explicit size, and its outline carries no dash pattern.
+ *
+ * Every field involved is independently optional, so the structural schema
+ * accepts both combinations; these are the semantic rules that reject them.
+ */
+import { describe, it, expect } from 'vitest';
+import { collectTextBoxShapeConflicts } from '../validation/unified/deep-validator';
+import { validate } from '../validation/unified';
+
+const child = { name: 'paragraph', props: { text: 'Boxed.' } };
+
+function textBox(props: Record<string, unknown>) {
+  return { name: 'text-box', props, children: [child] };
+}
+
+describe('collectTextBoxShapeConflicts — size', () => {
+  it('flags a shape with neither dimension', () => {
+    const errors = collectTextBoxShapeConflicts(textBox({ renderAs: 'shape' }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].path).toBe('/props/width');
+    expect(errors[0].code).toBe('required');
+    expect(errors[0].message).toContain('width and height');
+    expect(errors[0].message).toContain('renderAs "table"');
+  });
+
+  it.each([
+    ['height', { renderAs: 'shape', width: 200 }, '/props/height'],
+    ['width', { renderAs: 'shape', height: 100 }, '/props/width'],
+  ])('flags a shape missing %s', (_axis, props, path) => {
+    const errors = collectTextBoxShapeConflicts(textBox(props));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].path).toBe(path);
+  });
+
+  it('accepts percentage sizes, which resolve eagerly', () => {
+    expect(
+      collectTextBoxShapeConflicts(
+        textBox({ renderAs: 'shape', width: '50%', height: '30%' })
+      )
+    ).toHaveLength(0);
+  });
+
+  it('leaves the table rendering alone, explicitly or by default', () => {
+    expect(collectTextBoxShapeConflicts(textBox({}))).toHaveLength(0);
+    expect(
+      collectTextBoxShapeConflicts(textBox({ renderAs: 'table' }))
+    ).toHaveLength(0);
+  });
+});
+
+describe('collectTextBoxShapeConflicts — border style', () => {
+  const sized = (border: Record<string, unknown>) =>
+    textBox({ renderAs: 'shape', width: 200, height: 100, style: { border } });
+
+  it.each(['dashed', 'dotted', 'double'])(
+    'flags a %s border a shape outline cannot draw',
+    (style) => {
+      const errors = collectTextBoxShapeConflicts(
+        sized({ top: { style, width: 2 } })
+      );
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].path).toBe('/props/style/border/top/style');
+      expect(errors[0].code).toBe('unsupported_value');
+      expect(errors[0].message).toContain(`"${style}"`);
+    }
+  );
+
+  it('reports every offending side', () => {
+    const errors = collectTextBoxShapeConflicts(
+      sized({ top: { style: 'dashed' }, left: { style: 'dotted' } })
+    );
+
+    expect(errors.map((e) => e.path)).toEqual([
+      '/props/style/border/top/style',
+      '/props/style/border/left/style',
+    ]);
+  });
+
+  it('accepts solid and none', () => {
+    expect(
+      collectTextBoxShapeConflicts(
+        sized({ top: { style: 'solid', width: 2 }, left: { style: 'none' } })
+      )
+    ).toHaveLength(0);
+  });
+
+  it('leaves a dashed border on the table rendering alone', () => {
+    expect(
+      collectTextBoxShapeConflicts(
+        textBox({ style: { border: { top: { style: 'dashed' } } } })
+      )
+    ).toHaveLength(0);
+  });
+});
+
+describe('collectTextBoxShapeConflicts — traversal', () => {
+  it('finds a text box nested inside another component', () => {
+    const errors = collectTextBoxShapeConflicts({
+      name: 'section',
+      props: {},
+      children: [
+        {
+          name: 'columns',
+          props: { columns: 2 },
+          children: [textBox({ renderAs: 'shape', width: 200 })],
+        },
+      ],
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].path).toBe('/children/0/children/0/props/height');
+  });
+});
+
+describe('document validation', () => {
+  const document = (props: Record<string, unknown>) =>
+    JSON.stringify({
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [{ name: 'section', props: {}, children: [textBox(props)] }],
+    });
+
+  it('rejects a shape with no height', () => {
+    const result = validate.jsonDocument(
+      document({ renderAs: 'shape', width: 200 })
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.message.includes('no autofit'))).toBe(
+      true
+    );
+  });
+
+  it('rejects a shape with a dashed border', () => {
+    const result = validate.jsonDocument(
+      document({
+        renderAs: 'shape',
+        width: 200,
+        height: 100,
+        style: { border: { top: { style: 'dashed', width: 2 } } },
+      })
+    );
+
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.message.includes('no dash pattern'))
+    ).toBe(true);
+  });
+
+  it('accepts a well-formed shape', () => {
+    const result = validate.jsonDocument(
+      document({
+        renderAs: 'shape',
+        width: 200,
+        height: 100,
+        style: { border: { top: { style: 'solid', width: 2 } } },
+      })
+    );
+
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/shared-docx/src/validation/unified/deep-validator.ts
+++ b/packages/shared-docx/src/validation/unified/deep-validator.ts
@@ -222,6 +222,88 @@ export function collectNoteRevisionConflicts(data: unknown): ValidationError[] {
 }
 
 /**
+ * Collect `text-box` requests for a shape rendering that a shape cannot honour,
+ * anywhere in a document.
+ *
+ * `renderAs: 'shape'` emits a WPS DrawingML shape, and two of its limits are
+ * decidable from the props alone:
+ *
+ * - **Size.** A shape carries an absolute extent and has no autofit, so a box
+ *   without both `width` and `height` has no size to render at.
+ * - **Border style.** docx's outline options carry width, cap, compound and
+ *   fill but no `a:prstDash`, so a dash pattern cannot be expressed at all; the
+ *   `compoundLine` that could stand in for `double` is emitted as the enum key
+ *   (`cmpd="DOUBLE"`) rather than the OOXML value.
+ *
+ * Both are independently optional fields, so the combination passes TypeBox's
+ * structural check. Reporting them here rather than warning at render time puts
+ * the fault where the author can fix it — the renderer's own guards degrade to
+ * the table rendering, which is silent in an editor that only shows the result.
+ *
+ * Like the walks above this runs unconditionally over every nested value, so a
+ * text box inside columns, a table cell, a header/footer or another text box is
+ * covered too. The third render-time fallback — content that renders as a table
+ * rather than a paragraph — is deliberately absent: it depends on what the
+ * children render to, which no static walk can know.
+ */
+const UNDASHABLE_BORDER_STYLES = new Set(['dashed', 'dotted', 'double']);
+
+export function collectTextBoxShapeConflicts(data: unknown): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  const visit = (node: any, path: string): void => {
+    if (Array.isArray(node)) {
+      node.forEach((item, i) => visit(item, `${path}/${i}`));
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+
+    if (node.name === 'text-box' && node.props?.renderAs === 'shape') {
+      const missing = (['width', 'height'] as const).filter(
+        (axis) => node.props[axis] === undefined
+      );
+      if (missing.length > 0) {
+        errors.push({
+          path: `${path}/props/${missing[0]}`,
+          message:
+            `A text-box with renderAs "shape" requires ${missing.join(' and ')}: a shape ` +
+            'has no autofit, so its size cannot be derived from its content. Give it an ' +
+            'explicit size, or use renderAs "table", which grows to fit.',
+          code: 'required',
+        });
+      }
+
+      const border = node.props.style?.border;
+      if (border && typeof border === 'object') {
+        for (const side of ['top', 'right', 'bottom', 'left'] as const) {
+          const style = border[side]?.style;
+          if (
+            typeof style === 'string' &&
+            UNDASHABLE_BORDER_STYLES.has(style)
+          ) {
+            errors.push({
+              path: `${path}/props/style/border/${side}/style`,
+              message:
+                `A text-box with renderAs "shape" cannot draw a "${style}" border: a shape ` +
+                'outline carries no dash pattern. Use "solid", or use renderAs "table", ' +
+                'which draws every border style.',
+              code: 'unsupported_value',
+            });
+          }
+        }
+      }
+    }
+
+    for (const key of Object.keys(node)) {
+      visit(node[key], `${path}/${key}`);
+    }
+  };
+
+  visit(data, '');
+  return errors;
+}
+
+/**
  * Deep validate a document to collect ALL errors, not just union-level errors
  */
 export function deepValidateDocument(

--- a/packages/shared-docx/src/validation/unified/document-validator.ts
+++ b/packages/shared-docx/src/validation/unified/document-validator.ts
@@ -14,6 +14,7 @@ import {
   collectImageSourceConflicts,
   collectIndentConflicts,
   collectNoteRevisionConflicts,
+  collectTextBoxShapeConflicts,
 } from './deep-validator';
 
 // JsonComponentDefinitionSchema is just an alias for ComponentDefinitionSchema
@@ -69,6 +70,13 @@ export function validateDocument(
   const noteRevisionConflicts = collectNoteRevisionConflicts(data);
   if (noteRevisionConflicts.length > 0) {
     finalErrors = [...finalErrors, ...noteRevisionConflicts];
+    finalValid = false;
+  }
+
+  // Same for a text box asking for a shape rendering a shape cannot give it.
+  const textBoxShapeConflicts = collectTextBoxShapeConflicts(data);
+  if (textBoxShapeConflicts.length > 0) {
+    finalErrors = [...finalErrors, ...textBoxShapeConflicts];
     finalValid = false;
   }
 
@@ -148,6 +156,14 @@ export function validateJsonDocument(
   const noteRevisionConflicts = collectNoteRevisionConflicts(result.parsed);
   if (noteRevisionConflicts.length > 0) {
     finalErrors = [...finalErrors, ...noteRevisionConflicts];
+    finalValid = false;
+  }
+
+  // A text box asking for a shape rendering a shape cannot give it (see
+  // validateDocument).
+  const textBoxShapeConflicts = collectTextBoxShapeConflicts(result.parsed);
+  if (textBoxShapeConflicts.length > 0) {
+    finalErrors = [...finalErrors, ...textBoxShapeConflicts];
     finalValid = false;
   }
 

--- a/packages/shared-docx/src/validation/unified/index.ts
+++ b/packages/shared-docx/src/validation/unified/index.ts
@@ -38,6 +38,7 @@ export {
   comprehensiveValidateDocument,
   collectIndentConflicts,
   collectNoteRevisionConflicts,
+  collectTextBoxShapeConflicts,
 } from './deep-validator';
 
 // Format-agnostic schema utilities re-exported from @json-to-office/shared


### PR DESCRIPTION
Closes #244. Follow-up to #176 / #242.

`renderAs: 'shape'` had three fallbacks to the table rendering. Two are decidable from the props alone, and both now fail validation instead of silently producing a table:

- **no `width`/`height`** — a WPS shape carries an absolute extent and has no autofit;
- **`dashed`/`dotted`/`double` border** — docx's outline options carry no `a:prstDash`, and the `compoundLine` that could stand in for `double` is emitted as the enum key (`cmpd="DOUBLE"`) rather than the OOXML value.

A `console.warn` is invisible where these documents get written: the playground shows a table and no explanation. The errors now name both ways out — fix the prop, or write `renderAs: "table"`, which auto-fits and draws every border style:

```
/children/0/children/0/props/height: A text-box with renderAs "shape" requires height:
a shape has no autofit, so its size cannot be derived from its content. Give it an
explicit size, or use renderAs "table", which grows to fit.

/children/0/children/0/props/style/border/top/style: A text-box with renderAs "shape"
cannot draw a "dashed" border: a shape outline carries no dash pattern. Use "solid",
or use renderAs "table", which draws every border style.
```

## Implementation

`collectTextBoxShapeConflicts` in `deep-validator.ts`, alongside the three existing collectors for rules the structural schema cannot express (`collectImageSourceConflicts`, `collectIndentConflicts`, `collectNoteRevisionConflicts`) — a full-tree walk, so text boxes nested in columns, table cells, headers/footers and other text boxes are covered.

Wired into **both** `validateDocument` and `validateJsonDocument`. Those two functions duplicate the same collector block, and wiring only the first is exactly the bug my own tests caught mid-implementation — worth collapsing into one list in a follow-up.

The renderer's guards stay as a safety net for callers that render without validating, and are now documented as such. Non-paragraph content (a nested `columns`) remains a render-time fallback: it depends on what the children render to, which no static walk can know.

## Verification

`pnpm typecheck` 15/15 · `pnpm lint` 9/9 · `pnpm test` 15/15 (shared-docx 199, +18) · `pnpm generate:schemas` clean.

End-to-end through `generateBufferFromJson`: both bad shapes rejected with the messages above; the same props on the table rendering still accepted; a well-formed shape still accepted; and a document mixing valid shapes with a nested-`columns` shape still renders 2 shapes + 2 tables with the one expected runtime warning.

One caveat worth stating plainly: this is a behavior break for any document relying on either fallback — it now fails validation rather than rendering. That is the point of the change, and the changeset says so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for text boxes rendered as shapes.
  * Invalid shape requests now report errors when width or height is missing or when dashed, dotted, or double borders are used.
  * Validation covers nested text boxes and all border sides.

* **Documentation**
  * Clarified shape-rendering limitations and recommended using table rendering when appropriate.
  * Documented that unsupported nested content may still fall back to table rendering with a warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->