### PR TITLE
fix(docx): unique bookmark ids; build playground on node 22 + LibreOffice 25.2

### DIFF
--- a/.changeset/bookmark-link-ids.md
+++ b/.changeset/bookmark-link-ids.md
@@ -1,0 +1,20 @@
+---
+'@json-to-office/core-docx': patch
+---
+
+Give every bookmark its own `w:id`, so a cross-reference can read its target's
+text.
+
+`w:id` is what pairs a `w:bookmarkStart` with its `w:bookmarkEnd`, and docx
+emits `w:id="1"` for every bookmark it builds: its `Bookmark` constructor
+creates a fresh id generator per instance, so the counter never advances past
+one (dolanmiu/docx#3478, unfixed in 9.7.1). Every range in the document
+therefore opened and closed on the same id. Navigating by name still worked,
+which is why internal links and the numeric cross-reference switches looked
+healthy, but `[@id:none]` — which asks Word for the _text_ inside the range —
+rendered blank in LibreOffice, and so in every exported PDF.
+
+Bookmarks now take their numeric id from the render-scoped bookmark registry,
+in a range disjoint from the section bookmarks, and are emitted as an explicit
+start/end pair rather than through docx's `Bookmark`. Verified against both
+LibreOffice 25.x and the 7.4 that the hosted playground runs.

--- a/.changeset/node22-trixie-base.md
+++ b/.changeset/node22-trixie-base.md
@@ -1,0 +1,13 @@
+---
+'@json-to-office/jto': patch
+---
+
+Build the hosted playground image on `node:22-trixie-slim`.
+
+Debian bookworm is frozen at LibreOffice 7.4, which cannot parse a table-of-
+contents field nested in a `w:sdt` and prints the raw field instruction into
+the document instead — visible on every hosted PDF with a TOC. Trixie carries
+LibreOffice 25.2, which renders it correctly, and Node 22.
+
+The suite is pinned explicitly (`-trixie-slim`, not `-slim`) so the LibreOffice
+version cannot move when Docker retags the default.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: build ──
-FROM node:20-slim AS builder
+FROM node:22-trixie-slim AS builder
 
 RUN npm i -g pnpm@9.15.9
 
@@ -15,8 +15,15 @@ ENV VITE_AI_ENABLED=${VITE_AI_ENABLED}
 RUN pnpm build
 
 # ── Stage 2: runtime ──
-FROM node:20-slim
+FROM node:22-trixie-slim
 
+# Debian trixie, for LibreOffice 25.2: bookworm is frozen at LibreOffice 7.4,
+# which cannot parse a TOC field nested in a `w:sdt` and prints the field
+# instruction into the document instead. Every hosted PDF with a table of
+# contents showed it. Pin the base suite explicitly rather than tracking
+# `node:22-slim`, so the LibreOffice version cannot move under us when Docker
+# retags the default.
+#
 # LibreOffice + metric-compatible fonts. `--no-install-recommends` suppresses
 # libreoffice-common's `Recommends: fonts-liberation2 | ttf-mscorefonts-installer`,
 # which is why the image otherwise ships only DejaVu + OpenSymbol and every

--- a/packages/core-docx/src/components/__tests__/cross-reference.test.ts
+++ b/packages/core-docx/src/components/__tests__/cross-reference.test.ts
@@ -330,6 +330,75 @@ describe('unresolvable cross-references', () => {
   });
 });
 
