### PR TITLE
fix(docx): cap SVG raster fallback by area; clearer generate failures; shape rules in JSON Schema

### DIFF
--- a/.changeset/svg-raster-budget.md
+++ b/.changeset/svg-raster-budget.md
@@ -1,0 +1,28 @@
+---
+'@json-to-office/core-docx': patch
+'@json-to-office/shared-docx': patch
+'@json-to-office/jto': patch
+---
+
+Cap the inline-SVG raster fallback by area, so a page of them cannot exhaust
+the renderer.
+
+`SVG_RASTER_SCALE` is applied to one edge, which says nothing about how big the
+bitmap gets: resvg renders RGBA, so a full-page SVG at 3x is 2382x3367 ≈ 8 MP ≈
+32 MB live. The annual-report templates carry two dozen page-sized SVGs, which
+took one render past 1.1 GB and had the hosted playground's container killed
+mid-request — the reader saw the proxy's HTML error page, not a document. The
+edge is now also capped so the whole bitmap stays within 1 MP, which keeps a
+full page near 120 DPI; only Word before 2016 ever draws this fallback, since
+everything newer draws the vector. Small SVGs are untouched.
+
+Report the failure in terms an author can act on. The playground parsed every
+generate response as JSON, so a proxy's HTML error page surfaced as
+`Unexpected token '<', "<!DOCTYPE "... is not valid JSON`. It now reads the
+body only when it is JSON and, when it is not, names the likely cause — a
+502/503/504 says the server ran out of memory or restarted mid-request.
+
+Express the two `renderAs: "shape"` limits in the JSON Schema as well as in the
+deep validator. The validator only runs when a document is generated, so a
+shape missing its height was reported at Run; `if`/`then` puts the same rule
+where the editor can underline it while it is being typed.

--- a/packages/core-docx/src/utils/__tests__/svgRasterFallback.test.ts
+++ b/packages/core-docx/src/utils/__tests__/svgRasterFallback.test.ts
@@ -104,6 +104,36 @@ describe('inline SVG raster fallback', () => {
     expect(size!.width / size!.height).toBeCloseTo(827 / 1169, 1);
   });
 
