### PR TITLE
refactor(shared-docx): apply semantic collectors from one list

### DIFF
--- a/packages/shared-docx/src/__tests__/semantic-collector-parity.test.ts
+++ b/packages/shared-docx/src/__tests__/semantic-collector-parity.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Every semantic rule has to reach a document through both validation entry
+ * points: `validate.document` takes an object, `validate.jsonDocument` takes
+ * JSON, and callers reach for whichever fits.
+ *
+ * The two used to run hand-maintained copies of the same collector list, so a
+ * rule wired into one and not the other was invisible until a document arrived
+ * by the other path — which is exactly what happened when the text-box shape
+ * rule was added. This locks the parity down rather than the list's shape, so
+ * it keeps working however the collectors end up being applied.
+ */
+import { describe, it, expect } from 'vitest';
+import { validate } from '../validation/unified';
+
+const document = (child: Record<string, unknown>) => ({
+  name: 'docx',
+  props: { theme: 'minimal' },
+  children: [{ name: 'section', props: {}, children: [child] }],
+});
+
+/** One offending document per semantic rule, with the phrase it must report. */
+const OFFENDERS: [string, Record<string, unknown>, string][] = [
+  [
+    'image with two sources',
+    { name: 'image', props: { path: 'a.png', base64: 'AAAA' } },
+    'only one source',
+  ],
+  [
+    'indent with hanging and firstLine',
+    {
+      name: 'paragraph',
+      props: { text: 'x', indent: { hanging: 100, firstLine: 100 } },
+    },
+    'not both',
+  ],
+  [
+    'notes on a revised paragraph',
+    {
+      name: 'paragraph',
+      props: {
+        text: 'new[^a]',
+        revision: {
+          segments: [
+            { type: 'delete', text: 'old' },
+            { type: 'insert', text: 'new' },
+          ],
+        },
+        footnotes: [{ id: 'a', text: 'body' }],
+      },
+    },
+    'cannot apply to the same text',
+  ],
+  [
+    'shape text box with no height',
+    {
+      name: 'text-box',
+      props: { renderAs: 'shape', width: 200 },
+      children: [{ name: 'paragraph', props: { text: 'x' } }],
+    },
+    'no autofit',
+  ],
+];
+
+describe.each(OFFENDERS)('%s', (_label, child, phrase) => {
+  it('is rejected by validate.document', () => {
+    const result = validate.document(document(child));
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.message.includes(phrase))).toBe(true);
+  });
+
+  it('is rejected by validate.jsonDocument', () => {
+    const result = validate.jsonDocument(JSON.stringify(document(child)));
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.message.includes(phrase))).toBe(true);
+  });
+});
+
+describe('a document breaking no semantic rule', () => {
+  const clean = document({ name: 'paragraph', props: { text: 'Fine.' } });
+
+  it('passes both entry points', () => {
+    expect(validate.document(clean).valid).toBe(true);
+    expect(validate.jsonDocument(JSON.stringify(clean)).valid).toBe(true);
+  });
+});

