### PR TITLE
chore: zero the formatting drift, and gate it

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# Revisions to skip in `git blame` — mechanical reformats, no behaviour.
+# Enable locally (once):
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# GitHub honours this file automatically.
+
+# style: prettier sweep, repo-wide
+e60c1c7e16f03b011ba4343b659b2cf481cb1b0e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
 
       - run: pnpm lint
 
+      - run: pnpm format:check
+
       - run: pnpm check:renderer-docs
 
       - run: pnpm typecheck

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,7 @@
 THIRD-PARTY-NOTICES.md
+
+# LLM prompt sources. The compact single-line JSON examples in these files are
+# deliberate: Prettier explodes them across many lines, which inflates every
+# system prompt we send by ~4% and changes the authoring style the model is
+# shown by example. These files are product behaviour, not code style.
+packages/jto/src/server/prompts/

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,11 @@
   "trailingComma": "es5",
   "singleQuote": true,
   "printWidth": 80,
-  "tabWidth": 2
+  "tabWidth": 2,
+  "overrides": [
+    {
+      "files": ["**/tsconfig*.json", "**/jsconfig*.json"],
+      "options": { "trailingComma": "none" }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "version-packages": "changeset version",
     "release": "pnpm build && changeset publish",
     "\n\n=== GIT HOOKS ===": "",
-    "prepare": "husky"
+    "prepare": "husky",
+    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\""
   },
   "keywords": [
     "docx",

--- a/packages/core-docx/tsconfig.json
+++ b/packages/core-docx/tsconfig.json
@@ -15,8 +15,5 @@
     "**/*.spec.ts",
     "**/__tests__/**"
   ],
-  "references": [
-    { "path": "../shared" },
-    { "path": "../shared-docx" }
-  ]
+  "references": [{ "path": "../shared" }, { "path": "../shared-docx" }]
 }

--- a/packages/core-pptx/src/core/grid.ts
+++ b/packages/core-pptx/src/core/grid.ts
@@ -3,7 +3,12 @@
  * Converts grid coordinates to absolute x/y/w/h positions
  */
 
-import type { GridConfig, GridPosition, PptxComponentInput, PipelineWarning } from '../types';
+import type {
+  GridConfig,
+  GridPosition,
+  PptxComponentInput,
+  PipelineWarning,
+} from '../types';
 import { warn, W } from '../utils/warn';
 
 export const DEFAULT_GRID_CONFIG: Required<{
@@ -20,7 +25,8 @@ export const DEFAULT_GRID_CONFIG: Required<{
 
 function resolveMargin(margin: GridConfig['margin']) {
   if (margin == null) return DEFAULT_GRID_CONFIG.margin;
-  if (typeof margin === 'number') return { top: margin, right: margin, bottom: margin, left: margin };
+  if (typeof margin === 'number')
+    return { top: margin, right: margin, bottom: margin, left: margin };
   return margin;
 }
 
@@ -92,7 +98,9 @@ export function resolveGridPosition(
   const rowSpan = Math.max(1, Math.min(gridPos.rowSpan ?? 1, rows - row));
 
   if (gridPos.column !== col || gridPos.row !== row) {
-    warn(warnings, W.GRID_POSITION_CLAMPED,
+    warn(
+      warnings,
+      W.GRID_POSITION_CLAMPED,
       `Grid position clamped: column ${gridPos.column}→${col}, row ${gridPos.row}→${row} (grid: ${cols}×${rows})`
     );
   }
@@ -120,24 +128,36 @@ export function resolveComponentGridPosition(
   const gridPos = component.props.grid as GridPosition | undefined;
   if (!gridPos) return component;
 
-  const resolved = resolveGridPosition(gridPos, gridConfig, slideWidth, slideHeight, warnings);
+  const resolved = resolveGridPosition(
+    gridPos,
+    gridConfig,
+    slideWidth,
+    slideHeight,
+    warnings
+  );
 
   const { grid: _grid, ...restProps } = component.props; // eslint-disable-line no-unused-vars, @typescript-eslint/no-unused-vars
   const newProps = { ...restProps };
 
   // When explicit values use percentage strings, convert grid-resolved inches
   // to percentages too so pptxgenjs receives consistent units per element.
-  const hasPercentX = typeof newProps.x === 'string' || typeof newProps.w === 'string';
-  const hasPercentY = typeof newProps.y === 'string' || typeof newProps.h === 'string';
+  const hasPercentX =
+    typeof newProps.x === 'string' || typeof newProps.w === 'string';
+  const hasPercentY =
+    typeof newProps.y === 'string' || typeof newProps.h === 'string';
 
   const toPercX = (v: number) => `${+((v / slideWidth) * 100).toFixed(2)}%`;
   const toPercY = (v: number) => `${+((v / slideHeight) * 100).toFixed(2)}%`;
 
   // Grid sets x/y/w/h, but explicit values on the element override individually
-  if (newProps.x == null) newProps.x = hasPercentX ? toPercX(resolved.x) : resolved.x;
-  if (newProps.y == null) newProps.y = hasPercentY ? toPercY(resolved.y) : resolved.y;
-  if (newProps.w == null) newProps.w = hasPercentX ? toPercX(resolved.w) : resolved.w;
-  if (newProps.h == null) newProps.h = hasPercentY ? toPercY(resolved.h) : resolved.h;
+  if (newProps.x == null)
+    newProps.x = hasPercentX ? toPercX(resolved.x) : resolved.x;
+  if (newProps.y == null)
+    newProps.y = hasPercentY ? toPercY(resolved.y) : resolved.y;
+  if (newProps.w == null)
+    newProps.w = hasPercentX ? toPercX(resolved.w) : resolved.w;
+  if (newProps.h == null)
+    newProps.h = hasPercentY ? toPercY(resolved.h) : resolved.h;
 
   return { ...component, props: newProps };
 }

--- a/packages/core-pptx/tsconfig.json
+++ b/packages/core-pptx/tsconfig.json
@@ -15,8 +15,5 @@
     "**/*.spec.ts",
     "**/__tests__/**"
   ],
-  "references": [
-    { "path": "../shared" },
-    { "path": "../shared-pptx" }
-  ]
+  "references": [{ "path": "../shared" }, { "path": "../shared-pptx" }]
 }

--- a/packages/core-pptx/tsup.config.ts
+++ b/packages/core-pptx/tsup.config.ts
@@ -18,7 +18,5 @@ export default defineConfig({
     '**/temp/**',
     '**/.git/**',
   ],
-  external: [
-    'pptxgenjs',
-  ],
+  external: ['pptxgenjs'],
 });

--- a/packages/jto-cli/tsconfig.json
+++ b/packages/jto-cli/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "lib": ["ES2022"],
-    "jsx": "react-jsx",
+    "jsx": "react-jsx"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": [
@@ -12,7 +12,7 @@
     "dist",
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
-    "src/**/__tests__/**",
+    "src/**/__tests__/**"
   ],
   "references": [
     { "path": "../shared" },
@@ -20,6 +20,6 @@
     { "path": "../shared-pptx" },
     { "path": "../core-docx" },
     { "path": "../core-pptx" },
-    { "path": "../jto-ops" },
-  ],
+    { "path": "../jto-ops" }
+  ]
 }

--- a/packages/jto-ops/tsconfig.json
+++ b/packages/jto-ops/tsconfig.json
@@ -3,20 +3,20 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "lib": ["ES2022"],
+    "lib": ["ES2022"]
   },
   "include": ["src/**/*.ts"],
   "exclude": [
     "node_modules",
     "dist",
     "src/**/*.test.ts",
-    "src/**/__tests__/**",
+    "src/**/__tests__/**"
   ],
   "references": [
     { "path": "../shared" },
     { "path": "../shared-docx" },
     { "path": "../shared-pptx" },
     { "path": "../core-docx" },
-    { "path": "../core-pptx" },
-  ],
+    { "path": "../core-pptx" }
+  ]
 }