+describe('bookmark link ids', () => {
+  /**
+   * `w:id` pairs a bookmarkStart with its bookmarkEnd, so a document that
+   * reuses one leaves every range ambiguous — which is how `[@id:none]` came
+   * to render blank: navigating by name still worked, but a REF field could
+   * not read the target's text out of a range that never closed. docx's own
+   * `Bookmark` emits `w:id="1"` for every instance (dolanmiu/docx#3478).
+   */
+  it('gives every bookmark in a document its own id, paired with its end', async () => {
+    const xml = await documentXml([
+      ...numberedHeadings,
+      {
+        name: 'list',
+        props: {
+          format: 'numbered',
+          items: [
+            { text: 'First', id: 'item-one' },
+            { text: 'Second', id: 'item-two' },
+          ],
+        },
+      },
+      { name: 'paragraph', id: 'para-one', props: { text: 'Body.' } },
+    ]);
+
+    const starts = [
+      ...xml.matchAll(/<w:bookmarkStart w:name="([^"]+)" w:id="(\d+)"/g),
+    ].map((m) => ({ name: m[1], id: m[2] }));
+    const endIds = [...xml.matchAll(/<w:bookmarkEnd w:id="(\d+)"/g)].map(
+      (m) => m[1]
+    );
+
+    expect(starts.length).toBeGreaterThan(3);
+    const startIds = starts.map((s) => s.id);
+    expect(new Set(startIds).size).toBe(startIds.length);
+    // Every range closes, and closes on an id that was opened.
+    expect(endIds.slice().sort()).toEqual(startIds.slice().sort());
+  });
+
+  it('keeps content ids clear of the section bookmark range', async () => {
+    // A `section` component is what puts a `_Section_*` bookmark in the
+    // document, so both id ranges are present to compare.
+    const xml = await documentXml([
+      {
+        name: 'section',
+        props: {},
+        children: [{ name: 'heading', props: { text: 'Alpha', level: 1 } }],
+      },
+    ]);
+
+    const byName = Object.fromEntries(
+      [...xml.matchAll(/<w:bookmarkStart w:name="([^"]+)" w:id="(\d+)"/g)].map(
+        (m) => [m[1], Number(m[2])]
+      )
+    );
+    expect(byName._Section_1).toBeLessThan(1_000_000);
+    expect(byName.alpha).toBeGreaterThan(2_000_000);
+  });
+
+  it('resolves :none against the bookmarked text', async () => {
+    const xml = await documentXml([
+      ...numberedHeadings,
+      { name: 'paragraph', props: { text: 'See [@methods:none].' } },
+    ]);
+
+    const field = fields(xml).find((f) => f.includes('REF methods'));
+    expect(field).toContain('>Methods<');
+  });
+});
+
 describe('cross-reference id grammar', () => {
   // `id` is a free string in the schema, so the token grammar has to accept
   // whatever an author can legally write on a list item or a node.

--- a/packages/core-docx/src/core/content.ts
+++ b/packages/core-docx/src/core/content.ts
@@ -20,7 +20,6 @@ import {
   ColumnBreak,
   TableLayoutType,
   VerticalAlign,
-  Bookmark,
 } from 'docx';
 import type { ParagraphChild } from 'docx';
 import {
@@ -46,7 +45,10 @@ import {
 } from '../utils/placeholderProcessor';
 import { normalizeUnicodeText } from '../utils/unicode';
 import { getStyleIdForLevel } from '../styles/themeToDocxAdapter';
-import { globalBookmarkRegistry } from '../utils/bookmarkRegistry';
+import {
+  globalBookmarkRegistry,
+  createBookmarkedContent,
+} from '../utils/bookmarkRegistry';
 import {
   createMarkedTextRuns,
   createRevisionMark,
@@ -462,10 +464,7 @@ export function createText(
         'paragraph'
       );
       children.push(
-        new Bookmark({
-          id: options.bookmarkId,
-          children: revisionRuns as TextRun[],
-        })
+        ...createBookmarkedContent(options.bookmarkId, revisionRuns)
       );
     } else {
       children.push(...revisionRuns);
@@ -501,12 +500,7 @@ export function createText(
       );
 
       // Wrap text runs in bookmark
-      children.push(
-        new Bookmark({
-          id: options.bookmarkId,
-          children: textRuns as TextRun[],
-        })
-      );
+      children.push(...createBookmarkedContent(options.bookmarkId, textRuns));
     } else {
       // No bookmark, add text runs directly
       children.push(...textRuns);
@@ -756,10 +750,7 @@ export function createHeading(
         'heading'
       );
       children.push(
-        new Bookmark({
-          id: options.bookmarkId,
-          children: revisionRuns as TextRun[],
-        })
+        ...createBookmarkedContent(options.bookmarkId, revisionRuns)
       );
     } else {
       children.push(...revisionRuns);
@@ -792,10 +783,7 @@ export function createHeading(
 
     // Wrap in bookmark
     children.push(
-      new Bookmark({
-        id: options.bookmarkId,
-        children: headingTextChildren,
-      })
+      ...createBookmarkedContent(options.bookmarkId, headingTextChildren)
     );
   } else {
     // No bookmark, add text directly
@@ -1130,9 +1118,7 @@ export function createList(
     let itemContent: ParagraphChild[] = textRuns;
     if (itemId) {
       globalBookmarkRegistry.register(itemId, itemText, 'list-item');
-      itemContent = [
-        new Bookmark({ id: itemId, children: textRuns as TextRun[] }),
-      ];
+      itemContent = createBookmarkedContent(itemId, textRuns);
     }
 
     // Create the paragraph with proper numbering reference

--- a/packages/core-docx/src/utils/bookmarkRegistry.ts
+++ b/packages/core-docx/src/utils/bookmarkRegistry.ts
@@ -4,6 +4,8 @@
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { BookmarkStart, BookmarkEnd } from 'docx';
+import type { ParagraphChild } from 'docx';
 
 export interface BookmarkInfo {
   id: string;
@@ -13,6 +15,22 @@ export interface BookmarkInfo {
 
 interface BookmarkState {
   bookmarks: Map<string, BookmarkInfo>;
+  /** Next `w:bookmarkStart/@w:id` for a content bookmark. */
+  nextLinkId: number;
+}
+
+/**
+ * Content bookmarks number from here up.
+ *
+ * `w:id` pairs a `bookmarkStart` with its `bookmarkEnd`, so it has to be unique
+ * across the whole document — including against the section bookmarks, which
+ * allocate from their own two ranges in `sectionBookmarks.ts` (layout ordinals
+ * from 1, nested sections from 1_000_000). This is the third disjoint range.
+ */
+const CONTENT_LINK_ID_BASE = 2_000_000;
+
+function createState(): BookmarkState {
+  return { bookmarks: new Map(), nextLinkId: CONTENT_LINK_ID_BASE + 1 };
 }
 
 /**
@@ -52,7 +70,7 @@ export function dedupeBookmarkId(
  * Used to track bookmark IDs and validate internal hyperlink targets
  */
 export class BookmarkRegistry {
-  private readonly fallback: BookmarkState = { bookmarks: new Map() };
+  private readonly fallback: BookmarkState = createState();
   private readonly scopes = new AsyncLocalStorage<BookmarkState>();
 
   private get state(): BookmarkState {
@@ -61,7 +79,7 @@ export class BookmarkRegistry {
 
   /** Run work with an isolated registry that follows its async call chain. */
   runScoped<T>(callback: () => T): T {
-    return this.scopes.run({ bookmarks: new Map() }, callback);
+    return this.scopes.run(createState(), callback);
   }
 
   /**
@@ -74,6 +92,20 @@ export class BookmarkRegistry {
       );
     }
     this.state.bookmarks.set(id, { id, title, type });
+  }
+
+  /**
+   * A `w:id` no other bookmark in this document will use.
+   *
+   * docx's own `Bookmark` cannot supply one: its constructor builds a fresh
+   * id generator per instance (`bookmarkUniqueNumericIdGen()`), so every
+   * bookmark it emits carries `w:id="1"`. Reported upstream as dolanmiu/docx
+   * #3478, still unreleased as of 9.7.1. Duplicated ids leave the start/end
+   * pairing ambiguous, which is why a `REF` field could not read a target's
+   * text even though navigating to it by name worked.
+   */
+  allocateLinkId(): number {
+    return this.state.nextLinkId++;
   }
 
   /**
@@ -131,3 +163,22 @@ export class BookmarkRegistry {
 
 // Global registry instance
 export const globalBookmarkRegistry = new BookmarkRegistry();
+
+/**
+ * A bookmark around `children`, as the three elements OOXML actually wants:
+ * `w:bookmarkStart`, the content, `w:bookmarkEnd`.
+ *
+ * Replaces docx's `Bookmark`, which pairs every start/end with `w:id="1"`
+ * (see `allocateLinkId`). Spread the result into a paragraph's children.
+ */
+export function createBookmarkedContent(
+  name: string,
+  children: readonly ParagraphChild[]
+): ParagraphChild[] {
+  const linkId = globalBookmarkRegistry.allocateLinkId();
+  return [
+    new BookmarkStart(name, linkId),
+    ...children,
+    new BookmarkEnd(linkId),
+  ];
+}


### PR DESCRIPTION
Two independent fixes, both verified against the renderer the hosted playground actually runs.

## 1. Every bookmark gets its own `w:id` — `[@id:none]` was rendering blank

`w:id` is what pairs a `w:bookmarkStart` with its `w:bookmarkEnd`. docx emits `w:id="1"` for **every** bookmark: its `Bookmark` constructor builds a fresh id generator per instance, so the counter never advances ([dolanmiu/docx#3478](https://github.com/dolanmiu/docx/issues/3478) — open since July, fix PR #3502 unmerged, and 9.7.1 is the latest release, so there is nothing to upgrade to).

Every range in the document therefore opened and closed on the same id. Name-based lookup still worked, which is why internal links and the numeric cross-reference switches looked healthy and hid the problem — but `[@id:none]`, which asks for the *text* inside the range, rendered blank in LibreOffice and so in every exported PDF.

Bookmarks now take their numeric id from the render-scoped bookmark registry, in a range disjoint from the section bookmarks (which already had exactly this scheme), and are emitted as an explicit start/end pair instead of via docx's `Bookmark`. That is forward-compatible: when upstream lands their fix we are simply not using the broken generator.

| | before | after |
|---|---|---|
| LibreOffice 26.2 | `and text .` | `and text Methods.` |
| LibreOffice 7.4 (hosted) | `and text .` | `and text Methods.` |

Regression tests cover id uniqueness, start/end pairing, the disjoint range vs section bookmarks, and `:none` resolving to the target text.

## 2. Playground image on `node:22-trixie-slim`

Debian bookworm is frozen at **LibreOffice 7.4**, which cannot parse a TOC field nested in a `w:sdt` and prints the raw field instruction into the document. Every hosted PDF with a table of contents showed it; it was invisible locally because dev machines run a modern LibreOffice. Trixie carries **LibreOffice 25.2.3**, which renders it correctly, plus Node 22.

The suite is pinned explicitly (`-trixie-slim`, not `-slim`) so the LibreOffice version cannot move when Docker retags the default.

Verified by building this image and driving its own preview endpoint:

```
node v22.23.2 · LibreOffice 25.2.3.2 · Debian GNU/Linux 13 (trixie)
Contents
1. Field study.........................................
    1.1. Methods......................................
```

### Layout drift

A major LibreOffice jump changes line breaking, so stock templates were compared 7.4 vs 25.2:

- `invoice`: 3 pages → 3 pages, text-extraction ordering only
- `contract-v2`: 1 page → 1 page, one line-break moved

No pagination change on either. **Caveats:** only two docx templates were checked, and `jto-playground-pptx` builds from this same Dockerfile, so Impress rendering on 25.2 is untested. Worth a wider visual pass before this is relied on for pptx.