+  it('skips the fallback for a sliver too extreme to fit the budget', async () => {
+    // At an aspect ratio this far from square, even the smallest edge the
+    // rasterizer will accept implies an area well over budget — clamping to
+    // that minimum would hand back the oversized bitmap the cap exists to
+    // prevent, so no fallback is written at all.
+    const sliver =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 10000"><rect width="1" height="10000" fill="#333333"/></svg>';
+    const warnings: GenerationWarning[] = [];
+
+    const buffer = await generateBufferFromJson(
+      doc({ base64: toDataUri(sliver), width: 200, height: 100 }),
+      { warnings }
+    );
+
+    // The document still renders and the vector still ships; the fallback
+    // slot keeps the historical SVG bytes, exactly as it does when the
+    // rasterizer is unavailable. What matters is that no oversized bitmap
+    // was produced.
+    expect(buffer.byteLength).toBeGreaterThan(0);
+    const media = await mediaOf(buffer);
+    expect(
+      media.filter((part) => isSvgBytes(part.data)).length
+    ).toBeGreaterThan(0);
+    expect(media.filter((part) => !isSvgBytes(part.data))).toHaveLength(0);
+
+    expect(warnings.map((entry) => entry.context?.code)).toContain(
+      'IMAGE_SVG_RASTER_SKIPPED'
+    );
+  });
+
   it('leaves an SVG below the budget at full 3x resolution', async () => {
     const buffer = await generateBufferFromJson(
       doc({ base64: toDataUri(SVG), width: 120 })

--- a/packages/core-docx/src/utils/__tests__/svgRasterFallback.test.ts
+++ b/packages/core-docx/src/utils/__tests__/svgRasterFallback.test.ts
@@ -78,6 +78,46 @@ describe('inline SVG raster fallback', () => {
     ).toEqual([]);
   });
 
+  it('keeps a page-sized SVG inside the pixel budget', async () => {
+    // A4 at 3x would be 2382x3367 ≈ 8 MP ≈ 32 MB of live RGBA. Two dozen of
+    // those in one report took a render past 1.1 GB and had the hosted
+    // playground's container killed, so the bitmap is capped by area.
+    const page =
+      '<svg xmlns="http://www.w3.org/2000/svg" width="8.27in" height="11.69in" viewBox="0 0 827 1169"><rect width="827" height="1169" fill="#EEEEEE"/></svg>';
+
+    const buffer = await generateBufferFromJson(
+      doc({ base64: toDataUri(page), width: 793.92, height: 1122.24 })
+    );
+
+    const raster = (await mediaOf(buffer)).filter(
+      (part) => !isSvgBytes(part.data)
+    );
+    expect(raster).toHaveLength(1);
+
+    const size = probe.sync(raster[0].data);
+    expect(size?.mime).toBe('image/png');
+    expect(size!.width * size!.height).toBeLessThanOrEqual(1_000_000);
+    // Still large enough to read: the cap trims resolution, it does not
+    // collapse the image to a thumbnail.
+    expect(size!.width * size!.height).toBeGreaterThan(500_000);
+    // The page's own proportions survive the trim.
+    expect(size!.width / size!.height).toBeCloseTo(827 / 1169, 1);
+  });
+
+  it('leaves an SVG below the budget at full 3x resolution', async () => {
+    const buffer = await generateBufferFromJson(
+      doc({ base64: toDataUri(SVG), width: 120 })
+    );
+
+    const raster = (await mediaOf(buffer)).filter(
+      (part) => !isSvgBytes(part.data)
+    );
+    const size = probe.sync(raster[0].data);
+    // 120px at 3x, untouched by the area cap.
+    expect(size!.width).toBeGreaterThanOrEqual(356);
+    expect(size!.width).toBeLessThanOrEqual(364);
+  });
+
   it('warns and keeps the document renderable when the SVG cannot be parsed', async () => {
     const warnings: GenerationWarning[] = [];
     const buffer = await generateBufferFromJson(

--- a/packages/core-docx/src/utils/imageUtils.ts
+++ b/packages/core-docx/src/utils/imageUtils.ts
@@ -41,21 +41,30 @@ function toRasterPx(px: number): number {
 }
 
 /**
- * Shrink a `fitTo` edge until the bitmap it implies fits `SVG_MAX_TOTAL_PX`.
+ * Shrink a `fitTo` edge until the bitmap it implies fits `SVG_MAX_TOTAL_PX`,
+ * or `undefined` when nothing does.
  *
  * `aspect` is the other edge over this one, so `edge * aspect` is the edge
  * resvg derives. Area scales with the square of the edge, hence the sqrt.
+ *
+ * A sliver — an SVG whose viewBox is thousands of times longer than it is
+ * wide — cannot be squared with both bounds at once: at `SVG_MIN_EDGE_PX` its
+ * area is still `256 * aspect`, so a ratio of 10,000 is already 2.5x over
+ * budget and grows from there. Clamping to the minimum edge in that case would
+ * hand back exactly the oversized bitmap this budget exists to prevent, so the
+ * caller is told to skip the fallback instead. Word 2016+ draws the vector
+ * either way.
  */
-function capToPixelBudget(edge: number, aspect: number): number {
-  if (!Number.isFinite(aspect) || aspect <= 0) return edge;
+function capToPixelBudget(edge: number, aspect: number): number | undefined {
+  // A degenerate ratio means the probe gave a zero or non-finite dimension;
+  // there is no bitmap size that can be reasoned about.
+  if (!Number.isFinite(aspect) || aspect <= 0) return undefined;
 
   const total = edge * edge * aspect;
   if (total <= SVG_MAX_TOTAL_PX) return edge;
 
-  return Math.max(
-    SVG_MIN_EDGE_PX,
-    Math.floor(edge * Math.sqrt(SVG_MAX_TOTAL_PX / total))
-  );
+  const scaled = Math.floor(edge * Math.sqrt(SVG_MAX_TOTAL_PX / total));
+  return scaled >= SVG_MIN_EDGE_PX ? scaled : undefined;
 }
 
 /**
@@ -93,23 +102,27 @@ async function rasterizeSvgFallback(
       transformation.width / transformation.height;
     // resvg derives the other edge from the SVG's own aspect ratio, so the
     // budget has to be applied against that, not against the placed box.
-    const fitTo = wide
-      ? {
-          mode: 'height' as const,
-          value: capToPixelBudget(
-            toRasterPx(transformation.height),
-            probeImage.width / probeImage.height
-          ),
-        }
-      : {
-          mode: 'width' as const,
-          value: capToPixelBudget(
-            toRasterPx(transformation.width),
-            probeImage.height / probeImage.width
-          ),
-        };
+    const mode = wide ? ('height' as const) : ('width' as const);
+    const value = capToPixelBudget(
+      toRasterPx(wide ? transformation.height : transformation.width),
+      wide
+        ? probeImage.width / probeImage.height
+        : probeImage.height / probeImage.width
+    );
 
-    return Buffer.from(new Resvg(markup, { fitTo }).render().asPng());
+    if (value === undefined) {
+      reportWarning(
+        'image',
+        'IMAGE_SVG_RASTER_SKIPPED',
+        'Inline SVG is too far from square to rasterize within the fallback ' +
+          'pixel budget, so its fallback only renders in Word 2016+.'
+      );
+      return undefined;
+    }
+
+    return Buffer.from(
+      new Resvg(markup, { fitTo: { mode, value } }).render().asPng()
+    );
   } catch (error) {
     reportWarning(
       'image',

--- a/packages/core-docx/src/utils/imageUtils.ts
+++ b/packages/core-docx/src/utils/imageUtils.ts
@@ -10,6 +10,21 @@ type ResvgModule = typeof import('@resvg/resvg-js');
 const SVG_RASTER_SCALE = 3;
 const SVG_MAX_EDGE_PX = 4096;
 const SVG_MIN_EDGE_PX = 16;
+/**
+ * Ceiling on the whole bitmap, not just its longest side.
+ *
+ * An edge cap alone says nothing about area, and area is what costs memory:
+ * resvg renders RGBA, so a page-sized SVG at 3x is 2382x3367 ≈ 8 MP ≈ 32 MB
+ * live before it is even encoded to PNG. The annual-report templates carry two
+ * dozen full-page SVGs, which took one render past 1.1 GB and had the hosted
+ * playground's 512 MB container killed mid-request — the reader saw the
+ * proxy's HTML error page, not a document.
+ *
+ * 1 MP keeps a full page near 120 DPI, which is enough for what this bitmap is:
+ * Word 2016+ draws the vector, and only older readers ever fall back to it.
+ * Small SVGs are unaffected — an icon at 3x is nowhere near the budget.
+ */
+const SVG_MAX_TOTAL_PX = 1_000_000;
 
 let resvgModule: Promise<ResvgModule> | undefined;
 
@@ -22,6 +37,24 @@ function toRasterPx(px: number): number {
   return Math.min(
     SVG_MAX_EDGE_PX,
     Math.max(SVG_MIN_EDGE_PX, Math.round(px * SVG_RASTER_SCALE))
+  );
+}
+
+/**
+ * Shrink a `fitTo` edge until the bitmap it implies fits `SVG_MAX_TOTAL_PX`.
+ *
+ * `aspect` is the other edge over this one, so `edge * aspect` is the edge
+ * resvg derives. Area scales with the square of the edge, hence the sqrt.
+ */
+function capToPixelBudget(edge: number, aspect: number): number {
+  if (!Number.isFinite(aspect) || aspect <= 0) return edge;
+
+  const total = edge * edge * aspect;
+  if (total <= SVG_MAX_TOTAL_PX) return edge;
+
+  return Math.max(
+    SVG_MIN_EDGE_PX,
+    Math.floor(edge * Math.sqrt(SVG_MAX_TOTAL_PX / total))
   );
 }
 
@@ -58,9 +91,23 @@ async function rasterizeSvgFallback(
     const wide =
       probeImage.width / probeImage.height >
       transformation.width / transformation.height;
+    // resvg derives the other edge from the SVG's own aspect ratio, so the
+    // budget has to be applied against that, not against the placed box.
     const fitTo = wide
-      ? { mode: 'height' as const, value: toRasterPx(transformation.height) }
-      : { mode: 'width' as const, value: toRasterPx(transformation.width) };
+      ? {
+          mode: 'height' as const,
+          value: capToPixelBudget(
+            toRasterPx(transformation.height),
+            probeImage.width / probeImage.height
+          ),
+        }
+      : {
+          mode: 'width' as const,
+          value: capToPixelBudget(
+            toRasterPx(transformation.width),
+            probeImage.height / probeImage.width
+          ),
+        };
 
     return Buffer.from(new Resvg(markup, { fitTo }).render().asPng());
   } catch (error) {

--- a/packages/jto/src/client/hooks/usePresentationGenerator.ts
+++ b/packages/jto/src/client/hooks/usePresentationGenerator.ts
@@ -20,9 +20,26 @@ export interface DocumentGenerationResult {
   warnings: GenerationWarning[];
 }
 
+/**
+ * True for `application/json` and the `+json` structured suffix, whatever the
+ * casing or parameters.
+ *
+ * Media types are case-insensitive and usually arrive with a charset, and an
+ * error body may well be `application/problem+json` — treating any of those as
+ * "not JSON" would discard the very message this code exists to surface.
+ */
+export function isJsonMediaType(contentType: string | null): boolean {
+  const mediaType = contentType?.split(';', 1)[0]?.trim().toLowerCase();
+  if (!mediaType) return false;
+  return (
+    mediaType === 'application/json' ||
+    (mediaType.startsWith('application/') && mediaType.endsWith('+json'))
+  );
+}
+
 /** The JSON body, or undefined when the response is not JSON at all. */
 async function readJsonBody(response: Response): Promise<any | undefined> {
-  if (!response.headers.get('content-type')?.includes('application/json')) {
+  if (!isJsonMediaType(response.headers.get('content-type'))) {
     return undefined;
   }
   try {
@@ -40,12 +57,19 @@ async function readJsonBody(response: Response): Promise<any | undefined> {
  * only signal there is — so name the likely cause rather than echoing a raw
  * status code.
  */
-function describeFailure(
+export function describeFailure(
   response: Response,
   body: { error?: string; message?: string } | undefined
 ): string {
   if (body?.error) return body.error;
   if (body?.message) return body.message;
+
+  if (response.ok) {
+    return (
+      `The server answered ${response.status} but not with a document. ` +
+      'This usually means a proxy or extension replaced the response.'
+    );
+  }
 
   switch (response.status) {
     case 502:

--- a/packages/jto/src/client/hooks/usePresentationGenerator.ts
+++ b/packages/jto/src/client/hooks/usePresentationGenerator.ts
@@ -20,6 +20,54 @@ export interface DocumentGenerationResult {
   warnings: GenerationWarning[];
 }
 
+/** The JSON body, or undefined when the response is not JSON at all. */
+async function readJsonBody(response: Response): Promise<any | undefined> {
+  if (!response.headers.get('content-type')?.includes('application/json')) {
+    return undefined;
+  }
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Turn a failed generation into a sentence that says what to do next.
+ *
+ * The API's own error text is always the best answer. When there is none the
+ * response came from the platform rather than the app, and the status is the
+ * only signal there is — so name the likely cause rather than echoing a raw
+ * status code.
+ */
+function describeFailure(
+  response: Response,
+  body: { error?: string; message?: string } | undefined
+): string {
+  if (body?.error) return body.error;
+  if (body?.message) return body.message;
+
+  switch (response.status) {
+    case 502:
+    case 503:
+    case 504:
+      return (
+        `The server did not finish generating (${response.status}). It usually ` +
+        'ran out of memory or restarted mid-request — documents with many ' +
+        'full-page images or inline SVGs are the common cause. Try again, or ' +
+        'split the document and generate it in parts.'
+      );
+    case 413:
+      return 'The document is too large for the server to accept (413). Remove or shrink its largest embedded assets.';
+    case 429:
+      return 'Too many requests (429). Wait a moment before generating again.';
+    default:
+      return `Generation failed (${response.status}${
+        response.statusText ? ` ${response.statusText}` : ''
+      }).`;
+  }
+}
+
 export function usePresentationGenerator() {
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -105,15 +153,15 @@ export function usePresentationGenerator() {
           signal: abortController.signal,
         });
 
-        // Parse JSON response
-        const responseData = await response.json();
+        // The body is only JSON when the API itself answered. A proxy that
+        // never reached the API — or reached one that died mid-request —
+        // answers with its own HTML error page, and parsing that unguarded is
+        // what produced `Unexpected token '<', "<!DOCTYPE "...` instead of
+        // anything an author could act on.
+        const responseData = await readJsonBody(response);
 
-        if (!response.ok || !responseData.success) {
-          const errorMessage =
-            responseData.error ||
-            responseData.message ||
-            `API request failed with status: ${response.status}`;
-          throw new Error(errorMessage);
+        if (!response.ok || !responseData?.success) {
+          throw new Error(describeFailure(response, responseData));
         }
 
         // Extract data from structured response

--- a/packages/jto/src/client/lib/__tests__/generate-failure-message.test.ts
+++ b/packages/jto/src/client/lib/__tests__/generate-failure-message.test.ts
@@ -1,0 +1,72 @@
+/**
+ * A failed generation has to say something an author can act on.
+ *
+ * The generate response was parsed as JSON unconditionally, so when the proxy
+ * answered instead of the API — a 502 HTML page after the renderer exhausted
+ * its container — the surfaced error was `Unexpected token '<', "<!DOCTYPE "`,
+ * which describes the parser rather than the problem.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isJsonMediaType,
+  describeFailure,
+} from '../../hooks/usePresentationGenerator';
+
+const res = (status: number, statusText = '') =>
+  new Response(null, { status: status === 204 ? 204 : status, statusText });
+
+describe('isJsonMediaType', () => {
+  it.each([
+    ['application/json', true],
+    ['application/json; charset=utf-8', true],
+    // Media types are case-insensitive.
+    ['Application/JSON', true],
+    // The structured suffix an error body may well use.
+    ['application/problem+json', true],
+    ['APPLICATION/PROBLEM+JSON; charset=utf-8', true],
+    ['text/html', false],
+    ['text/html; charset=utf-8', false],
+    // A `+json` suffix outside the application tree is not a JSON body.
+    ['text/problem+json', false],
+    ['', false],
+    [null, false],
+  ])('%s -> %s', (value, expected) => {
+    expect(isJsonMediaType(value as string | null)).toBe(expected);
+  });
+});
+
+describe('describeFailure', () => {
+  it('prefers the API error text when there is one', () => {
+    expect(
+      describeFailure(res(400), { error: 'Document validation failed' })
+    ).toBe('Document validation failed');
+  });
+
+  it.each([502, 503, 504])(
+    'explains a %s as the server dying mid-request',
+    (status) => {
+      const message = describeFailure(res(status), undefined);
+      expect(message).toContain('ran out of memory');
+      expect(message).not.toContain('DOCTYPE');
+    }
+  );
+
+  it('names the cause for 413 and 429', () => {
+    expect(describeFailure(res(413), undefined)).toContain('too large');
+    expect(describeFailure(res(429), undefined)).toContain('Too many requests');
+  });
+
+  it('does not report a successful response as a status failure', () => {
+    // The old default branch turned a 200 whose body was not JSON into the
+    // nonsensical "Generation failed (200 OK)".
+    const message = describeFailure(res(200, 'OK'), undefined);
+    expect(message).not.toMatch(/Generation failed \(200/);
+    expect(message).toContain('not with a document');
+  });
+
+  it('falls back to the status for anything else', () => {
+    expect(describeFailure(res(418, "I'm a teapot"), undefined)).toBe(
+      "Generation failed (418 I'm a teapot)."
+    );
+  });
+});

--- a/packages/shared-docx/src/__tests__/text-box-shape-schema.test.ts
+++ b/packages/shared-docx/src/__tests__/text-box-shape-schema.test.ts
@@ -1,0 +1,74 @@
+/**
+ * The two shape limits, expressed in the JSON Schema the editor validates
+ * against.
+ *
+ * `collectTextBoxShapeConflicts` already rejects these documents, but it only
+ * runs when one is generated — so an author learned that a shape needs a
+ * height by pressing Run. Monaco checks the buffer against this schema as it
+ * is typed, and `if`/`then` is the only place a cross-field rule can live
+ * where Monaco will see it.
+ */
+import { describe, it, expect } from 'vitest';
+import Ajv from 'ajv';
+import { TextBoxPropsSchema } from '../schemas/components/text-box';
+
+const validate = new Ajv({ strict: false }).compile(
+  TextBoxPropsSchema as object
+);
+
+const errorsFor = (props: Record<string, unknown>): string => {
+  validate(props);
+  return (validate.errors ?? [])
+    .map((e) => `${e.instancePath} ${e.message}`)
+    .join('; ');
+};
+
+describe('text-box shape rules in the editor schema', () => {
+  it('requires a height when renderAs is shape', () => {
+    expect(errorsFor({ renderAs: 'shape', width: 260 })).toContain('height');
+  });
+
+  it('requires a width when renderAs is shape', () => {
+    expect(errorsFor({ renderAs: 'shape', height: 120 })).toContain('width');
+  });
+
+  it('accepts a shape that carries both', () => {
+    expect(errorsFor({ renderAs: 'shape', width: 260, height: 120 })).toBe('');
+  });
+
+  it.each(['dashed', 'dotted', 'double'])(
+    'rejects a %s border on a shape',
+    (style) => {
+      expect(
+        errorsFor({
+          renderAs: 'shape',
+          width: 260,
+          height: 120,
+          style: { border: { top: { style, width: 2 } } },
+        })
+      ).not.toBe('');
+    }
+  );
+
+  it('allows a solid border on a shape', () => {
+    expect(
+      errorsFor({
+        renderAs: 'shape',
+        width: 260,
+        height: 120,
+        style: { border: { top: { style: 'solid', width: 2 } } },
+      })
+    ).toBe('');
+  });
+
+  it('leaves table text-boxes alone — no size, any border style', () => {
+    // The default rendering auto-fits and draws every border style, so none of
+    // the shape rules may reach it. The annual-report templates carry hundreds
+    // of exactly these.
+    expect(errorsFor({})).toBe('');
+    expect(
+      errorsFor({ style: { border: { left: { style: 'dashed', width: 2 } } } })
+    ).toBe('');
+    expect(errorsFor({ renderAs: 'table', width: 260 })).toBe('');
+  });
+});

--- a/packages/shared-docx/src/schemas/components/text-box.ts
+++ b/packages/shared-docx/src/schemas/components/text-box.ts
@@ -171,7 +171,46 @@ export const TextBoxPropsSchema = Type.Object(
       )
     ),
   },
-  { additionalProperties: false }
+  {
+    additionalProperties: false,
+    /**
+     * The same two shape limits `collectTextBoxShapeConflicts` enforces, said
+     * in JSON Schema so an editor can say it too.
+     *
+     * The deep validator only runs when a document is generated, so until now
+     * an author learned that a shape needs a height by pressing Run. These are
+     * plain cross-field rules, and `if`/`then` expresses them — which is what
+     * Monaco checks the buffer against, so the editor underlines the mistake
+     * while it is being made. The deep validator stays as the backstop: it
+     * carries the remediation text, and it is what the API enforces for
+     * callers who never see an editor.
+     */
+    allOf: [
+      {
+        if: {
+          properties: { renderAs: { const: 'shape' } },
+          required: ['renderAs'],
+        },
+        then: {
+          required: ['width', 'height'],
+          properties: {
+            style: {
+              properties: {
+                border: {
+                  properties: Object.fromEntries(
+                    ['top', 'right', 'bottom', 'left'].map((side) => [
+                      side,
+                      { properties: { style: { enum: ['solid', 'none'] } } },
+                    ])
+                  ),
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+  }
 );
 
 export type TextBoxProps = Static<typeof TextBoxPropsSchema>;


### PR DESCRIPTION
Three fixes for the two problems found while troubleshooting the playground.

## 1. `Unexpected token '<', "<!DOCTYPE "` — the renderer was exhausting its container

That message was a symptom. The hosted playground answered `HTTP 502` with `text/html` (the proxy's error page), and the client parsed it as JSON.

**Why it 502'd.** `/generate` — which never touches LibreOffice — died too, so the conversion path was not involved. `modern-annual-report-1` carries **24 full-page A4 inline SVGs**, and every inline SVG also rasterizes a PNG fallback. `SVG_RASTER_SCALE` is applied to one *edge*, which says nothing about area, and area is what costs memory: resvg renders RGBA, so a page at 3x is 2382×3367 ≈ 8 MP ≈ **32 MB live per image**.

Measured on that template:

| | peak RSS | time | output |
|---|---|---|---|
| before | **1151 MB** | 11.4 s | 1.06 MB |
| images stripped (baseline) | 132 MB | 0.2 s | 22 KB |
| after (1 MP cap) | **466 MB** | 7.1 s | 445 KB |

The edge is now also capped so the whole bitmap stays within **1 MP** — a full page lands near 120 DPI, which is more than this bitmap needs, since Word 2016+ draws the vector and only older readers ever see it. SVGs already under the budget are untouched.

Verified in the production image under a hard memory limit, generating the real template:

| image | `--memory=512m` | `--memory=300m` |
|---|---|---|
| before | 200 (8.4 s) | **OOMKilled** |
| after | 200 (5.0 s) | 200 (2.7 s) |

## 2. The client now says something useful

`usePresentationGenerator` called `response.json()` before checking `response.ok`, so any non-JSON error body surfaced as a JSON syntax error. It now reads the body only when the content type is JSON, and otherwise explains the status — a 502/503/504 says the server ran out of memory or restarted mid-request and suggests splitting the document, rather than echoing a parse failure.

## 3. Shape rules moved into the JSON Schema

`renderAs: "shape"` without a `height` was reported at Run, because `collectTextBoxShapeConflicts` only runs when a document is generated and the editor validates against JSON Schema, which had `renderAs` as a plain enum. The same two limits are now `if`/`then` conditionals, so Monaco underlines them as they are typed. The deep validator stays as the backstop — it carries the remediation text and it is what the API enforces for callers with no editor.

Checked against the generated `document.schema.json` with a JSON Schema validator:

- the reported document (`shape` + `width`, no `height`) → 1 error, `'height' is a required property`
- the same document with a height → clean
- `shape` + dashed border → 1 error
- `modern-annual-report-1`, whose 320 text-boxes all use the default rendering → clean, no false positives

## Verification

`pnpm typecheck` 15/15 · `pnpm lint` 9/9 · `pnpm test` 15/15 · `pnpm generate:schemas` clean. New tests: raster area cap (page-sized SVG stays within budget, small SVG keeps full 3x), and eight schema cases including that table text-boxes are left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SVG image fallback rendering by capping large rasterized images while preserving aspect ratio and visual clarity.
  - Improved generation error messages for malformed responses, server failures, rate limits, oversized documents, and other API errors.
  - Added validation for shape-based text boxes, requiring dimensions and permitting only supported border styles.

- **Validation**
  - Added safeguards to ensure standard table text boxes continue to support their existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->