--- a/packages/jto/src/__tests__/apply-merge.test.ts
+++ b/packages/jto/src/__tests__/apply-merge.test.ts
@@ -12,7 +12,9 @@ import {
 describe('mergeAiOutput — selection splice', () => {
   it('splices unique match', () => {
     const doc = '{"a": 1, "b": 2}';
-    const { modified } = mergeAiOutput(doc, '"b": 99', { selectedText: '"b": 2' });
+    const { modified } = mergeAiOutput(doc, '"b": 99', {
+      selectedText: '"b": 2',
+    });
     expect(modified).toBe('{"a": 1, "b": 99}');
   });
 
@@ -238,7 +240,11 @@ describe('mergeAiOutput — named-object splice', () => {
 
   it('replaces only the matching named object', () => {
     const aiOutput = JSON.stringify(
-      { name: 'COVER', background: { color: 'green' }, objects: [{ type: 'text' }] },
+      {
+        name: 'COVER',
+        background: { color: 'green' },
+        objects: [{ type: 'text' }],
+      },
       null,
       2
     );
@@ -291,7 +297,11 @@ describe('mergeAiOutput — named-object splice', () => {
   });
 
   it('falls through to full-doc when AI name matches only the root', () => {
-    const aiOutput = JSON.stringify({ name: 'pptx', props: { templates: [] } }, null, 2);
+    const aiOutput = JSON.stringify(
+      { name: 'pptx', props: { templates: [] } },
+      null,
+      2
+    );
     const { modified } = mergeAiOutput(doc, aiOutput);
     // 'pptx' only exists on the root (not inside any array), so named splice
     // can't find it → falls through to full-doc replacement

--- a/packages/jto/src/client/components/playground/ai-chat/chat-apply-button.tsx
+++ b/packages/jto/src/client/components/playground/ai-chat/chat-apply-button.tsx
@@ -3,7 +3,11 @@ import { useState, useCallback, useMemo } from 'react';
 import { jsonrepair } from 'jsonrepair';
 import { Button } from '../../ui/button';
 import { useDocumentsStore } from '../../../store/documents-store-provider';
-import { mergeAiOutput, applyId as stableId, mergeTemplatesDelta } from '../../../lib/apply-merge';
+import {
+  mergeAiOutput,
+  applyId as stableId,
+  mergeTemplatesDelta,
+} from '../../../lib/apply-merge';
 import type { SelectionContext } from '../../../lib/monaco-selection-utils';
 import type { AiScope } from '../../../store/chat-store';
 
@@ -13,23 +17,47 @@ interface ChatApplyButtonProps {
   scope?: AiScope;
 }
 
-export function ChatApplyButton({ json: rawJson, context, scope }: ChatApplyButtonProps) {
+export function ChatApplyButton({
+  json: rawJson,
+  context,
+  scope,
+}: ChatApplyButtonProps) {
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const json = useMemo(() => {
-    try { JSON.parse(rawJson); return rawJson; } catch { /* needs repair */ }
-    try { return jsonrepair(rawJson); } catch { /* try wrapping */ }
+    try {
+      JSON.parse(rawJson);
+      return rawJson;
+    } catch {
+      /* needs repair */
+    }
+    try {
+      return jsonrepair(rawJson);
+    } catch {
+      /* try wrapping */
+    }
     // Bare property like "key": { ... } — wrap in braces
     const wrapped = `{${rawJson}}`;
-    try { JSON.parse(wrapped); return wrapped; } catch { /* needs repair */ }
-    try { return jsonrepair(wrapped); } catch { return null; }
+    try {
+      JSON.parse(wrapped);
+      return wrapped;
+    } catch {
+      /* needs repair */
+    }
+    try {
+      return jsonrepair(wrapped);
+    } catch {
+      return null;
+    }
   }, [rawJson]);
 
   const applyId = useMemo(() => stableId(json || rawJson), [json, rawJson]);
   const activeTab = useDocumentsStore((s) => s.activeTab);
   const documents = useDocumentsStore((s) => s.documents);
-  const applied = useDocumentsStore((s) => (s.acceptedApplyIds || []).includes(applyId));
+  const applied = useDocumentsStore((s) =>
+    (s.acceptedApplyIds || []).includes(applyId)
+  );
   const setPendingDiff = useDocumentsStore((s) => s.setPendingDiff);
   const createDocument = useDocumentsStore((s) => s.createDocument);
   const openDocument = useDocumentsStore((s) => s.openDocument);
@@ -51,13 +79,15 @@ export function ChatApplyButton({ json: rawJson, context, scope }: ChatApplyButt
               if (!currentDoc.props) currentDoc.props = {};
               currentDoc.props.templates = mergeTemplatesDelta(
                 currentDoc.props.templates || [],
-                fragment.templates,
+                fragment.templates
               );
               const modified = JSON.stringify(currentDoc, null, 2);
               setPendingDiff(activeTab, original, modified, applyId);
               return;
             }
-          } catch { /* fall through to generic merge */ }
+          } catch {
+            /* fall through to generic merge */
+          }
         }
 
         const ctx = context?.[0];
@@ -71,7 +101,17 @@ export function ChatApplyButton({ json: rawJson, context, scope }: ChatApplyButt
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Merge failed');
     }
-  }, [json, activeTab, documents, setPendingDiff, createDocument, openDocument, context, scope, applyId]);
+  }, [
+    json,
+    activeTab,
+    documents,
+    setPendingDiff,
+    createDocument,
+    openDocument,
+    context,
+    scope,
+    applyId,
+  ]);
 
   const handleCopy = useCallback(async () => {
     await navigator.clipboard.writeText(rawJson);
@@ -82,11 +122,20 @@ export function ChatApplyButton({ json: rawJson, context, scope }: ChatApplyButt
   return (
     <div className="flex flex-col gap-1 px-3 py-2 border-t">
       <div className="flex gap-1.5">
-        <Button variant="secondary" size="sm" onClick={handleApply} disabled={applied || !json}>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={handleApply}
+          disabled={applied || !json}
+        >
           {applied ? 'Applied' : !json ? 'Invalid JSON' : 'Apply to Editor'}
         </Button>
         <Button variant="ghost" size="sm" onClick={handleCopy}>
-          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+          {copied ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
         </Button>
       </div>
       {error && <p className="text-xs text-destructive m-0">{error}</p>}

--- a/packages/jto/src/client/components/playground/ai-chat/chat-context-chip.tsx
+++ b/packages/jto/src/client/components/playground/ai-chat/chat-context-chip.tsx
@@ -32,11 +32,18 @@ function humanizeContext(ctx: SelectionContext & { documentName?: string }) {
 
 /** One-line text preview */
 function previewText(text: string, max = 50) {
-  const oneLine = text.replace(/[\n\r]+/g, ' ').replace(/\s+/g, ' ').trim();
+  const oneLine = text
+    .replace(/[\n\r]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
   return oneLine.length > max ? oneLine.slice(0, max) + '…' : oneLine;
 }
 
-export function ChatContextChip({ context, onRemove, variant = 'default' }: ChatContextChipProps) {
+export function ChatContextChip({
+  context,
+  onRemove,
+  variant = 'default',
+}: ChatContextChipProps) {
   const componentName = humanizeContext(context);
   const docName = context.documentName?.replace(/\.json$/, '') ?? '';
   const label = docName ? `${docName} › ${componentName}` : componentName;
@@ -44,12 +51,16 @@ export function ChatContextChip({ context, onRemove, variant = 'default' }: Chat
 
   const sent = variant === 'sent';
   const chip = (
-    <div className={`group flex items-center gap-1.5 rounded-md border pl-2 ${onRemove ? 'pr-1' : 'pr-2'} py-1 text-xs max-w-[280px] transition-colors ${
-      sent
-        ? 'border-primary-foreground/20 bg-primary-foreground/10 hover:bg-primary-foreground/20'
-        : 'border-primary/20 bg-primary/5 hover:bg-primary/10'
-    }`}>
-      <FileCode2 className={`h-3 w-3 shrink-0 ${sent ? 'text-primary-foreground/60' : 'text-primary/60'}`} />
+    <div
+      className={`group flex items-center gap-1.5 rounded-md border pl-2 ${onRemove ? 'pr-1' : 'pr-2'} py-1 text-xs max-w-[280px] transition-colors ${
+        sent
+          ? 'border-primary-foreground/20 bg-primary-foreground/10 hover:bg-primary-foreground/20'
+          : 'border-primary/20 bg-primary/5 hover:bg-primary/10'
+      }`}
+    >
+      <FileCode2
+        className={`h-3 w-3 shrink-0 ${sent ? 'text-primary-foreground/60' : 'text-primary/60'}`}
+      />
       <span className="truncate font-medium">{label}</span>
       {onRemove && (
         <button
@@ -71,7 +82,9 @@ export function ChatContextChip({ context, onRemove, variant = 'default' }: Chat
         <p className="text-xs font-medium mb-0.5">{label}</p>
         <p className="text-xs text-muted-foreground font-mono">{preview}</p>
         {context.jsonPath && (
-          <p className="text-[10px] text-muted-foreground/60 mt-1">{context.jsonPath}</p>
+          <p className="text-[10px] text-muted-foreground/60 mt-1">
+            {context.jsonPath}
+          </p>
         )}
       </TooltipContent>
     </Tooltip>

--- a/packages/jto/src/client/components/playground/schema-dialog.tsx
+++ b/packages/jto/src/client/components/playground/schema-dialog.tsx
@@ -1,11 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Copy, Check } from 'lucide-react';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '../ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';

--- a/packages/jto/src/client/components/ui/form.tsx
+++ b/packages/jto/src/client/components/ui/form.tsx
@@ -29,8 +29,8 @@ const FormField = <
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >({
-    ...props
-  }: ControllerProps<TFieldValues, TName>) => {
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
   return (
     <FormFieldContext.Provider value={{ name: props.name }}>
       <Controller {...props} />

--- a/packages/jto/src/client/components/ui/sidebar.tsx
+++ b/packages/jto/src/client/components/ui/sidebar.tsx
@@ -50,131 +50,131 @@ const SidebarProvider = React.forwardRef<
     defaultOpen?: boolean;
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
-      }
-      >(
-      (
-        {
-          defaultOpen = true,
-          open: openProp,
-          onOpenChange: setOpenProp,
-          className,
-          style,
-          children,
-          ...props
-        },
-        ref
-      ) => {
-        const isMobile = useIsMobile();
-        const [openMobile, setOpenMobile] = React.useState(false);
+  }
+>(
+  (
+    {
+      defaultOpen = true,
+      open: openProp,
+      onOpenChange: setOpenProp,
+      className,
+      style,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const isMobile = useIsMobile();
+    const [openMobile, setOpenMobile] = React.useState(false);
 
-        // This is the internal state of the sidebar.
-        // We use openProp and setOpenProp for control from outside the component.
-        const [_open, _setOpen] = React.useState(defaultOpen);
-        const open = openProp ?? _open;
-        const setOpen = React.useCallback(
-          (value: boolean | ((value: boolean) => boolean)) => {
-            const openState = typeof value === 'function' ? value(open) : value;
-            if (setOpenProp) {
-              setOpenProp(openState);
-            } else {
-              _setOpen(openState);
-            }
+    // This is the internal state of the sidebar.
+    // We use openProp and setOpenProp for control from outside the component.
+    const [_open, _setOpen] = React.useState(defaultOpen);
+    const open = openProp ?? _open;
+    const setOpen = React.useCallback(
+      (value: boolean | ((value: boolean) => boolean)) => {
+        const openState = typeof value === 'function' ? value(open) : value;
+        if (setOpenProp) {
+          setOpenProp(openState);
+        } else {
+          _setOpen(openState);
+        }
 
-            // This sets the cookie to keep the sidebar state.
-            document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
-          },
-          [setOpenProp, open]
-        );
+        // This sets the cookie to keep the sidebar state.
+        document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+      },
+      [setOpenProp, open]
+    );
 
-        // Helper to toggle the sidebar.
-        const toggleSidebar = React.useCallback(() => {
-          return isMobile
-            ? setOpenMobile((open) => !open)
-            : setOpen((open) => !open);
-        }, [isMobile, setOpen, setOpenMobile]);
+    // Helper to toggle the sidebar.
+    const toggleSidebar = React.useCallback(() => {
+      return isMobile
+        ? setOpenMobile((open) => !open)
+        : setOpen((open) => !open);
+    }, [isMobile, setOpen, setOpenMobile]);
 
-        // Adds a keyboard shortcut to toggle the sidebar.
-        React.useEffect(() => {
-          const isEditableTarget = (el: EventTarget | null) => {
-            const node = el as HTMLElement | null;
-            if (!node) return false;
-            const tag = node.tagName?.toLowerCase();
-            if (
-              tag === 'input' ||
+    // Adds a keyboard shortcut to toggle the sidebar.
+    React.useEffect(() => {
+      const isEditableTarget = (el: EventTarget | null) => {
+        const node = el as HTMLElement | null;
+        if (!node) return false;
+        const tag = node.tagName?.toLowerCase();
+        if (
+          tag === 'input' ||
           tag === 'textarea' ||
           tag === 'select' ||
           (node as HTMLElement).isContentEditable
-            ) {
-              return true;
-            }
-            // If the target is inside Monaco editor, treat as editable
-            return !!(node.closest && node.closest('.monaco-editor'));
-          };
+        ) {
+          return true;
+        }
+        // If the target is inside Monaco editor, treat as editable
+        return !!(node.closest && node.closest('.monaco-editor'));
+      };
 
-          const handleKeyDown = (event: KeyboardEvent) => {
-            const isMeta = event.metaKey || event.ctrlKey;
-            const key = event.key.toLowerCase();
+      const handleKeyDown = (event: KeyboardEvent) => {
+        const isMeta = event.metaKey || event.ctrlKey;
+        const key = event.key.toLowerCase();
 
-            // Default shortcut (Cmd/Ctrl+B)
-            if (isMeta && key === SIDEBAR_KEYBOARD_SHORTCUT) {
-              event.preventDefault();
-              toggleSidebar();
-              return;
-            }
+        // Default shortcut (Cmd/Ctrl+B)
+        if (isMeta && key === SIDEBAR_KEYBOARD_SHORTCUT) {
+          event.preventDefault();
+          toggleSidebar();
+          return;
+        }
 
-            // Additional shortcut: Cmd/Ctrl+S to toggle, but only when not editing text/Monaco
-            if (isMeta && key === 's' && !isEditableTarget(event.target)) {
-              event.preventDefault();
-              toggleSidebar();
-            }
-          };
+        // Additional shortcut: Cmd/Ctrl+S to toggle, but only when not editing text/Monaco
+        if (isMeta && key === 's' && !isEditableTarget(event.target)) {
+          event.preventDefault();
+          toggleSidebar();
+        }
+      };
 
-          window.addEventListener('keydown', handleKeyDown);
-          return () => window.removeEventListener('keydown', handleKeyDown);
-        }, [toggleSidebar]);
+      window.addEventListener('keydown', handleKeyDown);
+      return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [toggleSidebar]);
 
-        // We add a state so that we can do data-state="expanded" or "collapsed".
-        // This makes it easier to style the sidebar with Tailwind classes.
-        const state = open ? 'expanded' : 'collapsed';
+    // We add a state so that we can do data-state="expanded" or "collapsed".
+    // This makes it easier to style the sidebar with Tailwind classes.
+    const state = open ? 'expanded' : 'collapsed';
 
-        const contextValue = React.useMemo<SidebarContextType>(
-          () => ({
-            state,
-            open,
-            setOpen,
-            isMobile,
-            openMobile,
-            setOpenMobile,
-            toggleSidebar,
-          }),
-          [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
-        );
+    const contextValue = React.useMemo<SidebarContextType>(
+      () => ({
+        state,
+        open,
+        setOpen,
+        isMobile,
+        openMobile,
+        setOpenMobile,
+        toggleSidebar,
+      }),
+      [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+    );
 
-        return (
-          <SidebarContext.Provider value={contextValue}>
-            <TooltipProvider delayDuration={0}>
-              <div
-                style={
+    return (
+      <SidebarContext.Provider value={contextValue}>
+        <TooltipProvider delayDuration={0}>
+          <div
+            style={
               {
                 '--sidebar-width': SIDEBAR_WIDTH,
                 '--sidebar-width-icon': SIDEBAR_WIDTH_ICON,
                 ...style,
               } as React.CSSProperties
-                }
-                className={cn(
-                  'group/sidebar-wrapper has-[[data-variant=inset]]:bg-sidebar flex min-h-svh w-full',
-                  className
-                )}
-                ref={ref}
-                {...props}
-              >
-                {children}
-              </div>
-            </TooltipProvider>
-          </SidebarContext.Provider>
-        );
-      }
-      );
+            }
+            className={cn(
+              'group/sidebar-wrapper has-[[data-variant=inset]]:bg-sidebar flex min-h-svh w-full',
+              className
+            )}
+            ref={ref}
+            {...props}
+          >
+            {children}
+          </div>
+        </TooltipProvider>
+      </SidebarContext.Provider>
+    );
+  }
+);
 SidebarProvider.displayName = 'SidebarProvider';
 
 const Sidebar = React.forwardRef<

--- a/packages/jto/src/client/components/ui/use-toast.tsx
+++ b/packages/jto/src/client/components/ui/use-toast.tsx
@@ -69,56 +69,56 @@ const addToRemoveQueue = (toastId: string) => {
 
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
-  case 'ADD_TOAST':
-    return {
-      ...state,
-      toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
-    };
-
-  case 'UPDATE_TOAST':
-    return {
-      ...state,
-      toasts: state.toasts.map((t) =>
-        t.id === action.toast.id ? { ...t, ...action.toast } : t
-      ),
-    };
-
-  case 'DISMISS_TOAST': {
-    const { toastId } = action;
-
-    // ! Side effects ! - This could be extracted into a dismissToast() action,
-    // but I'll keep it here for simplicity
-    if (toastId) {
-      addToRemoveQueue(toastId);
-    } else {
-      state.toasts.forEach((toast) => {
-        addToRemoveQueue(toast.id);
-      });
-    }
-
-    return {
-      ...state,
-      toasts: state.toasts.map((t) =>
-        t.id === toastId || toastId === undefined
-          ? {
-            ...t,
-            open: false,
-          }
-          : t
-      ),
-    };
-  }
-  case 'REMOVE_TOAST':
-    if (action.toastId === undefined) {
+    case 'ADD_TOAST':
       return {
         ...state,
-        toasts: [],
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      };
+
+    case 'UPDATE_TOAST':
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t
+        ),
+      };
+
+    case 'DISMISS_TOAST': {
+      const { toastId } = action;
+
+      // ! Side effects ! - This could be extracted into a dismissToast() action,
+      // but I'll keep it here for simplicity
+      if (toastId) {
+        addToRemoveQueue(toastId);
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id);
+        });
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t
+        ),
       };
     }
-    return {
-      ...state,
-      toasts: state.toasts.filter((t) => t.id !== action.toastId),
-    };
+    case 'REMOVE_TOAST':
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        };
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      };
   }
 };
 

--- a/packages/jto/src/client/hooks/useChatSession.ts
+++ b/packages/jto/src/client/hooks/useChatSession.ts
@@ -4,7 +4,11 @@ import { DefaultChatTransport, type UIMessage, type FileUIPart } from 'ai';
 import { useChatStore } from '../store/chat-store-provider';
 import { useDocumentsStore } from '../store/documents-store-provider';
 import { FORMAT } from '../lib/env';
-import { mergeAiOutput, applyId, mergeTemplatesDelta } from '../lib/apply-merge';
+import {
+  mergeAiOutput,
+  applyId,
+  mergeTemplatesDelta,
+} from '../lib/apply-merge';
 import type { SelectionContext } from '../lib/monaco-selection-utils';
 import type { AiScope } from '../store/chat-store';
 
@@ -13,10 +17,16 @@ type ContextEntry = (SelectionContext & { documentName?: string })[];
 /** Validate & return the last JSON code block, preserving original formatting. */
 function tryParseJsonBlocks(blocks: RegExpMatchArray[]): string | null {
   const raw = blocks[blocks.length - 1][1];
-  try { JSON.parse(raw); return raw; } catch {}
+  try {
+    JSON.parse(raw);
+    return raw;
+  } catch {}
   if (blocks.length > 1) {
-    const combined = blocks.map(m => m[1]).join('\n');
-    try { JSON.parse(combined); return combined; } catch {}
+    const combined = blocks.map((m) => m[1]).join('\n');
+    try {
+      JSON.parse(combined);
+      return combined;
+    } catch {}
   }
   return null;
 }
@@ -30,7 +40,7 @@ function tryParseJsonBlocks(blocks: RegExpMatchArray[]): string | null {
 function scopedMerge(
   currentDoc: string,
   aiOutput: string,
-  scope: AiScope,
+  scope: AiScope
 ): { original: string; modified: string } | null {
   if (scope === 'global') return null;
   try {
@@ -40,7 +50,10 @@ function scopedMerge(
       doc.children = fragment.children;
     } else if (scope === 'templates' && Array.isArray(fragment.templates)) {
       if (!doc.props) doc.props = {};
-      doc.props.templates = mergeTemplatesDelta(doc.props.templates || [], fragment.templates);
+      doc.props.templates = mergeTemplatesDelta(
+        doc.props.templates || [],
+        fragment.templates
+      );
     } else {
       return null; // unexpected shape, fall back
     }
@@ -94,11 +107,15 @@ export function useChatSession() {
 
   const transportRef = useRef<DefaultChatTransport<UIMessage> | null>(null);
   if (!transportRef.current) {
-    transportRef.current = new DefaultChatTransport<UIMessage>({ api: '/api/ai/chat' });
+    transportRef.current = new DefaultChatTransport<UIMessage>({
+      api: '/api/ai/chat',
+    });
   }
 
   const getActiveDocument = useCallback(() => {
-    const doc = documentsRef.current.find((d) => d.name === activeTabRef.current);
+    const doc = documentsRef.current.find(
+      (d) => d.name === activeTabRef.current
+    );
     return doc ? { name: doc.name, text: doc.text } : undefined;
   }, []);
 
@@ -120,7 +137,9 @@ export function useChatSession() {
         // Auto-title from first user message
         const thread = threadsRef.current[tid];
         if (thread && thread.title.startsWith('Chat ')) {
-          const firstUserMsg = (allMsgs as any[]).find((m) => m.role === 'user');
+          const firstUserMsg = (allMsgs as any[]).find(
+            (m) => m.role === 'user'
+          );
           if (firstUserMsg) {
             const text =
               firstUserMsg.parts
@@ -148,13 +167,18 @@ export function useChatSession() {
       }
 
       // Auto-apply: extract last JSON code block from assistant response
-      const lastMsg = (allMsgs as any[]).filter((m) => m.role === 'assistant').pop();
+      const lastMsg = (allMsgs as any[])
+        .filter((m) => m.role === 'assistant')
+        .pop();
       if (lastMsg) {
-        const fullText = lastMsg.parts
-          ?.filter((p: any) => p.type === 'text')
-          .map((p: any) => p.text)
-          .join('') || '';
-        const jsonBlocks = [...fullText.matchAll(/```(?:json|jsonc)\s*\n([\s\S]*?)```/g)];
+        const fullText =
+          lastMsg.parts
+            ?.filter((p: any) => p.type === 'text')
+            .map((p: any) => p.text)
+            .join('') || '';
+        const jsonBlocks = [
+          ...fullText.matchAll(/```(?:json|jsonc)\s*\n([\s\S]*?)```/g),
+        ];
         if (jsonBlocks.length > 0) {
           const formatted = tryParseJsonBlocks(jsonBlocks);
           if (formatted) {
@@ -166,11 +190,18 @@ export function useChatSession() {
               const ctx = sendContext[0];
               const scopedResult = scopedMerge(original, formatted, sendScope);
               if (!scopedResult && sendScope !== 'global') {
-                console.warn(`[chat] scopedMerge failed for scope="${sendScope}", falling back to text merge`);
+                console.warn(
+                  `[chat] scopedMerge failed for scope="${sendScope}", falling back to text merge`
+                );
               }
-              const { original: orig, modified } = scopedResult
-                ?? mergeAiOutput(original, formatted, ctx);
-              setPendingDiff(tab, orig, modified, applyId(raw.replace(/\n$/, '')));
+              const { original: orig, modified } =
+                scopedResult ?? mergeAiOutput(original, formatted, ctx);
+              setPendingDiff(
+                tab,
+                orig,
+                modified,
+                applyId(raw.replace(/\n$/, ''))
+              );
             } else {
               const name = `ai-generated-${Date.now()}`;
               createDocument(name, formatted);
@@ -192,7 +223,8 @@ export function useChatSession() {
       if (id in messageContextMapRef.current) break; // already mapped
       if (pendingContextsRef.current.length > 0) {
         messageContextMapRef.current[id] = pendingContextsRef.current[0];
-        messageScopeMapRef.current[id] = pendingScopesRef.current[0] || 'global';
+        messageScopeMapRef.current[id] =
+          pendingScopesRef.current[0] || 'global';
         bumpMapVersion();
       }
       break; // only process the latest unmapped user message
@@ -212,18 +244,31 @@ export function useChatSession() {
           format: FORMAT,
           context: contextAttachments,
           activeDocument: getActiveDocument(),
-          documentType: (activeTabRef.current && documentTypesRef.current[activeTabRef.current]) || 'application/json+report',
+          documentType:
+            (activeTabRef.current &&
+              documentTypesRef.current[activeTabRef.current]) ||
+            'application/json+report',
           scope,
           model,
         },
       });
     },
-    [chat.sendMessage, contextAttachments, getActiveDocument, clearContext, scope, model]
+    [
+      chat.sendMessage,
+      contextAttachments,
+      getActiveDocument,
+      clearContext,
+      scope,
+      model,
+    ]
   );
 
-  const getMessageScope = useCallback((userMsgId: string): AiScope | undefined => {
-    return messageScopeMapRef.current[userMsgId];
-  }, []);
+  const getMessageScope = useCallback(
+    (userMsgId: string): AiScope | undefined => {
+      return messageScopeMapRef.current[userMsgId];
+    },
+    []
+  );
 
   return {
     messages: chat.messages,

--- a/packages/jto/src/client/lib/apply-merge.ts
+++ b/packages/jto/src/client/lib/apply-merge.ts
@@ -23,7 +23,7 @@ export function mergeTemplatesDelta(existing: any[], delta: any[]): any[] {
 export function applyId(str: string): string {
   let h = 0;
   for (let i = 0; i < str.length; i++) {
-    h = Math.imul(31, h) + str.charCodeAt(i) | 0;
+    h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
   }
   return (h >>> 0).toString(36);
 }
@@ -80,7 +80,12 @@ export function mergeAiOutput(
 
     // indexOf failed — try line-range splice
     if (ctx.startLine && ctx.endLine) {
-      const result = lineRangeSplice(currentDoc, aiOutput, ctx.startLine, ctx.endLine);
+      const result = lineRangeSplice(
+        currentDoc,
+        aiOutput,
+        ctx.startLine,
+        ctx.endLine
+      );
       if (result) return result;
     }
 
@@ -114,7 +119,8 @@ function tryNamedObjectSplice(
   } catch {
     return null;
   }
-  if (!aiParsed || typeof aiParsed !== 'object' || Array.isArray(aiParsed)) return null;
+  if (!aiParsed || typeof aiParsed !== 'object' || Array.isArray(aiParsed))
+    return null;
   const name = aiParsed.name;
   if (typeof name !== 'string' || !name) return null;
 
@@ -138,11 +144,20 @@ function tryNamedObjectSplice(
 
 /** Recursively walk a parsed JSON tree and replace the first object whose
  *  "name" matches `target`. Returns true if a replacement was made. */
-function replaceNamedObject(node: unknown, target: string, replacement: Record<string, unknown>): boolean {
+function replaceNamedObject(
+  node: unknown,
+  target: string,
+  replacement: Record<string, unknown>
+): boolean {
   if (Array.isArray(node)) {
     for (let i = 0; i < node.length; i++) {
       const item = node[i];
-      if (item && typeof item === 'object' && !Array.isArray(item) && (item as Record<string, unknown>).name === target) {
+      if (
+        item &&
+        typeof item === 'object' &&
+        !Array.isArray(item) &&
+        (item as Record<string, unknown>).name === target
+      ) {
         node[i] = replacement;
         return true;
       }
@@ -294,7 +309,13 @@ export function findKeyValueSpans(text: string, keyPattern: string): Span[] {
     let prev = keyIdx - 1;
     while (prev >= 0 && (text[prev] === ' ' || text[prev] === '\t')) prev--;
     const precChar = prev < 0 ? '' : text[prev];
-    if (precChar !== '' && precChar !== '{' && precChar !== ',' && precChar !== '\n' && precChar !== '\r') {
+    if (
+      precChar !== '' &&
+      precChar !== '{' &&
+      precChar !== ',' &&
+      precChar !== '\n' &&
+      precChar !== '\r'
+    ) {
       searchFrom = keyIdx + 1;
       continue;
     }
@@ -384,11 +405,13 @@ export function lineRangeSplice(
   endLine: number
 ): { original: string; modified: string } | null {
   const lines = doc.split('\n');
-  if (startLine < 1 || endLine < startLine || startLine > lines.length) return null;
+  if (startLine < 1 || endLine < startLine || startLine > lines.length)
+    return null;
 
   const before = lines.slice(0, startLine - 1).join('\n');
   const after = lines.slice(endLine).join('\n');
-  const modified = before + (before ? '\n' : '') + replacement + (after ? '\n' : '') + after;
+  const modified =
+    before + (before ? '\n' : '') + replacement + (after ? '\n' : '') + after;
   return { original: doc, modified };
 }
 
@@ -424,7 +447,11 @@ function charOffsetForLine(text: string, line: number): number {
 }
 
 /** Find all occurrences and return the one closest to `targetOffset`. */
-function pickClosest(text: string, needle: string, targetOffset: number): number {
+function pickClosest(
+  text: string,
+  needle: string,
+  targetOffset: number
+): number {
   let best = -1;
   let bestDist = Infinity;
   let idx = text.indexOf(needle);

--- a/packages/jto/src/client/lib/monaco-selection-utils.ts
+++ b/packages/jto/src/client/lib/monaco-selection-utils.ts
@@ -62,10 +62,10 @@ export function getSelectionContext(
   // Try to determine the JSON path
   const jsonPath = isValidJson
     ? getJsonPathAtPosition(
-      fullDocumentText,
-      selection.startLineNumber,
-      selection.startColumn
-    )
+        fullDocumentText,
+        selection.startLineNumber,
+        selection.startColumn
+      )
     : undefined;
 
   // Extract property key if we're selecting a property value

--- a/packages/jto/src/client/lib/theme-json-schema.ts
+++ b/packages/jto/src/client/lib/theme-json-schema.ts
@@ -13,7 +13,8 @@ export async function fetchThemeJsonSchema(): Promise<any> {
 
   const res = await fetch('/api/discovery/schemas/theme');
   const json = await res.json();
-  if (!json.success) throw new Error(json.error ?? 'Failed to fetch theme schema');
+  if (!json.success)
+    throw new Error(json.error ?? 'Failed to fetch theme schema');
 
   _cachedSchema = json.data;
   return _cachedSchema;

--- a/packages/jto/src/client/lib/validation.ts
+++ b/packages/jto/src/client/lib/validation.ts
@@ -35,9 +35,11 @@ export function getDocumentFormSchema(
   }
 
   if (mode === 'create') {
-    properties['template'] = Type.Optional(Type.String({
-      description: 'Template selection',
-    }));
+    properties['template'] = Type.Optional(
+      Type.String({
+        description: 'Template selection',
+      })
+    );
   }
 
   // Create the base schema
@@ -71,7 +73,7 @@ export function getDocumentFormSchema(
         if (!trimmed) {
           errors.push({
             path: 'name',
-            message: 'Name can\'t be empty',
+            message: "Name can't be empty",
           });
         } else {
           // Update the data with trimmed value

--- a/packages/jto/src/client/public/templates/themes/corporate.pptx.theme.json
+++ b/packages/jto/src/client/public/templates/themes/corporate.pptx.theme.json
@@ -21,8 +21,18 @@
     "fontColor": "#1A202C"
   },
   "styles": {
-    "title": { "fontSize": 44, "bold": true, "fontColor": "text", "align": "center" },
-    "subtitle": { "fontSize": 20, "italic": true, "fontColor": "text2", "align": "center" },
+    "title": {
+      "fontSize": 44,
+      "bold": true,
+      "fontColor": "text",
+      "align": "center"
+    },
+    "subtitle": {
+      "fontSize": 20,
+      "italic": true,
+      "fontColor": "text2",
+      "align": "center"
+    },
     "heading1": { "fontSize": 28, "bold": true, "fontColor": "primary" },
     "heading2": { "fontSize": 22, "bold": true, "fontColor": "primary" },
     "heading3": { "fontSize": 18, "bold": true, "fontColor": "text" },

--- a/packages/jto/src/client/public/templates/themes/minimal.pptx.theme.json
+++ b/packages/jto/src/client/public/templates/themes/minimal.pptx.theme.json
@@ -21,8 +21,18 @@
     "fontColor": "#1F2937"
   },
   "styles": {
-    "title": { "fontSize": 36, "bold": true, "fontColor": "text", "align": "center" },
-    "subtitle": { "fontSize": 18, "italic": true, "fontColor": "text2", "align": "center" },
+    "title": {
+      "fontSize": 36,
+      "bold": true,
+      "fontColor": "text",
+      "align": "center"
+    },
+    "subtitle": {
+      "fontSize": 18,
+      "italic": true,
+      "fontColor": "text2",
+      "align": "center"
+    },
     "heading1": { "fontSize": 28, "bold": true, "fontColor": "primary" },
     "heading2": { "fontSize": 22, "bold": true, "fontColor": "primary" },
     "heading3": { "fontSize": 18, "bold": true, "fontColor": "text" },

--- a/packages/jto/src/client/public/templates/themes/vibrant.pptx.theme.json
+++ b/packages/jto/src/client/public/templates/themes/vibrant.pptx.theme.json
@@ -21,8 +21,18 @@
     "fontColor": "#F8FAFC"
   },
   "styles": {
-    "title": { "fontSize": 44, "bold": true, "fontColor": "text", "align": "center" },
-    "subtitle": { "fontSize": 18, "italic": true, "fontColor": "text2", "align": "center" },
+    "title": {
+      "fontSize": 44,
+      "bold": true,
+      "fontColor": "text",
+      "align": "center"
+    },
+    "subtitle": {
+      "fontSize": 18,
+      "italic": true,
+      "fontColor": "text2",
+      "align": "center"
+    },
     "heading1": { "fontSize": 32, "bold": true, "fontColor": "text" },
     "heading2": { "fontSize": 24, "bold": true, "fontColor": "primary" },
     "heading3": { "fontSize": 18, "bold": true, "fontColor": "text" },

--- a/packages/jto/src/client/store/chat-session-provider.tsx
+++ b/packages/jto/src/client/store/chat-session-provider.tsx
@@ -17,7 +17,9 @@ export function ChatSessionProvider({ children }: { children: ReactNode }) {
 export function useChatSessionContext(): ChatSessionValue {
   const ctx = useContext(ChatSessionContext);
   if (!ctx) {
-    throw new Error('useChatSessionContext must be used within ChatSessionProvider');
+    throw new Error(
+      'useChatSessionContext must be used within ChatSessionProvider'
+    );
   }
   return ctx;
 }

--- a/packages/jto/src/client/store/chat-store-provider.tsx
+++ b/packages/jto/src/client/store/chat-store-provider.tsx
@@ -1,10 +1,6 @@
 import { type ReactNode, createContext, useRef, useContext } from 'react';
 import { useStore } from 'zustand';
-import {
-  type ChatStore,
-  createChatStore,
-  initChatStore,
-} from './chat-store';
+import { type ChatStore, createChatStore, initChatStore } from './chat-store';
 
 export type ChatStoreApi = ReturnType<typeof createChatStore>;
 
@@ -29,9 +25,7 @@ export const ChatStoreProvider = ({ children }: ChatStoreProviderProps) => {
   );
 };
 
-export const useChatStore = <T,>(
-  selector: (store: ChatStore) => T
-): T => {
+export const useChatStore = <T,>(selector: (store: ChatStore) => T): T => {
   const chatStoreContext = useContext(ChatStoreContext);
 
   if (!chatStoreContext) {

--- a/packages/jto/src/client/store/chat-store.ts
+++ b/packages/jto/src/client/store/chat-store.ts
@@ -60,9 +60,7 @@ export const initChatStore = (): ChatState => ({
   activeThreadId: {},
 });
 
-export const createChatStore = (
-  initState: ChatState = initChatStore()
-) => {
+export const createChatStore = (initState: ChatState = initChatStore()) => {
   return createStore<ChatStore>()(
     devtools(
       persist(

--- a/packages/jto/src/client/store/documents-store.ts
+++ b/packages/jto/src/client/store/documents-store.ts
@@ -13,7 +13,9 @@ export type DocumentsState = {
   activeTab: string;
   buildErrors: { [key: string]: string };
   documentTypes: { [key: string]: DocumentType };
-  pendingDiffs: { [key: string]: { original: string; modified: string; applyId?: string } };
+  pendingDiffs: {
+    [key: string]: { original: string; modified: string; applyId?: string };
+  };
   acceptedApplyIds: string[];
 };
 
@@ -26,7 +28,12 @@ export type DocumentsActions = {
   closeDocument: (name: string) => void;
   setActiveTab: (name: string) => void;
   setBuildError: (name: string, buildError?: string) => void;
-  setPendingDiff: (name: string, original: string, modified: string, applyId?: string) => void;
+  setPendingDiff: (
+    name: string,
+    original: string,
+    modified: string,
+    applyId?: string
+  ) => void;
   clearPendingDiff: (name: string, accepted?: boolean) => void;
 };
 
@@ -129,7 +136,9 @@ export const createDocumentsStore = (
               );
               if (docIndex === -1) return state;
               const documents = state.documents.map((doc, i) =>
-                i === docIndex ? { ...doc, name: newName, ctime: new Date() } : doc
+                i === docIndex
+                  ? { ...doc, name: newName, ctime: new Date() }
+                  : doc
               );
               const docType = state.documentTypes[oldName];
               if (docType) {
@@ -151,9 +160,10 @@ export const createDocumentsStore = (
               );
               let openTabs = state.openTabs;
               if (!openTabs.includes(name)) {
-                openTabs = openTabs.length >= MAX_OPEN_TABS
-                  ? [...openTabs.slice(1), name]
-                  : [...openTabs, name];
+                openTabs =
+                  openTabs.length >= MAX_OPEN_TABS
+                    ? [...openTabs.slice(1), name]
+                    : [...openTabs, name];
               }
               return { documents, openTabs, activeTab: name };
             }),
@@ -220,7 +230,9 @@ export const createDocumentsStore = (
               for (const doc of state.documents) {
                 for (const key of ['mtime', 'ctime', 'atime'] as const) {
                   if (doc[key] && typeof doc[key] === 'string') {
-                    (doc as Record<string, unknown>)[key] = new Date(doc[key] as unknown as string);
+                    (doc as Record<string, unknown>)[key] = new Date(
+                      doc[key] as unknown as string
+                    );
                   }
                 }
               }

--- a/packages/jto/src/client/utils/retry.ts
+++ b/packages/jto/src/client/utils/retry.ts
@@ -166,7 +166,7 @@ export const RetryStrategies = {
   // Combine multiple strategies
   combine:
     (...strategies: ((error: Error) => boolean)[]) =>
-      (error: Error) => {
-        return strategies.some((strategy) => strategy(error));
-      },
+    (error: Error) => {
+      return strategies.some((strategy) => strategy(error));
+    },
 };

--- a/packages/jto/src/server/routes/health.ts
+++ b/packages/jto/src/server/routes/health.ts
@@ -14,7 +14,15 @@ healthRouter.get('/', (c) => {
     const cacheService = getContainer().get('cacheService');
     cacheStats = cacheService.getStats();
   } catch {
-    cacheStats = { enabled: false, hits: 0, misses: 0, hitRate: 0, evictions: 0, size: 0, itemCount: 0 };
+    cacheStats = {
+      enabled: false,
+      hits: 0,
+      misses: 0,
+      hitRate: 0,
+      evictions: 0,
+      size: 0,
+      itemCount: 0,
+    };
   }
 
   return c.json({

--- a/packages/jto/src/server/services/ai-schema.ts
+++ b/packages/jto/src/server/services/ai-schema.ts
@@ -81,10 +81,14 @@ export async function getThemeSchema(format: string): Promise<any> {
   return schema;
 }
 
-export async function getSchemaString(format: string, docType: 'document' | 'theme'): Promise<string> {
-  const schema = docType === 'theme'
-    ? await getThemeSchema(format)
-    : await getDocumentSchema(format);
+export async function getSchemaString(
+  format: string,
+  docType: 'document' | 'theme'
+): Promise<string> {
+  const schema =
+    docType === 'theme'
+      ? await getThemeSchema(format)
+      : await getDocumentSchema(format);
   return JSON.stringify(schema, null, 2);
 }
 

--- a/packages/jto/src/server/services/prompt-loader.ts
+++ b/packages/jto/src/server/services/prompt-loader.ts
@@ -11,8 +11,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // In prod (tsup): __dirname = dist → look for prompts in src/server/prompts (fallback)
 function resolvePromptsDir(): string {
   const candidates = [
-    join(__dirname, '..', 'prompts'),           // dev: src/server/prompts
-    join(__dirname, 'prompts'),                  // bundled: dist/prompts
+    join(__dirname, '..', 'prompts'), // dev: src/server/prompts
+    join(__dirname, 'prompts'), // bundled: dist/prompts
     join(__dirname, '..', 'src', 'server', 'prompts'), // prod from dist/
   ];
   for (const dir of candidates) {

--- a/packages/jto/src/server/utils/logger.ts
+++ b/packages/jto/src/server/utils/logger.ts
@@ -18,7 +18,11 @@ class Logger {
     return levels.indexOf(level) <= levels.indexOf(this.level);
   }
 
-  private formatMessage(level: LogLevel, message: string, context?: LogContext): string {
+  private formatMessage(
+    level: LogLevel,
+    message: string,
+    context?: LogContext
+  ): string {
     const timestamp = new Date().toISOString();
     const contextStr = context
       ? ` ${JSON.stringify(context, this.errorReplacer)}`
@@ -41,17 +45,33 @@ class Logger {
     if (!this.shouldLog(level)) return;
     const formatted = this.formatMessage(level, message, context);
     switch (level) {
-    case 'error': console.error(formatted); break;
-    case 'warn': console.warn(formatted); break;
-    case 'info': console.info(formatted); break;
-    case 'debug': console.debug(formatted); break;
+      case 'error':
+        console.error(formatted);
+        break;
+      case 'warn':
+        console.warn(formatted);
+        break;
+      case 'info':
+        console.info(formatted);
+        break;
+      case 'debug':
+        console.debug(formatted);
+        break;
     }
   }
 
-  error(message: string, context?: LogContext): void { this.log('error', message, context); }
-  warn(message: string, context?: LogContext): void { this.log('warn', message, context); }
-  info(message: string, context?: LogContext): void { this.log('info', message, context); }
-  debug(message: string, context?: LogContext): void { this.log('debug', message, context); }
+  error(message: string, context?: LogContext): void {
+    this.log('error', message, context);
+  }
+  warn(message: string, context?: LogContext): void {
+    this.log('warn', message, context);
+  }
+  info(message: string, context?: LogContext): void {
+    this.log('info', message, context);
+  }
+  debug(message: string, context?: LogContext): void {
+    this.log('debug', message, context);
+  }
 }
 
 export const logger = new Logger(config.LOG_LEVEL);

--- a/packages/jto/tsconfig.json
+++ b/packages/jto/tsconfig.json
@@ -8,8 +8,8 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
     "paths": {
-      "@/*": ["./src/client/*"],
-    },
+      "@/*": ["./src/client/*"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist"],
@@ -19,6 +19,6 @@
     { "path": "../shared-pptx" },
     { "path": "../core-docx" },
     { "path": "../core-pptx" },
-    { "path": "../jto-cli" },
-  ],
+    { "path": "../jto-cli" }
+  ]
 }

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -3,19 +3,19 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "lib": ["ES2022"],
+    "lib": ["ES2022"]
   },
   "include": ["src/**/*.ts"],
   "exclude": [
     "node_modules",
     "dist",
     "src/**/*.test.ts",
-    "src/**/__tests__/**",
+    "src/**/__tests__/**"
   ],
   "references": [
     { "path": "../shared" },
     { "path": "../shared-docx" },
     { "path": "../shared-pptx" },
-    { "path": "../jto-ops" },
-  ],
+    { "path": "../jto-ops" }
+  ]
 }

--- a/packages/shared-docx/tsconfig.json
+++ b/packages/shared-docx/tsconfig.json
@@ -6,7 +6,5 @@
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "src/**/*.test.ts"],
-  "references": [
-    { "path": "../shared" }
-  ]
+  "references": [{ "path": "../shared" }]
 }

--- a/packages/shared-docx/tsup.config.ts
+++ b/packages/shared-docx/tsup.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/schemas/*.ts', 'src/validation/unified/index.ts'],
+  entry: [
+    'src/index.ts',
+    'src/schemas/*.ts',
+    'src/validation/unified/index.ts',
+  ],
   format: ['esm'],
   dts: {
     compilerOptions: {
@@ -12,5 +16,11 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   target: 'es2022',
-  external: ['@sinclair/typebox', 'ajv', 'ajv-formats', 'docx', '@json-to-office/shared'],
+  external: [
+    '@sinclair/typebox',
+    'ajv',
+    'ajv-formats',
+    'docx',
+    '@json-to-office/shared',
+  ],
 });

--- a/packages/shared-pptx/src/schemas/component-defaults.ts
+++ b/packages/shared-pptx/src/schemas/component-defaults.ts
@@ -51,6 +51,4 @@ export type HighchartsComponentDefaults = Static<
 export type ChartComponentDefaults = Static<
   typeof ChartComponentDefaultsSchema
 >;
-export type PptxComponentDefaults = Static<
-  typeof PptxComponentDefaultsSchema
->;
+export type PptxComponentDefaults = Static<typeof PptxComponentDefaultsSchema>;

--- a/packages/shared-pptx/src/schemas/components/template.ts
+++ b/packages/shared-pptx/src/schemas/components/template.ts
@@ -23,81 +23,141 @@ const Coord = Type.Union([
 
 // Helper: wrap a props schema into { name, props } component format
 function contentComponent(name: string, propsSchema: TSchema) {
-  return Type.Object({
-    name: Type.Literal(name),
-    id: Type.Optional(Type.String()),
-    enabled: Type.Optional(Type.Boolean({
-      default: true,
-      description: 'When false, this component is filtered out and not rendered. Defaults to true.',
-    })),
-    props: propsSchema,
-  }, { additionalProperties: false });
+  return Type.Object(
+    {
+      name: Type.Literal(name),
+      id: Type.Optional(Type.String()),
+      enabled: Type.Optional(
+        Type.Boolean({
+          default: true,
+          description:
+            'When false, this component is filtered out and not rendered. Defaults to true.',
+        })
+      ),
+      props: propsSchema,
+    },
+    { additionalProperties: false }
+  );
 }
 
 // Content component union — same { name, props } format as slide children
-const TemplateObjectComponentSchema = Type.Union([
-  contentComponent('text', TextPropsSchema),
-  contentComponent('image', PptxImagePropsSchema),
-  contentComponent('shape', ShapePropsSchema),
-  contentComponent('table', PptxTablePropsSchema),
-  contentComponent('chart', PptxChartPropsSchema),
-  contentComponent('highcharts', PptxHighchartsPropsSchema),
-], {
-  discriminator: { propertyName: 'name' },
-  description: 'Fixed component on a template slide (same format as slide children)',
-});
+const TemplateObjectComponentSchema = Type.Union(
+  [
+    contentComponent('text', TextPropsSchema),
+    contentComponent('image', PptxImagePropsSchema),
+    contentComponent('shape', ShapePropsSchema),
+    contentComponent('table', PptxTablePropsSchema),
+    contentComponent('chart', PptxChartPropsSchema),
+    contentComponent('highcharts', PptxHighchartsPropsSchema),
+  ],
+  {
+    discriminator: { propertyName: 'name' },
+    description:
+      'Fixed component on a template slide (same format as slide children)',
+  }
+);
 
 // Defaults schema — partial component stub (carries styling props, not content)
 // Discriminated union so Monaco can autocomplete prop names per component type
 function defaultsComponent(name: string, propsSchema: TSchema) {
-  return Type.Object({
-    name: Type.Literal(name),
-    props: Type.Partial(propsSchema, { description: 'Default props inherited by the component placed in this placeholder' }),
-  }, { additionalProperties: false });
+  return Type.Object(
+    {
+      name: Type.Literal(name),
+      props: Type.Partial(propsSchema, {
+        description:
+          'Default props inherited by the component placed in this placeholder',
+      }),
+    },
+    { additionalProperties: false }
+  );
 }
 
-const PlaceholderDefaultsSchema = Type.Union([
-  defaultsComponent('text', TextPropsSchema),
-  defaultsComponent('image', PptxImagePropsSchema),
-  defaultsComponent('shape', ShapePropsSchema),
-  defaultsComponent('table', PptxTablePropsSchema),
-  defaultsComponent('chart', PptxChartPropsSchema),
-  defaultsComponent('highcharts', PptxHighchartsPropsSchema),
-], {
-  discriminator: { propertyName: 'name' },
-  description: 'Partial component stub — styling defaults only',
-});
+const PlaceholderDefaultsSchema = Type.Union(
+  [
+    defaultsComponent('text', TextPropsSchema),
+    defaultsComponent('image', PptxImagePropsSchema),
+    defaultsComponent('shape', ShapePropsSchema),
+    defaultsComponent('table', PptxTablePropsSchema),
+    defaultsComponent('chart', PptxChartPropsSchema),
+    defaultsComponent('highcharts', PptxHighchartsPropsSchema),
+  ],
+  {
+    discriminator: { propertyName: 'name' },
+    description: 'Partial component stub — styling defaults only',
+  }
+);
 
 // Placeholder definition
-export const PlaceholderDefinitionSchema = Type.Object({
-  name: Type.String({ description: 'Unique placeholder name' }),
-  x: Type.Optional(Coord),
-  y: Type.Optional(Coord),
-  w: Type.Optional(Coord),
-  h: Type.Optional(Coord),
-  grid: Type.Optional(GridPositionSchema),
-  defaults: Type.Optional(PlaceholderDefaultsSchema),
-}, { additionalProperties: false, description: 'Placeholder on a template slide — defaults is a component stub whose props are inherited by the actual component' });
-
-// Template slide definition
-export const TemplateSlideDefinitionSchema = Type.Object({
-  name: Type.String({ description: 'Unique template slide name' }),
-  background: Type.Optional(SlideBackgroundSchema),
-  margin: Type.Optional(Type.Union([
-    Type.Number({ description: 'Margin in inches (all sides)' }),
-    Type.Array(Type.Number(), { minItems: 4, maxItems: 4, description: 'Margin [top, right, bottom, left] in inches' }),
-  ])),
-  slideNumber: Type.Optional(Type.Object({
-    x: Coord, y: Coord,
+export const PlaceholderDefinitionSchema = Type.Object(
+  {
+    name: Type.String({ description: 'Unique placeholder name' }),
+    x: Type.Optional(Coord),
+    y: Type.Optional(Coord),
     w: Type.Optional(Coord),
     h: Type.Optional(Coord),
-    color: Type.Optional(ColorValueSchema),
-    fontSize: Type.Optional(Type.Number({ description: 'Slide number font size in points' })),
-  }, { additionalProperties: false, description: 'Slide number position and styling' })),
-  objects: Type.Optional(Type.Array(TemplateObjectComponentSchema, { description: 'Fixed components (logos, footers, decorations) — same { name, props } format as slide children' })),
-  placeholders: Type.Optional(Type.Array(PlaceholderDefinitionSchema, { description: 'Placeholder regions for slide content' })),
-  grid: Type.Optional(GridConfigSchema),
-}, { additionalProperties: false, description: 'Template slide definition (reusable slide template)' });
+    grid: Type.Optional(GridPositionSchema),
+    defaults: Type.Optional(PlaceholderDefaultsSchema),
+  },
+  {
+    additionalProperties: false,
+    description:
+      'Placeholder on a template slide — defaults is a component stub whose props are inherited by the actual component',
+  }
+);
+
+// Template slide definition
+export const TemplateSlideDefinitionSchema = Type.Object(
+  {
+    name: Type.String({ description: 'Unique template slide name' }),
+    background: Type.Optional(SlideBackgroundSchema),
+    margin: Type.Optional(
+      Type.Union([
+        Type.Number({ description: 'Margin in inches (all sides)' }),
+        Type.Array(Type.Number(), {
+          minItems: 4,
+          maxItems: 4,
+          description: 'Margin [top, right, bottom, left] in inches',
+        }),
+      ])
+    ),
+    slideNumber: Type.Optional(
+      Type.Object(
+        {
+          x: Coord,
+          y: Coord,
+          w: Type.Optional(Coord),
+          h: Type.Optional(Coord),
+          color: Type.Optional(ColorValueSchema),
+          fontSize: Type.Optional(
+            Type.Number({ description: 'Slide number font size in points' })
+          ),
+        },
+        {
+          additionalProperties: false,
+          description: 'Slide number position and styling',
+        }
+      )
+    ),
+    objects: Type.Optional(
+      Type.Array(TemplateObjectComponentSchema, {
+        description:
+          'Fixed components (logos, footers, decorations) — same { name, props } format as slide children',
+      })
+    ),
+    placeholders: Type.Optional(
+      Type.Array(PlaceholderDefinitionSchema, {
+        description: 'Placeholder regions for slide content',
+      })
+    ),
+    grid: Type.Optional(GridConfigSchema),
+  },
+  {
+    additionalProperties: false,
+    description: 'Template slide definition (reusable slide template)',
+  }
+);
 
 export type PlaceholderDefinition = Static<typeof PlaceholderDefinitionSchema>;
-export type TemplateSlideDefinition = Static<typeof TemplateSlideDefinitionSchema>;
+export type TemplateSlideDefinition = Static<
+  typeof TemplateSlideDefinitionSchema
+>;

--- a/packages/shared-pptx/tsconfig.json
+++ b/packages/shared-pptx/tsconfig.json
@@ -6,7 +6,5 @@
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "src/**/*.test.ts"],
-  "references": [
-    { "path": "../shared" }
-  ]
+  "references": [{ "path": "../shared" }]
 }

--- a/packages/shared-pptx/tsup.config.ts
+++ b/packages/shared-pptx/tsup.config.ts
@@ -12,5 +12,10 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   target: 'es2022',
-  external: ['@sinclair/typebox', 'ajv', 'ajv-formats', '@json-to-office/shared'],
+  external: [
+    '@sinclair/typebox',
+    'ajv',
+    'ajv-formats',
+    '@json-to-office/shared',
+  ],
 });

--- a/packages/shared/src/validation/unified/error-formatter-config.ts
+++ b/packages/shared/src/validation/unified/error-formatter-config.ts
@@ -10,7 +10,11 @@ export interface ErrorFormatterConfig {
 
 function isCI(): boolean {
   if (typeof process === 'undefined' || !process.env) return false;
-  return !!(process.env.CI || process.env.GITHUB_ACTIONS || process.env.GITLAB_CI);
+  return !!(
+    process.env.CI ||
+    process.env.GITHUB_ACTIONS ||
+    process.env.GITLAB_CI
+  );
 }
 
 function hasColorSupport(): boolean {

--- a/packages/shared/src/validation/unified/error-transformer.ts
+++ b/packages/shared/src/validation/unified/error-transformer.ts
@@ -63,7 +63,7 @@ function generateUnionErrorMessage(error: ValueError): string {
         return `Invalid component configuration for '${(value as any).name}'. Check that all required fields are present.`;
       }
       if ('children' in value && Array.isArray((value as any).children)) {
-        return 'Document is missing required \'name\' field.';
+        return "Document is missing required 'name' field.";
       }
     }
     return 'Invalid document structure. Check required fields.';

--- a/packages/shared/src/validation/unified/index.ts
+++ b/packages/shared/src/validation/unified/index.ts
@@ -7,7 +7,11 @@ export {
   calculatePosition,
 } from './error-transformer';
 
-export type { ValidationError, ValidationResult, TransformedError } from './types';
+export type {
+  ValidationError,
+  ValidationResult,
+  TransformedError,
+} from './types';
 
 export {
   type ErrorFormatterConfig,

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -13,13 +13,13 @@
       "@json-to-office/shared-docx": ["packages/shared-docx/src/index.ts"],
       "@json-to-office/shared-docx/*": ["packages/shared-docx/src/*"],
       "@json-to-office/shared-pptx": ["packages/shared-pptx/src/index.ts"],
-      "@json-to-office/shared-pptx/*": ["packages/shared-pptx/src/*"],
+      "@json-to-office/shared-pptx/*": ["packages/shared-pptx/src/*"]
     },
-    "sourceMap": false,
+    "sourceMap": false
   },
   "include": [
     "check-renderer-import-boundaries.ts",
     "generate-renderer-docs.ts",
-    "renderer-feature-notes.ts",
-  ],
+    "renderer-feature-notes.ts"
+  ]
 }


### PR DESCRIPTION
Mechanical. No behaviour change anywhere. Three commits, each green on its own.

## Why now

`pnpm format` is `prettier --write`, never `--check`, and CI never ran it — so drift
accumulated silently across 42 files. This zeroes it and closes the hole.

## The three commits

1. **`chore:` prettier config** — two deliberate carve-outs, both load-bearing:
   - `trailingComma: none` for `tsconfig*.json`. Prettier 3 parses those with the
     `jsonc` parser and was appending trailing commas, leaving them non-strict-JSON.
     `tsc` tolerates it; anything doing `JSON.parse` does not.
   - `packages/jto/src/server/prompts/` added to `.prettierignore`. Prettier explodes
     the compact single-line JSON examples in those prompts across many lines: +4% bytes
     on every system prompt we send, and it changes the authoring style the model is
     shown by example. Those files are product behaviour, not code style.
2. **`style:` the sweep** — 42 files. Verified mechanically: every file is byte-identical
   to `prettier(parent)`. Listed in `.git-blame-ignore-revs`.
3. **`ci:` the gate** — `format:check` runs `prettier --check` next to `pnpm lint`, plus
   `.git-blame-ignore-revs` so `git blame` skips commit 2 (GitHub honours it automatically;
   locally, `git config blame.ignoreRevsFile .git-blame-ignore-revs`).

## No conflict with #287

Zero overlap between these 42 files and the 39 in #287 — checked before starting. Either
order merges clean.

## Verification

- `pnpm format:check`, `pnpm lint`, `pnpm typecheck` (18/18) pass.
- `core-pptx` 699/699. Note: under `turbo test` three renderer tests time out at 5s from
  parallel load — pre-existing flake, unrelated; they pass run alone and the whole package
  passes serially.