--- a/packages/shared-docx/src/validation/unified/document-validator.ts
+++ b/packages/shared-docx/src/validation/unified/document-validator.ts
@@ -19,8 +19,59 @@ import {
 
 // JsonComponentDefinitionSchema is just an alias for ComponentDefinitionSchema
 const JsonComponentDefinitionSchema = ComponentDefinitionSchema;
-import type { DocumentValidationResult, ValidationOptions } from './types';
+import type {
+  DocumentValidationResult,
+  ValidationError,
+  ValidationOptions,
+} from './types';
 import { validateAgainstSchema, validateJson } from './base-validator';
+
+/**
+ * The semantic rules the structural schema cannot express.
+ *
+ * Each entry runs unconditionally over the whole document, because every one of
+ * them describes a payload TypeBox already accepted: the fields involved are
+ * independently optional, and only their combination is wrong.
+ *
+ * They live in one list because both entry points below need all of them, and a
+ * collector wired into only one of the two is invisible until a document takes
+ * the other path.
+ */
+const SEMANTIC_COLLECTORS: readonly {
+  readonly why: string;
+  readonly collect: (document: unknown) => ValidationError[];
+}[] = [
+  {
+    // A multi-source image passes the structural check: each source is its own
+    // optional field.
+    why: 'image source mutual-exclusivity',
+    collect: collectImageSourceConflicts,
+  },
+  {
+    why: 'indent hanging/firstLine mutual-exclusivity',
+    collect: collectIndentConflicts,
+  },
+  {
+    // Tracked-change text renders literally, so a note marker inside it never
+    // resolves and docx cannot express the pair anyway.
+    why: 'notes on a revised paragraph',
+    collect: collectNoteRevisionConflicts,
+  },
+  {
+    // A shape has no autofit and its outline carries no dash pattern, so the
+    // request could only ever come back as a table.
+    why: 'a text box asking for a shape rendering a shape cannot give it',
+    collect: collectTextBoxShapeConflicts,
+  },
+];
+
+/**
+ * Run every semantic rule over an already-resolved document — `data` for the
+ * object entry point, `result.parsed` for the JSON one.
+ */
+function collectSemanticConflicts(document: unknown): ValidationError[] {
+  return SEMANTIC_COLLECTORS.flatMap(({ collect }) => collect(document));
+}
 
 /**
  * Validate a document/report component definition
@@ -50,33 +101,11 @@ export function validateDocument(
     }
   }
 
-  // Image source mutual-exclusivity is a semantic rule the structural schema
-  // cannot express, so it runs unconditionally — a multi-source image passes
-  // the TypeBox check above.
-  const sourceConflicts = collectImageSourceConflicts(data);
-  if (sourceConflicts.length > 0) {
-    finalErrors = [...finalErrors, ...sourceConflicts];
-    finalValid = false;
-  }
-
-  // Same for indent hanging/firstLine mutual-exclusivity.
-  const indentConflicts = collectIndentConflicts(data);
-  if (indentConflicts.length > 0) {
-    finalErrors = [...finalErrors, ...indentConflicts];
-    finalValid = false;
-  }
-
-  // Same for notes on a revised paragraph, which the renderer cannot express.
-  const noteRevisionConflicts = collectNoteRevisionConflicts(data);
-  if (noteRevisionConflicts.length > 0) {
-    finalErrors = [...finalErrors, ...noteRevisionConflicts];
-    finalValid = false;
-  }
-
-  // Same for a text box asking for a shape rendering a shape cannot give it.
-  const textBoxShapeConflicts = collectTextBoxShapeConflicts(data);
-  if (textBoxShapeConflicts.length > 0) {
-    finalErrors = [...finalErrors, ...textBoxShapeConflicts];
+  // Semantic rules run on every document, valid or not: they describe payloads
+  // the structural check already accepted.
+  const semanticConflicts = collectSemanticConflicts(data);
+  if (semanticConflicts.length > 0) {
+    finalErrors = [...finalErrors, ...semanticConflicts];
     finalValid = false;
   }
 
@@ -138,32 +167,11 @@ export function validateJsonDocument(
     }
   }
 
-  // Image source mutual-exclusivity (see validateDocument) — runs always.
-  const sourceConflicts = collectImageSourceConflicts(result.parsed);
-  if (sourceConflicts.length > 0) {
-    finalErrors = [...finalErrors, ...sourceConflicts];
-    finalValid = false;
-  }
-
-  // Indent hanging/firstLine mutual-exclusivity (see validateDocument).
-  const indentConflicts = collectIndentConflicts(result.parsed);
-  if (indentConflicts.length > 0) {
-    finalErrors = [...finalErrors, ...indentConflicts];
-    finalValid = false;
-  }
-
-  // Notes on a revised paragraph (see validateDocument).
-  const noteRevisionConflicts = collectNoteRevisionConflicts(result.parsed);
-  if (noteRevisionConflicts.length > 0) {
-    finalErrors = [...finalErrors, ...noteRevisionConflicts];
-    finalValid = false;
-  }
-
-  // A text box asking for a shape rendering a shape cannot give it (see
-  // validateDocument).
-  const textBoxShapeConflicts = collectTextBoxShapeConflicts(result.parsed);
-  if (textBoxShapeConflicts.length > 0) {
-    finalErrors = [...finalErrors, ...textBoxShapeConflicts];
+  // Semantic rules run on every document, valid or not: they describe payloads
+  // the structural check already accepted.
+  const semanticConflicts = collectSemanticConflicts(result.parsed);
+  if (semanticConflicts.length > 0) {
+    finalErrors = [...finalErrors, ...semanticConflicts];
     finalValid = false;
   }
 


### PR DESCRIPTION
**Stacked on #245** (base is `fix/text-box-shape-validation`, since `collectTextBoxShapeConflicts` does not exist on `main` yet). GitHub retargets this to `main` once #245 merges.

`validateDocument` and `validateJsonDocument` each ran a hand-maintained copy of the same four semantic collectors, folding each one's errors into `finalErrors`/`finalValid` with an identical six-line block. Adding a rule meant remembering both. That is not a hypothetical: in #245 only the first site was wired, and the document-level tests caught it.

Both now call one helper over one list:

```ts
const semanticConflicts = collectSemanticConflicts(data);          // validateDocument
const semanticConflicts = collectSemanticConflicts(result.parsed); // validateJsonDocument
```

`SEMANTIC_COLLECTORS` holds the four rules with each one's *why* on its entry, so the reasoning that used to live in the inline comments is preserved rather than deleted. The only real difference between the two sites — object vs. parsed JSON — is the helper's argument, exactly as the task described.

## No behavior change

Error order is unchanged (the list runs in the previous sequence and `flatMap` preserves it), `finalValid` still flips only when something is found, and the collectors still run unconditionally on valid and invalid documents alike. All 199 pre-existing shared-docx tests pass untouched, including the four conflict suites that cover both entry points.

## The guard

`semantic-collector-parity.test.ts` asserts that each of the four rules rejects through **both** `validate.document` and `validate.jsonDocument`, plus that a clean document passes both. It locks the parity rather than the list's shape, so it keeps working however the collectors are applied later.

I verified it actually catches the original bug rather than just passing: temporarily unwiring the last collector from the JSON path only fails 3 tests, named e.g. `shape text box with no height > is rejected by validate.jsonDocument`. Restored, all green.

## Verification

`pnpm --filter @json-to-office/shared-docx test` 208 passed (199 + 9 new) · `pnpm typecheck` 15/15 · `pnpm lint` 9/9 · `pnpm test` 15/15.

No changeset: internal refactor with no public surface or behavior change.
