### PR TITLE
fix: bundled template fonts in safe mode, plus the unpushed #292 validation parity

### DIFF
--- a/.changeset/docx-validation-one-source-of-truth.md
+++ b/.changeset/docx-validation-one-source-of-truth.md
@@ -1,0 +1,27 @@
+---
+'@json-to-office/shared-docx': minor
+'@json-to-office/core-docx': minor
+'@json-to-office/jto': patch
+---
+
+docx validation gets one source of truth for validity (#292). The deep walk's
+embedded-component positions (section header/footer, table cell content) are
+now declared on `STANDARD_COMPONENTS_REGISTRY` entries and the walk is driven
+from those declarations, with a test pinning them to the `createPropsSchema`
+factories that wire the same positions into the live document schema.
+
+The flip-to-valid rescue no longer fails open: when the whole-document check
+rejects and the walk finds nothing, the document is accepted only for the
+three audited false-reject classes (`allowUnknownFields`, documents that use a
+registered plugin component, and `allowedChildren` containment — verified
+precisely against a containment-relaxed schema); anything else now fails
+closed. Unknown or wrong-typed keys next to `name`/`props`/`children` (a
+`bogus: 1`, an `enabled: "yes"`) — previously accepted silently, even inside
+section headers — are rejected with a path-addressed error, and a new guard test
+sweeps every closed object position of every component's props asserting
+validate, validateStrict and generation agree on rejecting unknown keys.
+
+The jto server now reads the document title for filenames from
+`props.metadata.title` (docx) / `props.title` (pptx) instead of a root-level
+`metadata` that was never part of the schema — real playground documents had
+always fallen back to the generic filename.

--- a/.changeset/docx-validation-one-source-of-truth.md
+++ b/.changeset/docx-validation-one-source-of-truth.md
@@ -24,4 +24,10 @@ validate, validateStrict and generation agree on rejecting unknown keys.
 The jto server now reads the document title for filenames from
 `props.metadata.title` (docx) / `props.title` (pptx) instead of a root-level
 `metadata` that was never part of the schema — real playground documents had
-always fallen back to the generic filename.
+always fallen back to the generic filename. Because that is the first time
+user-authored text reaches the filename, the title is sanitized where the name
+is built: path separators and control characters are replaced and the length is
+capped, on both the generated and the cache-hit branch. The filename travels
+into the generate response and into the `Content-Disposition` of
+`/preview/*-from-json`, which interpolates it verbatim, so an unescaped CR/LF
+in a title would otherwise have split that header.

--- a/.changeset/playground-template-fonts-safe-mode.md
+++ b/.changeset/playground-template-fonts-safe-mode.md
@@ -1,0 +1,20 @@
+---
+'@json-to-office/jto': patch
+---
+
+Hosted playground generation no longer 400s on bundled templates that ship
+their fonts as `fontRegistry` `kind:'file'` sources (vermilion-annual-report:
+"Unsafe outbound source ... local file sources are disabled for HTTP
+requests"). The template-media inliner — which already converted a discovered
+document's relative images to data URLs before safe-mode source validation —
+now also rewrites contained `{kind:'file', path}` font sources to
+`{kind:'data'}`, so the fonts pass the policy and travel to the remote
+rasterizer. Resolved font bytes are identical to the local file path, so the
+LibreOffice preview stages the same faces. A regression suite runs every
+bundled template through inlining + safe-mode validation against the
+render.yaml host allowlist.
+
+The playground also records template provenance (`templateSource`) when a
+discovered document is added, and sends it as `options.sourceName` instead of
+the display name — renaming a document created from a bundled template no
+longer breaks its media/font resolution.

--- a/.changeset/pptx-validation-292-parity.md
+++ b/.changeset/pptx-validation-292-parity.md
@@ -1,0 +1,20 @@
+---
+'@json-to-office/shared-pptx': minor
+'@json-to-office/core-pptx': minor
+---
+
+pptx validation gets the #292 hardening the docx side shipped. The deep walk
+(the only pptx validator — there is no whole-document stage behind it, so a
+blind spot was accepted AND rendered) now types the component-object sibling
+keys it previously only checked for presence: `enabled: "yes"`, `id: 7` and a
+non-string `$schema` — at the root, on nested components, in placeholder
+values, and a non-string `version` on plugin components — are rejected with
+path-addressed errors instead of silently rendering.
+
+The slide `placeholders` walk and props-strip are driven by the registry's
+`hasPlaceholders` flag instead of a hardcoded `'slide'`, so a future component
+whose published schema accepts placeholders is walked automatically. A new
+guard test mirrors the docx one: every closed object position of every
+component's props is swept with an unknown key, and every embedding position
+with prop, sibling-key and wrong-typed-sibling defects, asserting validate,
+validateStrict and generation agree on rejecting with localized errors.

--- a/packages/core-docx/src/core/__tests__/unknown-key-guard.test.ts
+++ b/packages/core-docx/src/core/__tests__/unknown-key-guard.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Unknown-key guard (#292): every closed object position in every standard
+ * component's props must reject an unknown key through BOTH entry points —
+ * the standalone validators and generation-time validation — with agreeing
+ * verdicts and a localized (non-root) diagnostic.
+ *
+ * This generalizes validate-generate-agreement.test.ts beyond table cell
+ * fonts. The positions are enumerated from the live props schemas (a registry
+ * entry's `createPropsSchema` factory probed with a marker, or its static
+ * schema), so a prop object added to any component is swept automatically —
+ * a deep-walk blind spot fails here instead of shipping as a silent
+ * fail-open acceptance.
+ *
+ * The second suite embeds a defective paragraph at every component-embedding
+ * position (children chains, section header/footer, table cell content): the
+ * historical blind-spot class (2dff712) that motivated the registry-driven
+ * walk.
+ *
+ * Agreement is asserted in the REJECT direction only: baselines are checked
+ * against the validators but never generated, because generating ~300
+ * accepted documents would exercise real renderers (fonts, rasterization)
+ * for no schema signal. The accept direction rests on validate and
+ * generation sharing one function (542f8ad) and is exercised with real
+ * generation by validate-generate-agreement.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { Type, type TSchema } from '@sinclair/typebox';
+import { Value } from '@sinclair/typebox/value';
+import {
+  STANDARD_COMPONENTS_REGISTRY,
+  validate,
+  validateStrict,
+} from '@json-to-office/shared-docx';
+import { generateBufferFromJson } from '../generator';
+import { JsonValidationError } from '../../json/parser';
+
+type Json = Record<string, unknown>;
+
+const MARKER = Type.Object({}, { $id: '__component_marker__' });
+const PLACEHOLDER_COMPONENT: Json = { name: 'paragraph', props: { text: 'x' } };
+const PROBE_KEY = 'zzUnknownProbeKey';
+
+// ---------------------------------------------------------------------------
+// Position enumeration: every additionalProperties:false object in a schema.
+// ---------------------------------------------------------------------------
+
+/** `*` stands for "an element of the array at this position". */
+type PositionPath = readonly string[];
+
+function enumerateClosedObjects(schema: TSchema): PositionPath[] {
+  const found = new Map<string, PositionPath>();
+
+  const visit = (
+    node: any,
+    path: PositionPath,
+    depth: number,
+    seenIds: readonly string[]
+  ): void => {
+    if (!node || typeof node !== 'object' || node === MARKER) return;
+    if (depth > 12) return;
+    // A `$ref` is a recursive self-reference (list items, cell content): the
+    // referenced component's own sweep covers its interior.
+    if (node.$ref) return;
+    if (node.$id) {
+      if (seenIds.includes(node.$id)) return;
+      seenIds = [...seenIds, node.$id];
+    }
+    if (Array.isArray(node.anyOf)) {
+      for (const branch of node.anyOf) visit(branch, path, depth + 1, seenIds);
+      return;
+    }
+    if (node.type === 'object' && node.properties) {
+      if (node.additionalProperties === false) {
+        found.set(path.join('/'), path);
+      }
+      for (const [key, child] of Object.entries(node.properties)) {
+        visit(child, [...path, key], depth + 1, seenIds);
+      }
+      return;
+    }
+    if (node.items) visit(node.items, [...path, '*'], depth + 1, seenIds);
+  };
+
+  visit(schema, [], 0, []);
+  return [...found.values()];
+}
+
+// ---------------------------------------------------------------------------
+// Minimal-instance builder: a valid value for a schema that materializes the
+// given path. Throws with a reason when it cannot — the test surfaces that as
+// a loud failure so the builder is extended instead of silently skipping.
+// ---------------------------------------------------------------------------
+
+const CANDIDATE_STRINGS = [
+  'x',
+  'n1',
+  '#123456',
+  '10%',
+  '10pt',
+  'https://example.com/x',
+] as const;
+
+function sampleForPattern(pattern: string): string {
+  const regex = new RegExp(pattern);
+  const match = CANDIDATE_STRINGS.find((candidate) => regex.test(candidate));
+  if (match !== undefined) return match;
+  throw new Error(`no sample string for pattern ${pattern}`);
+}
+
+/**
+ * `terminalObject` — the value at the END of `includePath` is the probe
+ * target and must come out as a plain object: union branches that would put a
+ * primitive there (a `width: number | {...}` union built as the number) are
+ * skipped in favor of an object branch.
+ */
+function buildValue(
+  schema: any,
+  includePath: PositionPath,
+  terminalObject = false
+): unknown {
+  if (!schema || typeof schema !== 'object') {
+    throw new Error('missing schema');
+  }
+  if (schema === MARKER) return structuredClone(PLACEHOLDER_COMPONENT);
+  if (schema.$ref) {
+    throw new Error('cannot build a recursive $ref value');
+  }
+  const atTerminal = includePath.length === 0 && terminalObject;
+  if ('const' in schema) {
+    if (atTerminal) throw new Error('terminal is a literal, not an object');
+    return schema.const;
+  }
+  if (Array.isArray(schema.enum)) {
+    if (atTerminal) throw new Error('terminal is an enum, not an object');
+    return schema.enum[0];
+  }
+
+  if (Array.isArray(schema.anyOf)) {
+    const reasons: string[] = [];
+    for (const branch of schema.anyOf) {
+      try {
+        const candidate = buildValue(branch, includePath, terminalObject);
+        if (Value.Check(branch, candidate)) return candidate;
+        reasons.push('built candidate failed its own branch check');
+      } catch (error) {
+        reasons.push(error instanceof Error ? error.message : String(error));
+      }
+    }
+    throw new Error(`no union branch buildable (${reasons.join('; ')})`);
+  }
+
+  if (atTerminal && schema.type !== 'object') {
+    throw new Error(`terminal has type ${schema.type}, not object`);
+  }
+  if (
+    includePath.length > 0 &&
+    schema.type !== 'object' &&
+    schema.type !== 'array'
+  ) {
+    // A primitive cannot carry the rest of the path — refuse instead of
+    // returning a value the probe injection would then miss (matters inside
+    // unions like `number | { … }`, where the object branch owns the path).
+    throw new Error(`cannot materialize a path inside type ${schema.type}`);
+  }
+
+  const [head, ...rest] = includePath;
+
+  switch (schema.type) {
+    case 'string': {
+      if (schema.default !== undefined) return schema.default;
+      if (Array.isArray(schema.examples) && schema.examples.length > 0) {
+        return schema.examples[0];
+      }
+      if (schema.pattern) return sampleForPattern(schema.pattern);
+      if (schema.format === 'uri') return 'https://example.com/x';
+      const min = schema.minLength ?? 1;
+      return 'x'.repeat(Math.max(1, min));
+    }
+    case 'number':
+    case 'integer': {
+      let n: number =
+        schema.default ??
+        schema.minimum ??
+        (schema.exclusiveMinimum !== undefined
+          ? schema.exclusiveMinimum + 1
+          : 1);
+      if (schema.multipleOf) {
+        n = Math.ceil(n / schema.multipleOf) * schema.multipleOf;
+      }
+      if (schema.maximum !== undefined) n = Math.min(n, schema.maximum);
+      if (schema.type === 'integer') n = Math.ceil(n);
+      return n;
+    }
+    case 'boolean':
+      return schema.default ?? true;
+    case 'array': {
+      if (head === '*') {
+        // First element materializes the path; pad to minItems (gradient
+        // stops require two, for example).
+        const first = buildValue(schema.items, rest, terminalObject);
+        const padding = Math.max(0, (schema.minItems ?? 1) - 1);
+        return [
+          first,
+          ...Array.from({ length: padding }, () =>
+            buildValue(schema.items, [])
+          ),
+        ];
+      }
+      const count = schema.minItems ?? 0;
+      return Array.from({ length: count }, () => buildValue(schema.items, []));
+    }
+    case 'object': {
+      if (!schema.properties) {
+        if (head !== undefined) {
+          throw new Error('cannot materialize a path inside an open object');
+        }
+        return {};
+      }
+      const value: Json = {};
+      const required: string[] = schema.required ?? [];
+      for (const key of required) {
+        if (key === head) continue;
+        value[key] = buildValue(schema.properties[key], []);
+      }
+      if (head !== undefined) {
+        const child = schema.properties[head];
+        if (!child) throw new Error(`no property "${head}" to materialize`);
+        value[head] = buildValue(child, rest, terminalObject);
+      }
+      return value;
+    }
+    default:
+      // Type.Any / unrecognized: only safe as a leaf.
+      if (head !== undefined) {
+        throw new Error('cannot materialize a path inside an untyped schema');
+      }
+      return 'x';
+  }
+}
+
+/** Deep-set the probe key at `path` ('*' resolves to index 0). */
+function injectProbe(value: unknown, path: PositionPath): unknown {
+  const clone = structuredClone(value) as any;
+  let cursor = clone;
+  for (const segment of path) {
+    cursor = segment === '*' ? cursor[0] : cursor[segment];
+  }
+  cursor[PROBE_KEY] = 1;
+  return clone;
+}
+
+// ---------------------------------------------------------------------------
+// Document wrappers and the three-way verdict.
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap a component instance into a whole document. `chart` and `visual` need
+ * the `office-open` renderer to validate without `unsupported_renderer_feature`
+ * noise; everything else stays on the default `docxjs` — office-open has gaps
+ * of its own (it rejects comment threads, which several props sweeps hit).
+ */
+const OFFICE_OPEN_ONLY = new Set(['chart', 'visual']);
+
+function componentDoc(name: string, props: unknown): Json {
+  const renderer = OFFICE_OPEN_ONLY.has(name)
+    ? { renderer: 'office-open' }
+    : {};
+  if (name === 'docx') {
+    return { name: 'docx', ...renderer, props, children: [] };
+  }
+  const component: Json = { name, props };
+  return {
+    name: 'docx',
+    ...renderer,
+    props: { theme: 'minimal' },
+    children:
+      name === 'section'
+        ? [component]
+        : [{ name: 'section', children: [component] }],
+  };
+}
+
+async function generationVerdict(
+  doc: Json
+): Promise<'accepted' | 'rejected-by-validation' | 'failed-otherwise'> {
+  try {
+    await generateBufferFromJson(doc as never);
+    return 'accepted';
+  } catch (error) {
+    return error instanceof JsonValidationError
+      ? 'rejected-by-validation'
+      : 'failed-otherwise';
+  }
+}
+
+/** Baseline must validate; the injected document must be refused everywhere. */
+async function expectGuarded(
+  label: string,
+  baseline: Json,
+  injected: Json
+): Promise<void> {
+  const baseResult = validate.jsonDocument(JSON.stringify(baseline));
+  expect(
+    { label, valid: baseResult.valid, errors: baseResult.errors ?? [] },
+    `baseline for ${label} must be valid — fix the test builder, not the guard`
+  ).toEqual({ label, valid: true, errors: [] });
+
+  const lenient = validate.jsonDocument(JSON.stringify(injected));
+  const strict = validateStrict.jsonDocument(JSON.stringify(injected));
+  const generation = await generationVerdict(injected);
+
+  expect({
+    label,
+    lenient: lenient.valid,
+    strict: strict.valid,
+    generation,
+  }).toEqual({
+    label,
+    lenient: false,
+    strict: false,
+    generation: 'rejected-by-validation',
+  });
+
+  // The rejection must be localized: a root-only generic error means the
+  // deep walk never saw the position and the fail-closed net caught it —
+  // the verdict survives, but the author is left without a usable path.
+  const localized = (lenient.errors ?? []).some(
+    (e) => e.path && e.path !== 'root' && e.path !== '/'
+  );
+  expect(
+    localized,
+    `expected a non-root error path for ${label}, got: ${JSON.stringify(lenient.errors)}`
+  ).toBe(true);
+}
+
+// ---------------------------------------------------------------------------
+// Sweep 1: every closed object position of every component's props.
+// ---------------------------------------------------------------------------
+
+describe('unknown keys are rejected at every closed props position', () => {
+  it.each(STANDARD_COMPONENTS_REGISTRY.map((c) => [c.name, c] as const))(
+    '%s',
+    async (name, component) => {
+      const liveProps = component.createPropsSchema
+        ? component.createPropsSchema(MARKER)
+        : component.propsSchema;
+
+      const positions = enumerateClosedObjects(liveProps);
+      // highcharts is the one deliberately open props surface (a Highcharts
+      // config passthrough) — every other component must expose at least one
+      // closed object, or the whole sweep silently degrades to a no-op.
+      if (name !== 'highcharts') {
+        expect(positions.length).toBeGreaterThan(0);
+      }
+
+      for (const path of positions) {
+        const label = `${name} props/${path.join('/') || '(root)'}`;
+        let baselineProps: unknown;
+        try {
+          baselineProps = buildValue(liveProps, path, true);
+        } catch (error) {
+          throw new Error(
+            `could not build a valid instance for ${label}: ${
+              error instanceof Error ? error.message : error
+            }`
+          );
+        }
+        await expectGuarded(
+          label,
+          componentDoc(name, baselineProps),
+          componentDoc(name, injectProbe(baselineProps, path))
+        );
+      }
+    },
+    120_000
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Sweep 2: a defective component at every embedding position.
+// ---------------------------------------------------------------------------
+
+describe('a defective component is rejected at every embedding position', () => {
+  const paragraph = (extra?: Json): Json => ({
+    name: 'paragraph',
+    props: { text: 'x', ...extra },
+  });
+
+  const doc = (children: unknown[]): Json => ({
+    name: 'docx',
+    props: { theme: 'minimal' },
+    children,
+  });
+
+  /** Each embedding builds the same document around a paragraph payload. */
+  const EMBEDDINGS: Record<string, (p: Json) => Json> = {
+    'root children': (p) => doc([p]),
+    'section children': (p) => doc([{ name: 'section', children: [p] }]),
+    'columns children': (p) =>
+      doc([
+        {
+          name: 'section',
+          children: [
+            { name: 'columns', props: { columns: 2 }, children: [p, p] },
+          ],
+        },
+      ]),
+    'text-box children': (p) =>
+      doc([
+        { name: 'section', children: [{ name: 'text-box', children: [p] }] },
+      ]),
+    'text-box nested in columns': (p) =>
+      doc([
+        {
+          name: 'section',
+          children: [
+            {
+              name: 'columns',
+              props: { columns: 2 },
+              children: [{ name: 'text-box', children: [p] }, p],
+            },
+          ],
+        },
+      ]),
+    'section header': (p) =>
+      doc([{ name: 'section', props: { header: [p] }, children: [] }]),
+    'section footer': (p) =>
+      doc([{ name: 'section', props: { footer: [p] }, children: [] }]),
+    'table column header content': (p) =>
+      doc([
+        {
+          name: 'section',
+          children: [
+            {
+              name: 'table',
+              props: {
+                columns: [
+                  { header: { content: p }, cells: [{ content: 'A' }] },
+                ],
+              },
+            },
+          ],
+        },
+      ]),
+    'table cell content': (p) =>
+      doc([
+        {
+          name: 'section',
+          children: [
+            {
+              name: 'table',
+              props: {
+                columns: [
+                  { header: { content: 'H' }, cells: [{ content: p }] },
+                ],
+              },
+            },
+          ],
+        },
+      ]),
+  };
+
+  it.each(Object.entries(EMBEDDINGS))(
+    '%s',
+    async (label, build) => {
+      await expectGuarded(
+        label,
+        build(paragraph()),
+        build(paragraph({ [PROBE_KEY]: 1 }))
+      );
+    },
+    60_000
+  );
+
+  // The same positions again, with the junk key NEXT TO name/props instead of
+  // inside props — the position no per-component props check ever sees, and
+  // the exact fail-open hole that motivated #292's rescue audit.
+  it.each(Object.entries(EMBEDDINGS))(
+    '%s (sibling key)',
+    async (label, build) => {
+      const sibling = { ...paragraph(), [PROBE_KEY]: 1 };
+      await expectGuarded(
+        `${label} (sibling)`,
+        build(paragraph()),
+        build(sibling)
+      );
+    },
+    60_000
+  );
+
+  it('rejects an unknown key on the document root itself', async () => {
+    const baseline = doc([paragraph()]);
+    await expectGuarded('document root sibling', baseline, {
+      ...baseline,
+      [PROBE_KEY]: 1,
+    });
+  }, 60_000);
+});

--- a/packages/core-pptx/src/core/__tests__/unknown-key-guard.test.ts
+++ b/packages/core-pptx/src/core/__tests__/unknown-key-guard.test.ts
@@ -1,0 +1,531 @@
+/**
+ * Unknown-key guard, pptx (#292 parity): every closed object position in
+ * every standard component's props must reject an unknown key through BOTH
+ * entry points — the standalone validators and generation-time validation —
+ * with agreeing verdicts and a localized (non-root) diagnostic.
+ *
+ * Unlike docx, pptx has no whole-document TypeBox stage: the deep walk IS the
+ * validator, so a walk blind spot fails open directly (accepted and rendered)
+ * with no fail-closed net behind it. This sweep is that net, at test time:
+ * positions are enumerated from the registry's props schemas, so a prop
+ * object added to any component is swept automatically.
+ *
+ * The second suite plants a defective component at every embedding position
+ * (root children, slide children, slide placeholders) — in the props, as an
+ * unknown sibling key, and as a wrong-typed known sibling key (`enabled:
+ * "yes"`), the class the walk historically missed because it checked key
+ * presence but not value type.
+ *
+ * Agreement is asserted in the REJECT direction only: baselines are checked
+ * against the validators but never generated, mirroring the docx guard —
+ * generation shares assertValidPresentationForGeneration with the
+ * validators, and rendering accepted decks here would buy no schema signal.
+ */
+import { describe, it, expect } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+import {
+  PPTX_STANDARD_COMPONENTS_REGISTRY,
+  validate,
+  validateStrict,
+} from '@json-to-office/shared-pptx';
+import { generateBufferFromJson } from '../generator';
+import { PresentationValidationError } from '../generationOptions';
+
+type Json = Record<string, unknown>;
+
+const PROBE_KEY = 'zzUnknownProbeKey';
+
+// ---------------------------------------------------------------------------
+// Position enumeration: every additionalProperties:false object in a schema.
+// ---------------------------------------------------------------------------
+
+/** `*` stands for "an element of the array at this position". */
+type PositionPath = readonly string[];
+
+function enumerateClosedObjects(schema: unknown): PositionPath[] {
+  const found = new Map<string, PositionPath>();
+
+  const visit = (
+    node: any,
+    path: PositionPath,
+    depth: number,
+    seenIds: readonly string[]
+  ): void => {
+    if (!node || typeof node !== 'object') return;
+    if (depth > 12) return;
+    // A `$ref` is a recursive self-reference: the referenced component's own
+    // sweep covers its interior.
+    if (node.$ref) return;
+    if (node.$id) {
+      if (seenIds.includes(node.$id)) return;
+      seenIds = [...seenIds, node.$id];
+    }
+    if (Array.isArray(node.anyOf)) {
+      for (const branch of node.anyOf) visit(branch, path, depth + 1, seenIds);
+      return;
+    }
+    // Type.Intersect (highcharts `options`): positions live in the branches.
+    if (Array.isArray(node.allOf)) {
+      for (const branch of node.allOf) visit(branch, path, depth + 1, seenIds);
+      return;
+    }
+    if (node.type === 'object' && node.properties) {
+      if (node.additionalProperties === false) {
+        found.set(path.join('/'), path);
+      }
+      for (const [key, child] of Object.entries(node.properties)) {
+        visit(child, [...path, key], depth + 1, seenIds);
+      }
+      return;
+    }
+    if (node.items) visit(node.items, [...path, '*'], depth + 1, seenIds);
+  };
+
+  visit(schema, [], 0, []);
+  return [...found.values()];
+}
+
+// ---------------------------------------------------------------------------
+// Minimal-instance builder: a valid value for a schema that materializes the
+// given path. Throws with a reason when it cannot — the test surfaces that as
+// a loud failure so the builder is extended instead of silently skipping.
+// ---------------------------------------------------------------------------
+
+const CANDIDATE_STRINGS = [
+  'x',
+  'n1',
+  '#123456',
+  '10%',
+  '10pt',
+  'https://example.com/x',
+] as const;
+
+function sampleForPattern(pattern: string): string {
+  const regex = new RegExp(pattern);
+  const match = CANDIDATE_STRINGS.find((candidate) => regex.test(candidate));
+  if (match !== undefined) return match;
+  throw new Error(`no sample string for pattern ${pattern}`);
+}
+
+/**
+ * `terminalObject` — the value at the END of `includePath` is the probe
+ * target and must come out as a plain object: union branches that would put a
+ * primitive there (a `width: number | {...}` union built as the number) are
+ * skipped in favor of an object branch.
+ */
+function buildValue(
+  schema: any,
+  includePath: PositionPath,
+  terminalObject = false
+): unknown {
+  if (!schema || typeof schema !== 'object') {
+    throw new Error('missing schema');
+  }
+  if (schema.$ref) {
+    throw new Error('cannot build a recursive $ref value');
+  }
+  const atTerminal = includePath.length === 0 && terminalObject;
+  if ('const' in schema) {
+    if (atTerminal) throw new Error('terminal is a literal, not an object');
+    return schema.const;
+  }
+  if (Array.isArray(schema.enum)) {
+    if (atTerminal) throw new Error('terminal is an enum, not an object');
+    return schema.enum[0];
+  }
+
+  if (Array.isArray(schema.anyOf)) {
+    const reasons: string[] = [];
+    for (const branch of schema.anyOf) {
+      try {
+        const candidate = buildValue(branch, includePath, terminalObject);
+        if (Value.Check(branch, candidate)) return candidate;
+        reasons.push('built candidate failed its own branch check');
+      } catch (error) {
+        reasons.push(error instanceof Error ? error.message : String(error));
+      }
+    }
+    throw new Error(`no union branch buildable (${reasons.join('; ')})`);
+  }
+
+  // Type.Intersect (highcharts `options`: a Record intersected with a shape
+  // object): build every branch and merge, routing the path to the first
+  // branch that can carry it.
+  if (Array.isArray(schema.allOf)) {
+    const merged: Json = {};
+    let pathCarried = includePath.length === 0;
+    for (const branch of schema.allOf) {
+      let part: unknown;
+      if (!pathCarried) {
+        try {
+          part = buildValue(branch, includePath, terminalObject);
+          pathCarried = true;
+        } catch {
+          part = buildValue(branch, []);
+        }
+      } else {
+        part = buildValue(branch, []);
+      }
+      if (part && typeof part === 'object' && !Array.isArray(part)) {
+        Object.assign(merged, part);
+      }
+    }
+    if (!pathCarried) {
+      throw new Error('no intersect branch carries the path');
+    }
+    return merged;
+  }
+
+  if (atTerminal && schema.type !== 'object') {
+    throw new Error(`terminal has type ${schema.type}, not object`);
+  }
+  if (
+    includePath.length > 0 &&
+    schema.type !== 'object' &&
+    schema.type !== 'array'
+  ) {
+    // A primitive cannot carry the rest of the path — refuse instead of
+    // returning a value the probe injection would then miss (matters inside
+    // unions like `number | { … }`, where the object branch owns the path).
+    throw new Error(`cannot materialize a path inside type ${schema.type}`);
+  }
+
+  const [head, ...rest] = includePath;
+
+  switch (schema.type) {
+    case 'string': {
+      if (schema.default !== undefined) return schema.default;
+      if (Array.isArray(schema.examples) && schema.examples.length > 0) {
+        return schema.examples[0];
+      }
+      if (schema.pattern) return sampleForPattern(schema.pattern);
+      if (schema.format === 'uri') return 'https://example.com/x';
+      const min = schema.minLength ?? 1;
+      return 'x'.repeat(Math.max(1, min));
+    }
+    case 'number':
+    case 'integer': {
+      let n: number =
+        schema.default ??
+        schema.minimum ??
+        (schema.exclusiveMinimum !== undefined
+          ? schema.exclusiveMinimum + 1
+          : 1);
+      if (schema.multipleOf) {
+        n = Math.ceil(n / schema.multipleOf) * schema.multipleOf;
+      }
+      if (schema.maximum !== undefined) n = Math.min(n, schema.maximum);
+      if (schema.type === 'integer') n = Math.ceil(n);
+      return n;
+    }
+    case 'boolean':
+      return schema.default ?? true;
+    case 'array': {
+      if (head === '*') {
+        // First element materializes the path; pad to minItems.
+        const first = buildValue(schema.items, rest, terminalObject);
+        const padding = Math.max(0, (schema.minItems ?? 1) - 1);
+        return [
+          first,
+          ...Array.from({ length: padding }, () =>
+            buildValue(schema.items, [])
+          ),
+        ];
+      }
+      const count = schema.minItems ?? 0;
+      return Array.from({ length: count }, () => buildValue(schema.items, []));
+    }
+    case 'object': {
+      if (!schema.properties) {
+        if (head !== undefined) {
+          throw new Error('cannot materialize a path inside an open object');
+        }
+        return {};
+      }
+      const value: Json = {};
+      const required: string[] = schema.required ?? [];
+      for (const key of required) {
+        if (key === head) continue;
+        value[key] = buildValue(schema.properties[key], []);
+      }
+      if (head !== undefined) {
+        const child = schema.properties[head];
+        if (!child) throw new Error(`no property "${head}" to materialize`);
+        value[head] = buildValue(child, rest, terminalObject);
+      }
+      return value;
+    }
+    default:
+      // Type.Any / unrecognized: only safe as a leaf.
+      if (head !== undefined) {
+        throw new Error('cannot materialize a path inside an untyped schema');
+      }
+      return 'x';
+  }
+}
+
+/** Deep-set the probe key at `path` ('*' resolves to index 0). */
+function injectProbe(value: unknown, path: PositionPath): unknown {
+  const clone = structuredClone(value) as any;
+  let cursor = clone;
+  for (const segment of path) {
+    cursor = segment === '*' ? cursor[0] : cursor[segment];
+  }
+  cursor[PROBE_KEY] = 1;
+  return clone;
+}
+
+// ---------------------------------------------------------------------------
+// Document wrappers and the three-way verdict.
+// ---------------------------------------------------------------------------
+
+/**
+ * Semantic rules the props schema cannot express, satisfied on the baseline:
+ * `text` demands exactly one of `text`/`runs` (both optional in the schema),
+ * and the conflict collector walks the WHOLE document — including component
+ * stubs built inside template `objects`. Seed a `text` wherever a text node
+ * carries neither, without touching nodes a materialized path already fed.
+ *
+ * MUTATES `built` in place (and returns it): the seeded nodes are found by
+ * walking, so cloning would mean re-locating them. For the `text` component
+ * itself, `built` IS the props — the wrapper below only lends it the
+ * `{ name: 'text' }` shape the walk keys on; the wrapper is discarded.
+ */
+function satisfyTextContentRule(componentName: string, built: Json): Json {
+  const props =
+    componentName === 'text' ? { name: 'text', props: built } : built;
+  const visit = (node: any): void => {
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    if (node.name === 'text') {
+      const p = node.props;
+      if (p && typeof p === 'object' && !('text' in p) && !('runs' in p)) {
+        p.text = 'x';
+      }
+    }
+    Object.values(node).forEach(visit);
+  };
+  visit(props);
+  return built;
+}
+
+function componentDoc(name: string, props: unknown): Json {
+  if (name === 'pptx') {
+    return { name: 'pptx', props, children: [] };
+  }
+  const component: Json = { name, props };
+  return {
+    name: 'pptx',
+    props: { title: 'Guard deck' },
+    children:
+      name === 'slide'
+        ? [component]
+        : [{ name: 'slide', children: [component] }],
+  };
+}
+
+async function generationVerdict(
+  doc: Json
+): Promise<'accepted' | 'rejected-by-validation' | 'failed-otherwise'> {
+  try {
+    await generateBufferFromJson(doc as never);
+    return 'accepted';
+  } catch (error) {
+    return error instanceof PresentationValidationError
+      ? 'rejected-by-validation'
+      : 'failed-otherwise';
+  }
+}
+
+/** Baseline must validate; the injected document must be refused everywhere. */
+async function expectGuarded(
+  label: string,
+  baseline: Json,
+  injected: Json
+): Promise<void> {
+  const baseResult = validate.jsonDocument(JSON.stringify(baseline));
+  expect(
+    { label, valid: baseResult.valid, errors: baseResult.errors ?? [] },
+    `baseline for ${label} must be valid — fix the test builder, not the guard`
+  ).toEqual({ label, valid: true, errors: [] });
+
+  const lenient = validate.jsonDocument(JSON.stringify(injected));
+  const strict = validateStrict.jsonDocument(JSON.stringify(injected));
+  const generation = await generationVerdict(injected);
+
+  expect({
+    label,
+    lenient: lenient.valid,
+    strict: strict.valid,
+    generation,
+  }).toEqual({
+    label,
+    lenient: false,
+    strict: false,
+    generation: 'rejected-by-validation',
+  });
+
+  // The rejection must be localized: with no whole-document stage behind the
+  // walk, a root-only generic error would mean nothing actually saw the
+  // position.
+  const localized = (lenient.errors ?? []).some(
+    (e) => e.path && e.path !== 'root' && e.path !== '/'
+  );
+  expect(
+    localized,
+    `expected a non-root error path for ${label}, got: ${JSON.stringify(lenient.errors)}`
+  ).toBe(true);
+}
+
+// ---------------------------------------------------------------------------
+// Sweep 1: every closed object position of every component's props.
+// ---------------------------------------------------------------------------
+
+describe('unknown keys are rejected at every closed props position', () => {
+  it.each(PPTX_STANDARD_COMPONENTS_REGISTRY.map((c) => [c.name, c] as const))(
+    '%s',
+    async (name, component) => {
+      const positions = enumerateClosedObjects(component.propsSchema);
+      expect(positions.length).toBeGreaterThan(0);
+
+      for (const path of positions) {
+        const label = `${name} props/${path.join('/') || '(root)'}`;
+        let baselineProps: Json;
+        try {
+          baselineProps = satisfyTextContentRule(
+            name,
+            buildValue(component.propsSchema, path, true) as Json
+          );
+        } catch (error) {
+          throw new Error(
+            `could not build a valid instance for ${label}: ${
+              error instanceof Error ? error.message : error
+            }`
+          );
+        }
+
+        let baseline = componentDoc(name, baselineProps);
+        let injected = componentDoc(name, injectProbe(baselineProps, path));
+
+        // A materialized prop may be renderer-gated (slide `transition` is
+        // office-open-only). The guard pins schema shape, not renderer
+        // capability — when the ONLY baseline complaints are renderer-profile
+        // ones, pin the renderer that supports the feature and sweep on.
+        const probe = validate.jsonDocument(JSON.stringify(baseline));
+        if (
+          !probe.valid &&
+          (probe.errors ?? []).length > 0 &&
+          (probe.errors ?? []).every(
+            (e) => e.code === 'unsupported_renderer_feature'
+          )
+        ) {
+          baseline = { ...baseline, renderer: 'office-open' };
+          injected = { ...injected, renderer: 'office-open' };
+        }
+
+        await expectGuarded(label, baseline, injected);
+      }
+    },
+    120_000
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Sweep 2: a defective component at every embedding position — junk in the
+// props, an unknown sibling key, and a wrong-typed known sibling key.
+// ---------------------------------------------------------------------------
+
+describe('a defective component is rejected at every embedding position', () => {
+  const text = (extra?: Json): Json => ({
+    name: 'text',
+    props: { text: 'x', ...(extra?.props as Json) },
+    ...(extra
+      ? Object.fromEntries(Object.entries(extra).filter(([k]) => k !== 'props'))
+      : {}),
+  });
+
+  const deck = (slides: unknown[]): Json => ({
+    name: 'pptx',
+    props: { title: 'Guard deck' },
+    children: slides,
+  });
+
+  /** Each embedding builds the same document around a text payload. */
+  const EMBEDDINGS: Record<string, (t: Json) => Json> = {
+    'slide children': (t) => deck([{ name: 'slide', children: [t] }]),
+    'slide placeholder value': (t) =>
+      deck([
+        { name: 'slide', props: { placeholders: { title: t } }, children: [] },
+      ]),
+    'root children (slide)': (t) =>
+      deck([{ name: 'slide', children: [], ...pickSiblings(t) }]),
+  };
+
+  /** For the root-children case the payload's defect rides on the SLIDE. */
+  function pickSiblings(t: Json): Json {
+    return Object.fromEntries(
+      Object.entries(t).filter(([key]) => key !== 'name' && key !== 'props')
+    );
+  }
+
+  const CASES: [string, Json][] = [
+    ['unknown props key', text({ props: { [PROBE_KEY]: 1 } })],
+    ['unknown sibling key', text({ [PROBE_KEY]: 1 })],
+    ['wrong-typed enabled sibling', text({ enabled: 'yes' })],
+    ['wrong-typed id sibling', text({ id: 7 })],
+  ];
+
+  for (const [embedLabel, build] of Object.entries(EMBEDDINGS)) {
+    // The root-children embedding carries only sibling defects — the payload
+    // rides on the SLIDE via pickSiblings, so a props-key case would probe
+    // nothing (a slide's own props junk is Sweep 1's job). Filtered out here
+    // rather than skipped in the body, so no green test hides an unexercised
+    // case.
+    const cases =
+      embedLabel === 'root children (slide)'
+        ? CASES.filter(([caseLabel]) => caseLabel !== 'unknown props key')
+        : CASES;
+    it.each(cases)(
+      `${embedLabel} — %s`,
+      async (caseLabel, payload) => {
+        await expectGuarded(
+          `${embedLabel}: ${caseLabel}`,
+          build(text()),
+          build(payload)
+        );
+      },
+      60_000
+    );
+  }
+
+  // The embeddings above are written out by hand, so their coverage is pinned
+  // to the registry: a component gaining `hasPlaceholders` (or a new
+  // container) widens the embedding surface, and this assertion is what makes
+  // that widening extend the sweep instead of silently escaping it.
+  it('EMBEDDINGS cover every container and placeholder carrier the registry declares', () => {
+    const placeholderCarriers = PPTX_STANDARD_COMPONENTS_REGISTRY.filter(
+      (c) => c.hasPlaceholders
+    ).map((c) => c.name);
+    const containers = PPTX_STANDARD_COMPONENTS_REGISTRY.filter(
+      (c) => c.hasChildren
+    ).map((c) => c.name);
+
+    expect(placeholderCarriers).toEqual(['slide']);
+    expect(containers.sort()).toEqual(['pptx', 'slide']);
+  });
+
+  it('rejects sibling defects on the document root itself', async () => {
+    const baseline = deck([{ name: 'slide', children: [text()] }]);
+    await expectGuarded('root unknown sibling', baseline, {
+      ...baseline,
+      [PROBE_KEY]: 1,
+    });
+    await expectGuarded('root wrong-typed enabled', baseline, {
+      ...baseline,
+      enabled: 'yes',
+    });
+  }, 60_000);
+});

--- a/packages/jto/src/client/components/playground/document-sidebar.tsx
+++ b/packages/jto/src/client/components/playground/document-sidebar.tsx
@@ -210,7 +210,11 @@ function DocumentSidebarComponent({
         if (!res.ok) throw new Error(res.statusText);
         const content = await res.text();
         const parsed = JSON.parse(content);
-        createDocument(name, JSON.stringify(parsed, null, 2));
+        // Record provenance so generate/preview keep resolving the template's
+        // bundled media/fonts (options.sourceName) after the user renames it.
+        createDocument(name, JSON.stringify(parsed, null, 2), {
+          templateSource: name,
+        });
         openDocument(name);
         toast({ title: `Added ${isTheme ? 'theme' : 'document'}: ${name}` });
       } catch {

--- a/packages/jto/src/client/components/playground/global-preview-header.tsx
+++ b/packages/jto/src/client/components/playground/global-preview-header.tsx
@@ -44,6 +44,13 @@ export function GlobalPreviewHeader({
       ? s.documents.find((d) => d.name === s.activeTab)?.text
       : undefined
   );
+  // The name owning that text. `name` above is the last output's, so without
+  // this the copy request pairs one document's JSON with another's provenance.
+  const editorDocumentName = useDocumentsStore((s) =>
+    s.activeTab && s.documentTypes[s.activeTab] !== 'application/json+theme'
+      ? s.activeTab
+      : undefined
+  );
 
   const chatOpen = __AI_ENABLED__ ? useChatStore((s) => s.chatOpen) : false;
 
@@ -82,6 +89,7 @@ export function GlobalPreviewHeader({
         onShowFonts={() => openFontPicker()}
         documentText={text}
         editorDocumentText={editorDocumentText}
+        editorDocumentName={editorDocumentName}
         warnings={warnings}
         onToggleChat={__AI_ENABLED__ ? toggleChat : undefined}
         chatOpen={__AI_ENABLED__ ? chatOpen : undefined}

--- a/packages/jto/src/client/components/playground/preview-header.tsx
+++ b/packages/jto/src/client/components/playground/preview-header.tsx
@@ -50,6 +50,7 @@ import { download } from '../../lib/download';
 import { KbdShortcut } from '../ui/kbd';
 import { apiClient } from '../../api/client';
 import { useToast } from '../ui/use-toast';
+import { useResolveSourceName } from '../../store/documents-store-provider';
 import { usePresentationGenerator } from '../../hooks/usePresentationGenerator';
 import { useRendererIds } from '../../hooks/useRendererIds';
 import { useSettingsStore } from '../../store/settings-store-provider';
@@ -129,6 +130,7 @@ function PreviewHeader({
   const [standardComponentsFallbackJson, setStandardComponentsFallbackJson] =
     useState<string | null>(null);
   const { toast } = useToast();
+  const resolveSourceName = useResolveSourceName();
   // The hook is format-agnostic (dispatches on FORMAT env); alias to a
   // neutral name so DOCX call sites don't read as if they're calling a
   // PPTX-specific generator.
@@ -376,7 +378,8 @@ function PreviewHeader({
           // sourceName lets the server inline a discovered document's bundled
           // media before safe-mode source validation — without it, templates
           // referencing relative media paths 400 here while rendering fine.
-          options: { sourceName: name },
+          // Resolved from template provenance so renamed copies keep working.
+          options: { sourceName: resolveSourceName(name) },
         }),
       });
 
@@ -450,7 +453,7 @@ function PreviewHeader({
         setIsCopyingStandardComponents(false);
       }
     })();
-  }, [copySourceText, name, getFreshThemeData, toast]);
+  }, [copySourceText, name, resolveSourceName, getFreshThemeData, toast]);
 
   const handleCopyFromFallbackDialog = useCallback(async () => {
     if (standardComponentsFallbackJson == null) return;

--- a/packages/jto/src/client/components/playground/preview-header.tsx
+++ b/packages/jto/src/client/components/playground/preview-header.tsx
@@ -92,6 +92,7 @@ function PreviewHeader({
   onShowFonts,
   documentText,
   editorDocumentText,
+  editorDocumentName,
   warnings,
   onToggleChat,
   chatOpen,
@@ -113,6 +114,14 @@ function PreviewHeader({
    * before the first Run (#155).
    */
   editorDocumentText?: string;
+  /**
+   * The name that owns `editorDocumentText`. `name` identifies the last
+   * successful output, so on its own it pairs the active document's JSON with
+   * the previous document's provenance after a tab switch — and is a
+   * placeholder before the first Run. Undefined whenever `editorDocumentText`
+   * is, so the two always travel together.
+   */
+  editorDocumentName?: string;
   warnings?: GenerationWarning[] | null;
   onToggleChat?: () => void;
   chatOpen?: boolean;
@@ -378,8 +387,13 @@ function PreviewHeader({
           // sourceName lets the server inline a discovered document's bundled
           // media before safe-mode source validation — without it, templates
           // referencing relative media paths 400 here while rendering fine.
-          // Resolved from template provenance so renamed copies keep working.
-          options: { sourceName: resolveSourceName(name) },
+          // Resolved from template provenance so renamed copies keep working,
+          // and off the SAME document `copySourceText` came from — `name` is
+          // the last output's, which is stale after a tab switch and a
+          // placeholder before the first Run.
+          options: {
+            sourceName: resolveSourceName(editorDocumentName ?? name),
+          },
         }),
       });
 
@@ -453,7 +467,14 @@ function PreviewHeader({
         setIsCopyingStandardComponents(false);
       }
     })();
-  }, [copySourceText, name, resolveSourceName, getFreshThemeData, toast]);
+  }, [
+    copySourceText,
+    name,
+    editorDocumentName,
+    resolveSourceName,
+    getFreshThemeData,
+    toast,
+  ]);
 
   const handleCopyFromFallbackDialog = useCallback(async () => {
     if (standardComponentsFallbackJson == null) return;

--- a/packages/jto/src/client/components/playground/preview.tsx
+++ b/packages/jto/src/client/components/playground/preview.tsx
@@ -69,6 +69,14 @@ export function Preview() {
       ? s.documents.find((d) => d.name === s.activeTab)?.text
       : undefined
   );
+  // Same condition as the text above, so the name and the JSON sent with it
+  // always describe one document — the output store's `name` trails a tab
+  // switch and is a placeholder before the first Run.
+  const editorDocumentName = useDocumentsStore((s) =>
+    s.activeTab && s.documentTypes[s.activeTab] !== 'application/json+theme'
+      ? s.activeTab
+      : undefined
+  );
   const documentsStore = useContext(DocumentsStoreContext)!;
   const { toast } = useToast();
   const applyQualityFix = useApplyQualityFix();
@@ -358,6 +366,7 @@ export function Preview() {
             onShowCacheMetrics={() => setShowCacheMetrics(true)}
             documentText={text}
             editorDocumentText={editorDocumentText}
+            editorDocumentName={editorDocumentName}
             warnings={warnings}
           />
         )}

--- a/packages/jto/src/client/components/playground/preview.tsx
+++ b/packages/jto/src/client/components/playground/preview.tsx
@@ -26,6 +26,7 @@ import { renderDocument } from '../../lib/render';
 import {
   DocumentsStoreContext,
   useDocumentsStore,
+  useResolveSourceName,
 } from '../../store/documents-store-provider';
 import { useEditorRefsStore } from '../../store/editor-refs-store';
 import { useThemesStore } from '../../store/themes-store-provider';
@@ -230,6 +231,7 @@ export function Preview() {
 
   const renderCleanupRef = useRef<(() => void) | null>(null);
   const pendingManualRenderRef = useRef(false);
+  const resolveSourceName = useResolveSourceName();
 
   const cleanupRenderedPreview = useCallback(() => {
     if (renderCleanupRef.current) {
@@ -259,7 +261,8 @@ export function Preview() {
           docBlob,
           docText,
           themes,
-          renderer
+          renderer,
+          resolveSourceName(docName)
         );
 
         if (status !== 'success') {
@@ -288,7 +291,7 @@ export function Preview() {
         setOutput({ isRendering: false });
       }
     },
-    [setOutput, cleanupRenderedPreview]
+    [setOutput, cleanupRenderedPreview, resolveSourceName]
   );
 
   // Ref to always hold latest manual-render deps so the event listener never goes stale

--- a/packages/jto/src/client/hooks/usePresentationGenerator.ts
+++ b/packages/jto/src/client/hooks/usePresentationGenerator.ts
@@ -3,6 +3,7 @@ import { FORMAT, FORMAT_LABEL } from '../lib/env';
 import { API_ENDPOINTS } from '../config/api';
 import type { QualityRequestOptions } from '../lib/quality-profiles';
 import { useSettingsStore } from '../store/settings-store-provider';
+import { useResolveSourceName } from '../store/documents-store-provider';
 
 export interface GenerationWarning {
   component: string;
@@ -142,6 +143,7 @@ export function usePresentationGenerator() {
   // selected backend, and a call site that forgot would silently render on the
   // default one while the UI said otherwise.
   const generationBackend = useSettingsStore((s) => s.generationBackend);
+  const resolveSourceName = useResolveSourceName();
 
   const generatePresentation = useCallback(
     async (
@@ -210,10 +212,11 @@ export function usePresentationGenerator() {
         } = {
           jsonDefinition,
           // sourceName lets the server resolve relative asset paths against
-          // the discovered document's own directory (#142).
+          // the discovered document's own directory (#142). Resolved from the
+          // document's template provenance, so a renamed copy keeps working.
           options: {
             ...options,
-            sourceName: name,
+            sourceName: resolveSourceName(name),
             // An explicit per-call renderer still wins, which is what lets a
             // comparison view ask for both without changing the setting.
             ...(effectiveRenderer ? { renderer: effectiveRenderer } : {}),
@@ -317,7 +320,7 @@ export function usePresentationGenerator() {
         }
       }
     },
-    [generationBackend]
+    [generationBackend, resolveSourceName]
   );
 
   const cancelGeneration = useCallback(() => {

--- a/packages/jto/src/client/lib/__tests__/render-renderer.test.ts
+++ b/packages/jto/src/client/lib/__tests__/render-renderer.test.ts
@@ -62,4 +62,21 @@ describe('renderDocument', () => {
     // from the field being missing.
     expect(request.body()?.options).not.toHaveProperty('renderer');
   });
+
+  it('prefers an explicit sourceName over the display name', async () => {
+    const request = captureRequest();
+
+    // A renamed copy of a bundled template: the display name means nothing to
+    // the server, the provenance is what resolves its media and fonts.
+    await renderDocument(
+      'my-report',
+      blob,
+      json,
+      {},
+      undefined,
+      'vermilion-annual-report'
+    );
+
+    expect(request.body()?.options?.sourceName).toBe('vermilion-annual-report');
+  });
 });

--- a/packages/jto/src/client/lib/render.ts
+++ b/packages/jto/src/client/lib/render.ts
@@ -12,7 +12,8 @@ async function renderWithLibreOffice(
   blob: Blob,
   jsonText?: string,
   customThemes?: Record<string, unknown>,
-  renderer?: string
+  renderer?: string,
+  sourceName?: string
 ): Promise<RenderPayload> {
   // When we know the source JSON, hit the from-json endpoint. The server
   // generates + converts in one step and passes resolved fonts directly to
@@ -34,12 +35,16 @@ async function renderWithLibreOffice(
       customThemes: customThemes ?? {},
       // sourceName lets the server resolve relative asset paths against the
       // discovered document's own directory (#142). Names only — the server
-      // maps them to paths itself.
+      // maps them to paths itself. Callers pass the document's template
+      // provenance when they know it; the display name is only the fallback.
       //
       // `renderer` is what keeps the preview honest: the server regenerates
       // the document here, and without it the PDF on screen came from the
       // default backend while the download came from the selected one (#255).
-      options: { sourceName: name, ...(renderer ? { renderer } : {}) },
+      options: {
+        sourceName: sourceName ?? name,
+        ...(renderer ? { renderer } : {}),
+      },
     };
     response = await fetch(API_ENDPOINTS.preview.libreofficeFromJson, {
       method: 'POST',
@@ -99,7 +104,8 @@ export async function renderDocument(
   blob: Blob,
   jsonText?: string,
   customThemes?: Record<string, unknown>,
-  renderer?: string
+  renderer?: string,
+  sourceName?: string
 ) {
   try {
     if (!blob || blob.size === 0) {
@@ -111,7 +117,8 @@ export async function renderDocument(
       blob,
       jsonText,
       customThemes,
-      renderer
+      renderer,
+      sourceName
     );
 
     return { status: 'success' as const, name, payload };

--- a/packages/jto/src/client/lib/types.ts
+++ b/packages/jto/src/client/lib/types.ts
@@ -9,6 +9,13 @@ type BaseFile = {
 
 export type TextFile = BaseFile & {
   text: string;
+  /**
+   * Name of the server-discovered document this one was created from, if any.
+   * Sent as `options.sourceName` so the server can inline the template's
+   * bundled media/fonts — keyed on provenance rather than the display name,
+   * which the user is free to rename.
+   */
+  templateSource?: string;
 };
 
 export type BinaryFile = BaseFile & {

--- a/packages/jto/src/client/store/__tests__/documents-template-source.test.ts
+++ b/packages/jto/src/client/store/__tests__/documents-template-source.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// In-memory stand-in: idb-keyval touches real IndexedDB at import time under
+// the persist middleware, which node's test environment doesn't have.
+vi.mock('idb-keyval', () => {
+  const store = new Map<string, unknown>();
+  return {
+    get: async (k: string) => store.get(k),
+    set: async (k: string, v: unknown) => void store.set(k, v),
+    del: async (k: string) => void store.delete(k),
+  };
+});
+
+import {
+  createDocumentsStore,
+  initDocumentsStore,
+  resolveSourceName,
+} from '../documents-store';
+
+describe('template provenance', () => {
+  it('createDocument records templateSource and rename preserves it', () => {
+    const store = createDocumentsStore(initDocumentsStore());
+    store.getState().createDocument('vermilion-annual-report', '{}', {
+      templateSource: 'vermilion-annual-report',
+    });
+    store.getState().createDocument('scratch', '{}');
+
+    let docs = store.getState().documents;
+    expect(
+      docs.find((d) => d.name === 'vermilion-annual-report')
+    ).toMatchObject({ templateSource: 'vermilion-annual-report' });
+    expect(
+      docs.find((d) => d.name === 'scratch')?.templateSource
+    ).toBeUndefined();
+
+    store.getState().renameDocument('vermilion-annual-report', 'my-report');
+    docs = store.getState().documents;
+    expect(docs.find((d) => d.name === 'my-report')).toMatchObject({
+      templateSource: 'vermilion-annual-report',
+    });
+  });
+
+  it('resolveSourceName prefers provenance and falls back to the name', () => {
+    const docs = [
+      { name: 'my-report', templateSource: 'vermilion-annual-report' },
+      { name: 'scratch' },
+    ] as Parameters<typeof resolveSourceName>[0];
+
+    expect(resolveSourceName(docs, 'my-report')).toBe(
+      'vermilion-annual-report'
+    );
+    // Pre-provenance documents and never-persisted names keep today's
+    // behaviour: the display name goes to the server as-is.
+    expect(resolveSourceName(docs, 'scratch')).toBe('scratch');
+    expect(resolveSourceName(docs, 'unknown')).toBe('unknown');
+  });
+});

--- a/packages/jto/src/client/store/documents-store-provider.tsx
+++ b/packages/jto/src/client/store/documents-store-provider.tsx
@@ -1,9 +1,16 @@
-import { type ReactNode, createContext, useRef, useContext } from 'react';
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useRef,
+  useContext,
+} from 'react';
 import { useStore } from 'zustand';
 import {
   type DocumentsStore,
   createDocumentsStore,
   initDocumentsStore,
+  resolveSourceName,
 } from './documents-store';
 
 export type DocumentsStoreApi = ReturnType<typeof createDocumentsStore>;
@@ -43,4 +50,25 @@ export const useDocumentsStore = <T,>(
   }
 
   return useStore(documentsStoreContext, selector);
+};
+
+/**
+ * Stable `docName -> options.sourceName` resolver for generate/preview
+ * requests. Reads the store imperatively at call time — no subscription, so
+ * callbacks holding it don't re-create on every document edit.
+ */
+export const useResolveSourceName = (): ((docName: string) => string) => {
+  const documentsStoreContext = useContext(DocumentsStoreContext);
+
+  if (!documentsStoreContext) {
+    throw new Error(
+      'useResolveSourceName must be used within DocumentsStoreProvider'
+    );
+  }
+
+  return useCallback(
+    (docName: string) =>
+      resolveSourceName(documentsStoreContext.getState().documents, docName),
+    [documentsStoreContext]
+  );
 };

--- a/packages/jto/src/client/store/documents-store.ts
+++ b/packages/jto/src/client/store/documents-store.ts
@@ -20,7 +20,11 @@ export type DocumentsState = {
 };
 
 export type DocumentsActions = {
-  createDocument: (name: string, text: string) => void;
+  createDocument: (
+    name: string,
+    text: string,
+    opts?: { templateSource?: string }
+  ) => void;
   deleteDocument: (name: string) => void;
   saveDocument: (name: string, text: string) => void;
   renameDocument: (oldName: string, newName: string) => void;
@@ -38,6 +42,23 @@ export type DocumentsActions = {
 };
 
 export type DocumentsStore = DocumentsState & DocumentsActions;
+
+/**
+ * The `options.sourceName` to send with generate/preview requests: the
+ * document's template provenance when it has one, else its display name.
+ * The server only matches sourceName against its own discovered documents,
+ * so provenance keeps a renamed copy of a bundled template resolving its
+ * relative media/fonts, while the display-name fallback preserves behaviour
+ * for documents created before templateSource existed.
+ */
+export function resolveSourceName(
+  documents: TextFile[],
+  docName: string
+): string {
+  return (
+    documents.find((doc) => doc.name === docName)?.templateSource ?? docName
+  );
+}
 
 export const initDocumentsStore = (): DocumentsState => {
   return {
@@ -63,7 +84,7 @@ export const createDocumentsStore = (
       persist(
         (set) => ({
           ...initState,
-          createDocument: (name, text) =>
+          createDocument: (name, text, opts) =>
             set((state) => {
               const docIndex = state.documents.findIndex(
                 (doc) => doc.name === name
@@ -96,6 +117,10 @@ export const createDocumentsStore = (
                   mtime: new Date(),
                   ctime: new Date(),
                   atime: new Date(),
+                  // Survives renames: renameDocument spreads the record.
+                  ...(opts?.templateSource
+                    ? { templateSource: opts.templateSource }
+                    : {}),
                 };
                 return {
                   documents: [...state.documents, newDoc],

--- a/packages/jto/src/server/routes/__tests__/format-generate-warnings.test.ts
+++ b/packages/jto/src/server/routes/__tests__/format-generate-warnings.test.ts
@@ -29,8 +29,7 @@ const UNKNOWN_FAMILY = 'Acme Brand Sans';
 
 const docWithUnknownFont = {
   name: 'docx',
-  props: { theme: 'minimal' },
-  metadata: { title: 'route-warnings' },
+  props: { theme: 'minimal', metadata: { title: 'route-warnings' } },
   children: [
     {
       name: 'paragraph',

--- a/packages/jto/src/server/routes/format.ts
+++ b/packages/jto/src/server/routes/format.ts
@@ -123,10 +123,11 @@ export function createFormatRouter(adapter: FormatAdapter) {
     }
   };
 
-  // In safe mode, relative media of a server-discovered document is inlined
-  // as data URLs so bundled templates pass source validation and survive the
-  // trip to the remote rasterizer. Development mode keeps filesystem
-  // resolution (and the path-keyed visual cache) untouched.
+  // In safe mode, relative media and `kind:'file'` font sources of a
+  // server-discovered document are inlined as data so bundled templates pass
+  // source validation and survive the trip to the remote rasterizer.
+  // Development mode keeps filesystem resolution (and the path-keyed visual
+  // cache) untouched.
   const inlineDiscoveredMedia = async (
     jsonDefinition: unknown,
     baseDir: string | undefined

--- a/packages/jto/src/server/services/__tests__/bundled-templates-safe-mode.test.ts
+++ b/packages/jto/src/server/services/__tests__/bundled-templates-safe-mode.test.ts
@@ -1,0 +1,83 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import { inlineTemplateMedia } from '../template-media-inliner';
+import { assertSafeOutboundSources } from '../../security/outbound-source-policy';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_DIR = path.resolve(
+  __dirname,
+  '../../../client/public/templates'
+);
+const RENDER_YAML = path.resolve(__dirname, '../../../../../../render.yaml');
+
+/**
+ * The hosted playgrounds run OUTBOUND_SOURCE_MODE=safe, where every bundled
+ * template must pass `assertSafeOutboundSources` after the sourceName ->
+ * inlineTemplateMedia step (format.ts) — with only the hosts render.yaml
+ * actually allowlists. The vermilion template shipped `kind:'file'` font
+ * sources that 400'd every remote generation because nothing asserted this.
+ */
+function productionAllowlist(): string[] {
+  const yaml = fs.readFileSync(RENDER_YAML, 'utf8');
+  const values = [
+    ...yaml.matchAll(
+      /key:\s*OUTBOUND_HOST_ALLOWLIST\s*\n\s*value:\s*'?([^'\n]+)'?/g
+    ),
+  ].map((m) => m[1].trim());
+  expect(values.length).toBeGreaterThan(0);
+  // Every service must agree, or a template could pass on one deployment and
+  // 400 on another.
+  expect(new Set(values).size).toBe(1);
+  return values[0].split(',').map((h) => h.trim());
+}
+
+const POLICY = { mode: 'safe' as const, allowedHosts: productionAllowlist() };
+
+const templateFiles = fs
+  .readdirSync(TEMPLATE_DIR)
+  .filter((f) => f.endsWith('.docx.json') || f.endsWith('.pptx.json'))
+  .sort();
+
+describe('bundled playground templates in safe mode', () => {
+  it('ships at least the known stock templates', () => {
+    expect(templateFiles.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it.each(templateFiles)(
+    '%s survives inlining + safe-mode source validation',
+    async (file) => {
+      const json = JSON.parse(
+        fs.readFileSync(path.join(TEMPLATE_DIR, file), 'utf8')
+      );
+      const inlined = await inlineTemplateMedia(json, TEMPLATE_DIR);
+      expect(() =>
+        assertSafeOutboundSources(inlined, POLICY, 'jsonDefinition')
+      ).not.toThrow();
+    }
+  );
+
+  it('the vermilion fonts are what the inlining step neutralizes', async () => {
+    // Guards against this suite going vacuous: the raw template must actually
+    // trip the policy, and inlining must be the thing that fixes it.
+    const raw = JSON.parse(
+      fs.readFileSync(
+        path.join(TEMPLATE_DIR, 'vermilion-annual-report.docx.json'),
+        'utf8'
+      )
+    );
+    expect(() =>
+      assertSafeOutboundSources(raw, POLICY, 'jsonDefinition')
+    ).toThrow(/local file sources are disabled/);
+
+    const inlined = (await inlineTemplateMedia(raw, TEMPLATE_DIR)) as {
+      props: { fontRegistry: { sources: { kind: string }[] }[] };
+    };
+    for (const entry of inlined.props.fontRegistry) {
+      for (const source of entry.sources) {
+        expect(source.kind).not.toBe('file');
+      }
+    }
+  });
+});

--- a/packages/jto/src/server/services/__tests__/generator-document-registry.test.ts
+++ b/packages/jto/src/server/services/__tests__/generator-document-registry.test.ts
@@ -39,8 +39,8 @@ const docWithRegistry = () => ({
         sources: [{ kind: 'data', data: fakeTtfBase64(), weight: 400 }],
       },
     ],
+    metadata: { title: 'registry-materialization' },
   },
-  metadata: { title: 'registry-materialization' },
   children: [
     { name: 'paragraph', props: { text: 'Body.', font: { family: FAMILY } } },
   ],
@@ -86,8 +86,7 @@ describe('props.fontRegistry materialization', () => {
     const result = await service.generate({
       jsonDefinition: {
         name: 'docx',
-        props: { theme: 'minimal' },
-        metadata: { title: 'safe-only' },
+        props: { theme: 'minimal', metadata: { title: 'safe-only' } },
         children: [
           {
             name: 'paragraph',

--- a/packages/jto/src/server/services/__tests__/generator-filename.test.ts
+++ b/packages/jto/src/server/services/__tests__/generator-filename.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The returned `filename` is built from the document's own title, which is
+ * arbitrary user text. It does not stay inside the process: the generate
+ * response carries it, and `/preview/*-from-json` interpolates it straight
+ * into a `Content-Disposition` header. #292 is what made this reachable —
+ * before it the title was read from a root-level `metadata.title` that was
+ * never part of either schema, so every real document fell back to the
+ * adapter label and no user text ever reached the filename.
+ *
+ * The LibreOffice converter's `sanitizeBaseName` protects only the temp path
+ * it builds for itself, so it never covered this value.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { DocxFormatAdapter } from '@json-to-office/jto-cli';
+import { GeneratorService } from '../generator';
+import { CacheService } from '../cache';
+
+function report(title: unknown) {
+  return {
+    name: 'docx',
+    props: { theme: 'minimal', metadata: { title } },
+    children: [{ name: 'paragraph', props: { text: 'Body.' } }],
+  };
+}
+
+describe('GeneratorService filename construction', () => {
+  let cache: CacheService;
+  let service: GeneratorService;
+
+  beforeEach(() => {
+    cache = new CacheService();
+    service = new GeneratorService(new DocxFormatAdapter(), cache);
+  });
+
+  afterEach(() => {
+    service.destroy();
+    cache.destroy();
+  });
+
+  const filenameFor = async (title: unknown) =>
+    (await service.generate({ jsonDefinition: report(title) })).filename;
+
+  it('keeps an ordinary title readable', async () => {
+    expect(await filenameFor('Annual Report 2026')).toBe(
+      'Annual_Report_2026.docx'
+    );
+  });
+
+  it('strips path separators', async () => {
+    const filename = await filenameFor('../../etc/passwd');
+    expect(filename).not.toMatch(/[/\\]/);
+    expect(filename).toBe('.._.._etc_passwd.docx');
+  });
+
+  it('strips control characters that would split the header', async () => {
+    // The sharp end: a raw CRLF here ends Content-Disposition and starts an
+    // attacker-chosen header.
+    const filename = await filenameFor(
+      'ok\r\nX-Injected: yes\r\n\r\n<script>alert(1)</script>'
+    );
+    expect(filename).not.toMatch(/[\r\n]/);
+    // Nothing that could terminate or re-open the quoted filename either.
+    expect(filename).not.toMatch(/["'<>;]/);
+  });
+
+  it('caps an overlong title', async () => {
+    const filename = await filenameFor('A'.repeat(5000));
+    expect(filename.length).toBeLessThanOrEqual(105);
+    expect(filename.endsWith('.docx')).toBe(true);
+  });
+
+  it('falls back to the adapter label when nothing survives sanitizing', async () => {
+    // "../.." is all separators and dots — sanitizing leaves no name, and
+    // emitting `...docx` would be worse than the label.
+    expect(await filenameFor('../..')).toBe('document.docx');
+    expect(await filenameFor('///')).toBe('document.docx');
+  });
+
+  it('falls back to the adapter label when the title is absent', async () => {
+    expect(await filenameFor(undefined)).toBe('document.docx');
+  });
+
+  it('never sees a non-string title — the schema rejects it first', async () => {
+    // `documentTitle`'s typeof check is the second line; this is the first.
+    // Pinned so a schema loosening shows up here rather than as a surprise
+    // `[object Object].docx`.
+    await expect(
+      service.generate({ jsonDefinition: report(42) })
+    ).rejects.toThrow(/validation failed/i);
+  });
+
+  it('sanitizes on the cache-hit branch too', async () => {
+    // Two filename branches exist — the cached return and the generated one.
+    // A fix applied to only one of them leaves the second render exposed.
+    const definition = report('../../etc/passwd');
+    const first = await service.generate({ jsonDefinition: definition });
+    const second = await service.generate({ jsonDefinition: definition });
+
+    expect(second.cached).toBe(true);
+    expect(second.filename).toBe(first.filename);
+    expect(second.filename).not.toMatch(/[/\\]/);
+  });
+});

--- a/packages/jto/src/server/services/__tests__/generator-renderer-cache.test.ts
+++ b/packages/jto/src/server/services/__tests__/generator-renderer-cache.test.ts
@@ -22,8 +22,7 @@ const UNREADABLE_POLICY = { maxDiagnostics: -1 };
 
 const DOCUMENT = {
   name: 'docx',
-  props: { theme: 'minimal' },
-  metadata: { title: 'renderer-cache' },
+  props: { theme: 'minimal', metadata: { title: 'renderer-cache' } },
   children: [{ name: 'paragraph', props: { text: 'Body.' } }],
 };
 

--- a/packages/jto/src/server/services/__tests__/generator-warnings.test.ts
+++ b/packages/jto/src/server/services/__tests__/generator-warnings.test.ts
@@ -23,8 +23,7 @@ const UNKNOWN_FAMILY = 'Acme Brand Sans';
 function report(props: Record<string, unknown>, title: string) {
   return {
     name: 'docx',
-    props: { theme: 'minimal' },
-    metadata: { title },
+    props: { theme: 'minimal', metadata: { title } },
     children: [{ name: 'paragraph', props: { text: 'Body.', ...props } }],
   };
 }

--- a/packages/jto/src/server/services/__tests__/supplemental-warnings.test.ts
+++ b/packages/jto/src/server/services/__tests__/supplemental-warnings.test.ts
@@ -130,8 +130,7 @@ describe('FONT_OVERRIDE_LOCAL end-to-end', () => {
     const result = await service.generate({
       jsonDefinition: {
         name: 'docx',
-        props: { theme: 'minimal' },
-        metadata: { title: 'override-local' },
+        props: { theme: 'minimal', metadata: { title: 'override-local' } },
         children: [
           {
             name: 'paragraph',

--- a/packages/jto/src/server/services/__tests__/template-media-inliner.test.ts
+++ b/packages/jto/src/server/services/__tests__/template-media-inliner.test.ts
@@ -6,6 +6,10 @@ import { inlineTemplateMedia } from '../template-media-inliner';
 
 const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const PNG_DATA_URL = `data:image/png;base64,${PNG_BYTES.toString('base64')}`;
+const OTF_BYTES = Buffer.from('OTTO-fake-font-bytes');
+const OTF_DATA_URL = `data:font/otf;base64,${OTF_BYTES.toString('base64')}`;
+const TTF_BYTES = Buffer.from([0x00, 0x01, 0x00, 0x00, 0x00]);
+const TTF_DATA_URL = `data:font/ttf;base64,${TTF_BYTES.toString('base64')}`;
 
 let baseDir: string;
 
@@ -15,6 +19,9 @@ beforeAll(async () => {
   await fs.writeFile(path.join(baseDir, 'media', 'logo.png'), PNG_BYTES);
   await fs.writeFile(path.join(baseDir, 'media', 'big.png'), PNG_BYTES);
   await fs.writeFile(path.join(baseDir, 'media', 'notes.txt'), 'not an image');
+  await fs.mkdir(path.join(baseDir, 'fonts'), { recursive: true });
+  await fs.writeFile(path.join(baseDir, 'fonts', 'body.otf'), OTF_BYTES);
+  await fs.writeFile(path.join(baseDir, 'fonts', 'body.ttf'), TTF_BYTES);
 });
 
 afterAll(async () => {
@@ -139,6 +146,106 @@ describe('inlineTemplateMedia', () => {
     expect(result.children[0].props.path).toBe(PNG_DATA_URL);
     // malformed strings pass through for structural validation
     expect(await inlineTemplateMedia('{oops', baseDir)).toBe('{oops');
+  });
+
+  it('rewrites contained kind:file font sources to kind:data', async () => {
+    const doc = {
+      props: {
+        fontRegistry: [
+          {
+            id: 'Body',
+            family: 'Body',
+            sources: [
+              { kind: 'file', path: 'fonts/body.otf', weight: 300 },
+              {
+                kind: 'file',
+                path: 'fonts/body.ttf',
+                weight: 700,
+                italic: true,
+              },
+              { kind: 'google', family: 'Poppins' },
+            ],
+          },
+        ],
+      },
+    };
+    const result = (await inlineTemplateMedia(doc, baseDir)) as any;
+    const [otf, ttf, google] = result.props.fontRegistry[0].sources;
+    expect(otf).toEqual({ kind: 'data', data: OTF_DATA_URL, weight: 300 });
+    expect(ttf).toEqual({
+      kind: 'data',
+      data: TTF_DATA_URL,
+      weight: 700,
+      italic: true,
+    });
+    expect(google).toEqual({ kind: 'google', family: 'Poppins' });
+    // input untouched
+    expect(doc.props.fontRegistry[0].sources[0]).toEqual({
+      kind: 'file',
+      path: 'fonts/body.otf',
+      weight: 300,
+    });
+  });
+
+  it('leaves escaping, absolute, missing, and non-font kind:file paths alone', async () => {
+    const sources = [
+      { kind: 'file', path: '../outside.otf' },
+      { kind: 'file', path: '/etc/fonts/system.otf' },
+      { kind: 'file', path: 'fonts/missing.otf' },
+      { kind: 'file', path: 'media/notes.txt' },
+    ];
+    const doc = {
+      props: { fontRegistry: [{ id: 'X', family: 'X', sources }] },
+    };
+    const result = (await inlineTemplateMedia(doc, baseDir)) as any;
+    expect(result.props.fontRegistry[0].sources).toEqual(sources);
+  });
+
+  it('keeps image and font extension verdicts independent for one file', async () => {
+    // The .otf referenced as an image must not be inlined — and that verdict
+    // must not poison the cache for the font-source reference to the same
+    // file, in either visit order.
+    const doc = {
+      children: [{ name: 'image', props: { path: 'fonts/body.otf' } }],
+      props: {
+        fontRegistry: [
+          {
+            id: 'Body',
+            family: 'Body',
+            sources: [{ kind: 'file', path: 'fonts/body.otf' }],
+          },
+        ],
+      },
+    };
+    const result = (await inlineTemplateMedia(doc, baseDir)) as any;
+    expect(result.children[0].props.path).toBe('fonts/body.otf');
+    expect(result.props.fontRegistry[0].sources[0]).toEqual({
+      kind: 'data',
+      data: OTF_DATA_URL,
+    });
+  });
+
+  it('charges fonts against the shared total budget', async () => {
+    const doc = {
+      props: {
+        fontRegistry: [
+          {
+            id: 'Body',
+            family: 'Body',
+            sources: [
+              { kind: 'file', path: 'fonts/body.otf' },
+              { kind: 'file', path: 'fonts/body.ttf' },
+            ],
+          },
+        ],
+      },
+    };
+    const result = (await inlineTemplateMedia(doc, baseDir, {
+      maxTotalBytes: OTF_BYTES.length,
+    })) as any;
+    const [first, second] = result.props.fontRegistry[0].sources;
+    expect(first).toEqual({ kind: 'data', data: OTF_DATA_URL });
+    expect(second).toEqual({ kind: 'file', path: 'fonts/body.ttf' });
   });
 
   it('reuses cached data for repeated references without double-charging', async () => {

--- a/packages/jto/src/server/services/generator.ts
+++ b/packages/jto/src/server/services/generator.ts
@@ -49,6 +49,22 @@ function toQualityWarnings(
 }
 
 /**
+ * The document's own title, for filenames and logs. docx spells it
+ * `props.metadata.title`, pptx `props.title`. The root-level `metadata.title`
+ * this used to read was never part of either document schema — it survived
+ * only through validation's flip-to-valid rescue, retired in #292 — and the
+ * playground has always written the props spelling, so the filename fell back
+ * to the adapter label for every real document.
+ */
+function documentTitle(config: unknown): string | undefined {
+  const props = (config as { props?: Record<string, unknown> } | undefined)
+    ?.props;
+  const metadata = props?.metadata as { title?: unknown } | undefined;
+  const title = metadata?.title ?? props?.title;
+  return typeof title === 'string' ? title : undefined;
+}
+
+/**
  * Playground-only convenience: scan the document for font names that match
  * a POPULAR_GOOGLE_FONTS family and auto-build `fonts.extraEntries` so the
  * LibreOffice preview stager can materialise the bytes for PDF conversion.
@@ -535,9 +551,9 @@ export class GeneratorService {
     if (!bypassCache && !hasDynamicContent) {
       const cached = this.cacheService.get(cacheKey);
       if (cached) {
-        logger.info('Served from cache', { title: config.metadata?.title });
+        logger.info('Served from cache', { title: documentTitle(config) });
         return {
-          filename: `${config.metadata?.title || this.adapter.label}${this.adapter.extension}`,
+          filename: `${documentTitle(config) || this.adapter.label}${this.adapter.extension}`,
           fileId: Date.now().toString(),
           buffer: cached.buffer,
           // Render warnings ride with bytes. Quality is request policy, so it
@@ -553,7 +569,7 @@ export class GeneratorService {
 
     // Generate — use plugin-aware generator when plugins are loaded
     logger.info(`Generating ${this.adapter.label}`, {
-      title: config.metadata?.title,
+      title: documentTitle(config),
     });
     let buffer: Buffer;
 
@@ -622,7 +638,7 @@ export class GeneratorService {
     );
 
     return {
-      filename: `${config.metadata?.title || this.adapter.label}${this.adapter.extension}`,
+      filename: `${documentTitle(config) || this.adapter.label}${this.adapter.extension}`,
       fileId: Date.now().toString(),
       buffer,
       cached: false,

--- a/packages/jto/src/server/services/generator.ts
+++ b/packages/jto/src/server/services/generator.ts
@@ -64,6 +64,33 @@ function documentTitle(config: unknown): string | undefined {
   return typeof title === 'string' ? title : undefined;
 }
 
+// Long enough for a real title, short enough to stay under the filesystem and
+// header limits once the extension is appended.
+const MAX_FILENAME_BASE = 100;
+
+/**
+ * The title as a filename base. Reading the title from props (above) is what
+ * first put arbitrary user text into `filename` — before #292 the root-level
+ * spelling never matched, so every document fell back to the adapter label.
+ * That filename leaves the process: into the generate response, and into the
+ * `Content-Disposition` of `/preview/*-from-json`, which interpolates it
+ * verbatim. A CR/LF would split that header and a separator would reshape the
+ * path, so both are stripped here, at the point the name is built. The
+ * LibreOffice converter's own `sanitizeBaseName` only ever protected its temp
+ * path, never this value.
+ */
+function documentFilenameBase(config: unknown): string | undefined {
+  const title = documentTitle(config);
+  if (title === undefined) return undefined;
+  const base = title
+    .replace(/[^a-zA-Z0-9._-]/g, '_')
+    .slice(0, MAX_FILENAME_BASE);
+  // A title made only of separators or dots sanitizes down to padding — no
+  // name left to use, so fall back to the adapter label rather than emitting
+  // `...docx`.
+  return /^[._]*$/.test(base) ? undefined : base;
+}
+
 /**
  * Playground-only convenience: scan the document for font names that match
  * a POPULAR_GOOGLE_FONTS family and auto-build `fonts.extraEntries` so the
@@ -553,7 +580,7 @@ export class GeneratorService {
       if (cached) {
         logger.info('Served from cache', { title: documentTitle(config) });
         return {
-          filename: `${documentTitle(config) || this.adapter.label}${this.adapter.extension}`,
+          filename: `${documentFilenameBase(config) || this.adapter.label}${this.adapter.extension}`,
           fileId: Date.now().toString(),
           buffer: cached.buffer,
           // Render warnings ride with bytes. Quality is request policy, so it
@@ -638,7 +665,7 @@ export class GeneratorService {
     );
 
     return {
-      filename: `${documentTitle(config) || this.adapter.label}${this.adapter.extension}`,
+      filename: `${documentFilenameBase(config) || this.adapter.label}${this.adapter.extension}`,
       fileId: Date.now().toString(),
       buffer,
       cached: false,

--- a/packages/jto/src/server/services/template-media-inliner.ts
+++ b/packages/jto/src/server/services/template-media-inliner.ts
@@ -6,12 +6,14 @@ import path from 'node:path';
  * URLs, so bundled templates survive safe-mode outbound-source validation and
  * remote rasterization (which runs on a host without the template's files).
  *
- * Only relative paths that canonicalize inside `baseDir` are inlined; anything
- * else (absolute paths, URLs, data URLs, `..` escapes, missing or oversized
- * files) is left untouched for the outbound-source policy to judge.
+ * Covers image paths and `fontRegistry` `kind:'file'` sources — together the
+ * shapes safe-mode validation rejects as local reads. Only relative paths that
+ * canonicalize inside `baseDir` are inlined; anything else (absolute paths,
+ * URLs, data URLs, `..` escapes, missing or oversized files) is left untouched
+ * for the outbound-source policy to judge.
  */
 
-const MIME_BY_EXTENSION: Record<string, string> = {
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
   '.jpeg': 'image/jpeg',
@@ -21,6 +23,16 @@ const MIME_BY_EXTENSION: Record<string, string> = {
   '.bmp': 'image/bmp',
   '.tiff': 'image/tiff',
   '.tif': 'image/tiff',
+};
+
+// `loadDataFontSource` accepts a base64 data URL and magic-byte checks the
+// payload, so a mislabeled file fails font resolution with a warning instead
+// of slipping past the policy layer.
+const FONT_MIME_BY_EXTENSION: Record<string, string> = {
+  '.ttf': 'font/ttf',
+  '.otf': 'font/otf',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
 };
 
 type JsonRecord = Record<string, unknown>;
@@ -58,8 +70,14 @@ interface InlineState {
 async function toDataUrl(
   source: string,
   baseDir: string,
-  state: InlineState
+  state: InlineState,
+  mimeByExtension: Record<string, string>
 ): Promise<string | null> {
+  // Extension gate first, before the cache: the cached verdict for a path
+  // must not depend on which MIME table asked (an .otf referenced as an image
+  // is not inlineable, but the same file as a font source is).
+  const mime = mimeByExtension[path.extname(source).toLowerCase()];
+  if (!mime) return null;
   // Key the cache by canonical path so equivalent spellings of the same file
   // (`media/logo.png` vs `media/./logo.png`) share one budget charge.
   let cacheKey = source;
@@ -73,18 +91,15 @@ async function toDataUrl(
       resolved === state.baseDirReal ||
       resolved.startsWith(state.baseDirReal + path.sep);
     if (contained) {
-      const mime = MIME_BY_EXTENSION[path.extname(resolved).toLowerCase()];
-      if (mime) {
-        const stat = await fs.stat(resolved);
-        if (
-          stat.isFile() &&
-          stat.size <= state.maxFileBytes &&
-          stat.size <= state.totalBudget
-        ) {
-          const buffer = await fs.readFile(resolved);
-          state.totalBudget -= buffer.length;
-          result = `data:${mime};base64,${buffer.toString('base64')}`;
-        }
+      const stat = await fs.stat(resolved);
+      if (
+        stat.isFile() &&
+        stat.size <= state.maxFileBytes &&
+        stat.size <= state.totalBudget
+      ) {
+        const buffer = await fs.readFile(resolved);
+        state.totalBudget -= buffer.length;
+        result = `data:${mime};base64,${buffer.toString('base64')}`;
       }
     }
   } catch {
@@ -114,6 +129,30 @@ async function visit(
 
   const record = value as JsonRecord;
 
+  // Font sources: { kind: 'file', path } is exactly the shape safe-mode
+  // validation rejects wherever it appears (fontRegistry is the only schema
+  // that uses it). Rewriting to { kind: 'data' } keeps a bundled template
+  // generable over HTTP and carries its fonts to the remote rasterizer.
+  if (
+    record.kind === 'file' &&
+    typeof record.path === 'string' &&
+    isInlineCandidate(record.path)
+  ) {
+    const inlined = await toDataUrl(
+      record.path,
+      baseDir,
+      state,
+      FONT_MIME_BY_EXTENSION
+    );
+    if (inlined !== null) {
+      record.kind = 'data';
+      record.data = inlined;
+      // DataFontSourceSchema is additionalProperties:false — a leftover
+      // `path` would fail structural validation downstream.
+      delete record.path;
+    }
+  }
+
   // Image components: { name: 'image', props: { path } }.
   const componentName =
     typeof record.name === 'string' ? record.name.toLowerCase() : undefined;
@@ -124,7 +163,12 @@ async function visit(
     typeof props.path === 'string' &&
     isInlineCandidate(props.path)
   ) {
-    const inlined = await toDataUrl(props.path, baseDir, state);
+    const inlined = await toDataUrl(
+      props.path,
+      baseDir,
+      state,
+      IMAGE_MIME_BY_EXTENSION
+    );
     if (inlined !== null) props.path = inlined;
   }
 
@@ -134,7 +178,12 @@ async function visit(
     typeof record.path === 'string' &&
     isInlineCandidate(record.path)
   ) {
-    const inlined = await toDataUrl(record.path, baseDir, state);
+    const inlined = await toDataUrl(
+      record.path,
+      baseDir,
+      state,
+      IMAGE_MIME_BY_EXTENSION
+    );
     if (inlined !== null) record.path = inlined;
   }
 

--- a/packages/shared-docx/src/__tests__/document-validator.test.ts
+++ b/packages/shared-docx/src/__tests__/document-validator.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { validate } from '../validation/unified';
-import { isValidDocument } from '../validation/unified/document-validator';
+import { validate, validateStrict } from '../validation/unified';
+import {
+  isValidDocument,
+  validateDocument,
+} from '../validation/unified/document-validator';
 
 describe('validateJsonDocument: docx root recognition', () => {
   it('accepts a minimal docx document with a heading child', () => {
@@ -698,5 +701,147 @@ describe('paragraph boldColor accepts the same values as font.color', () => {
     expect(
       (result.errors ?? []).some((e) => e.path.includes('boldColor'))
     ).toBe(true);
+  });
+});
+
+describe('stage-1 rejection with an empty deep walk fails closed (#292)', () => {
+  const base = {
+    name: 'docx',
+    props: { theme: 'minimal' },
+    children: [
+      {
+        name: 'section',
+        children: [{ name: 'paragraph', props: { text: 'hi' } }],
+      },
+    ],
+  };
+
+  it('rejects an unknown key next to name/props at the root', () => {
+    const doc = { ...base, bogus: 1 };
+    const lenient = validate.jsonDocument(JSON.stringify(doc));
+    const strict = validateStrict.jsonDocument(JSON.stringify(doc));
+
+    expect(lenient.valid).toBe(false);
+    expect(strict.valid).toBe(false);
+    expect((lenient.errors ?? []).length).toBeGreaterThan(0);
+  });
+
+  it('rejects an unknown sibling key on a nested component', () => {
+    const doc = {
+      ...base,
+      children: [
+        {
+          name: 'section',
+          children: [{ name: 'paragraph', props: { text: 'hi' }, bogus: 1 }],
+        },
+      ],
+    };
+
+    expect(validate.jsonDocument(JSON.stringify(doc)).valid).toBe(false);
+    expect(validateStrict.jsonDocument(JSON.stringify(doc)).valid).toBe(false);
+  });
+
+  it('still accepts unknown keys when the caller opts into allowUnknownFields', () => {
+    const sibling = { ...base, bogus: 1 };
+    const inProps = {
+      ...base,
+      children: [
+        {
+          name: 'section',
+          children: [{ name: 'paragraph', props: { text: 'hi', bogus: 1 } }],
+        },
+      ],
+    };
+
+    expect(validateDocument(sibling, { allowUnknownFields: true }).valid).toBe(
+      true
+    );
+    expect(validateDocument(inProps, { allowUnknownFields: true }).valid).toBe(
+      true
+    );
+  });
+
+  it('still accepts a document that uses a registered plugin component', () => {
+    const doc = {
+      ...base,
+      children: [
+        {
+          name: 'section',
+          children: [{ name: 'my-widget', props: { anything: true } }],
+        },
+      ],
+    };
+
+    const result = validateDocument(doc, {
+      knownCustomNames: new Set(['my-widget']),
+    });
+    expect(result.errors ?? []).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a defective document even when custom names are registered but unused', () => {
+    const doc = { ...base, bogus: 1 };
+
+    const result = validateDocument(doc, {
+      knownCustomNames: new Set(['my-widget']),
+    });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('wrong-typed sibling keys fail everywhere the schema types them', () => {
+  // `enabled`/`id` are known sibling keys, so a key-presence check passes
+  // them; only their TYPE is wrong. The live schema rejects the value, and
+  // the containment-relaxed rescue gate must not re-admit it — it once did
+  // for embedded regions, because the gate was built without the recursive
+  // ref and fell back to the static section schema's Type.Any() regions.
+  const withHeaderParagraph = (extra: Record<string, unknown>) => ({
+    name: 'docx',
+    props: { theme: 'minimal' },
+    children: [
+      {
+        name: 'section',
+        props: {
+          header: [{ name: 'paragraph', props: { text: 'x' }, ...extra }],
+        },
+        children: [{ name: 'paragraph', props: { text: 'body' } }],
+      },
+    ],
+  });
+
+  it('rejects a non-boolean enabled on a paragraph inside a section header', () => {
+    const result = validate.jsonDocument(
+      JSON.stringify(withHeaderParagraph({ enabled: 'yes' }))
+    );
+    expect(result.valid).toBe(false);
+    expect((result.errors ?? []).some((e) => e.path.includes('/enabled'))).toBe(
+      true
+    );
+  });
+
+  it('rejects a non-string id on a nested child', () => {
+    const doc = {
+      name: 'docx',
+      props: { theme: 'minimal' },
+      children: [
+        {
+          name: 'section',
+          children: [{ name: 'paragraph', props: { text: 'x' }, id: 7 }],
+        },
+      ],
+    };
+    const result = validate.jsonDocument(JSON.stringify(doc));
+    expect(result.valid).toBe(false);
+    expect((result.errors ?? []).some((e) => e.path.includes('/id'))).toBe(
+      true
+    );
+  });
+
+  it('still accepts well-typed sibling keys in a header', () => {
+    const result = validate.jsonDocument(
+      JSON.stringify(withHeaderParagraph({ enabled: true, id: 'p1' }))
+    );
+    expect(result.errors ?? []).toEqual([]);
+    expect(result.valid).toBe(true);
   });
 });

--- a/packages/shared-docx/src/__tests__/embedded-component-regions.test.ts
+++ b/packages/shared-docx/src/__tests__/embedded-component-regions.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The deep-validation walk visits the embedded-component positions declared on
+ * `STANDARD_COMPONENTS_REGISTRY` entries (`embeddedComponents`). The live
+ * whole-document schema wires the same positions through each entry's
+ * `createPropsSchema` factory. Nothing ties the two together structurally, so
+ * this test does: it probes every factory with a marker schema, records where
+ * the marker lands, and asserts the declaration matches exactly.
+ *
+ * A factory position without a declaration is a walk blind spot (issue #292's
+ * fail-open class); a declaration without a factory position is a walk over
+ * ground the schema does not own. Both fail here.
+ */
+import { describe, it, expect } from 'vitest';
+import { Type, type TSchema } from '@sinclair/typebox';
+import { STANDARD_COMPONENTS_REGISTRY } from '../schemas/component-registry';
+
+/** A discovered embedding position: where the marker landed in the factory. */
+interface DiscoveredRegion {
+  path: readonly string[];
+  arity: 'component' | 'component-array';
+}
+
+const MARKER = Type.Object({}, { $id: '__embedded_component_marker__' });
+
+/**
+ * Walk a props schema for the marker, recording each position. `*` stands for
+ * every element of an array. A marker directly under an array's `items` is the
+ * array-of-components arity, anchored at the array itself.
+ */
+function discoverRegions(schema: TSchema): DiscoveredRegion[] {
+  const found: DiscoveredRegion[] = [];
+  const seen = new Set<TSchema>();
+
+  const visit = (node: TSchema, path: readonly string[]): void => {
+    if (!node || typeof node !== 'object') return;
+    if (node === MARKER) {
+      found.push({ path, arity: 'component' });
+      return;
+    }
+    if (seen.has(node)) return;
+    seen.add(node);
+
+    const union = (node as { anyOf?: TSchema[] }).anyOf;
+    if (Array.isArray(union)) {
+      for (const branch of union) visit(branch, path);
+    }
+
+    const items = (node as { items?: TSchema }).items;
+    if (items) {
+      if (items === MARKER) {
+        found.push({ path, arity: 'component-array' });
+      } else {
+        visit(items, [...path, '*']);
+      }
+    }
+
+    const properties = (node as { properties?: Record<string, TSchema> })
+      .properties;
+    if (properties) {
+      for (const [key, child] of Object.entries(properties)) {
+        visit(child, [...path, key]);
+      }
+    }
+  };
+
+  visit(schema, []);
+  return found;
+}
+
+const sortKey = (r: DiscoveredRegion) => r.path.join('/');
+
+describe('embeddedComponents declarations match the live schema factories', () => {
+  it.each(STANDARD_COMPONENTS_REGISTRY.map((c) => [c.name, c] as const))(
+    '%s',
+    (_name, component) => {
+      const discovered = component.createPropsSchema
+        ? discoverRegions(component.createPropsSchema(MARKER))
+        : [];
+
+      const declared = (component.embeddedComponents ?? []).map((r) => ({
+        path: r.path,
+        arity: r.arity,
+      }));
+
+      expect(
+        [...declared].sort((a, b) => sortKey(a).localeCompare(sortKey(b)))
+      ).toEqual(
+        [...discovered].sort((a, b) => sortKey(a).localeCompare(sortKey(b)))
+      );
+    }
+  );
+
+  it('covers the two factories that exist today (sanity)', () => {
+    const withFactories = STANDARD_COMPONENTS_REGISTRY.filter(
+      (c) => c.createPropsSchema
+    ).map((c) => c.name);
+    expect(withFactories.sort()).toEqual(['section', 'table']);
+  });
+});

--- a/packages/shared-docx/src/schemas/component-registry.ts
+++ b/packages/shared-docx/src/schemas/component-registry.ts
@@ -40,6 +40,37 @@ import {
 } from './renderer';
 
 /**
+ * A position under a component's `props` where full component definitions are
+ * embedded outside the shared `children` array.
+ *
+ * Declaring these here is what keeps the deep-validation walk aligned with the
+ * live document schema: the same entry's `createPropsSchema` wires a recursive
+ * component ref into these positions, and the walk visits exactly what is
+ * declared. `embedded-component-regions.test.ts` probes each factory with a
+ * marker schema and fails when a declaration and the factory disagree, so a
+ * new embedded position cannot silently become a walk blind spot (#292).
+ */
+export interface EmbeddedComponentRegion {
+  /** Path segments under `props`; `'*'` means every element of an array. */
+  path: readonly string[];
+  /**
+   * `'component'` — the position holds one component definition;
+   * `'component-array'` — it holds an array of them. Values of another legal
+   * shape at the position (a string cell content, `'linkToPrevious'`) are
+   * simply not walked.
+   */
+  arity: 'component' | 'component-array';
+  /**
+   * Whether the walk reports malformed entries (a non-object, a missing
+   * `name`) at this position. True where the static props schema types the
+   * position loosely (`Type.Any()` — the walk is its only structural checker);
+   * false where the props schema already validates structure, so the walk only
+   * adds per-component prop errors and must not double-report.
+   */
+  reportStructure: boolean;
+}
+
+/**
  * Component definition with metadata
  */
 export interface StandardComponentDefinition {
@@ -62,6 +93,13 @@ export interface StandardComponentDefinition {
    * available, used instead of the static `propsSchema`.
    */
   createPropsSchema?: (recursiveRef: TSchema) => TSchema;
+  /**
+   * Where `createPropsSchema` embeds component definitions inside `props`.
+   * Drives the deep-validation walk; must match the factory (enforced by
+   * `embedded-component-regions.test.ts`). Omit when the component embeds
+   * none.
+   */
+  embeddedComponents?: readonly EmbeddedComponentRegion[];
   /**
    * The renderers that can draw this component. Omitted means all of them.
    *
@@ -114,6 +152,13 @@ export const STANDARD_COMPONENTS_REGISTRY: readonly StandardComponentDefinition[
       name: 'section',
       propsSchema: SectionPropsSchema,
       createPropsSchema: createSectionPropsSchema,
+      embeddedComponents: [
+        // The static schema types both regions as an array of Type.Any() (or
+        // the 'linkToPrevious' literal), so the walk is their only structural
+        // checker — report malformed entries too.
+        { path: ['header'], arity: 'component-array', reportStructure: true },
+        { path: ['footer'], arity: 'component-array', reportStructure: true },
+      ],
       hasChildren: true,
       allowedChildren: [
         'heading',
@@ -203,6 +248,22 @@ export const STANDARD_COMPONENTS_REGISTRY: readonly StandardComponentDefinition[
       name: 'table',
       propsSchema: TablePropsSchema,
       createPropsSchema: createTablePropsSchema,
+      embeddedComponents: [
+        // Cell content is `string | component`. The table's own props schema
+        // already validates the cell structure, so the walk only adds the
+        // per-component prop errors the loose static content ref misses —
+        // reporting structure here would double-report.
+        {
+          path: ['columns', '*', 'header', 'content'],
+          arity: 'component',
+          reportStructure: false,
+        },
+        {
+          path: ['columns', '*', 'cells', '*', 'content'],
+          arity: 'component',
+          reportStructure: false,
+        },
+      ],
       hasChildren: false,
       category: 'content',
       description:

--- a/packages/shared-docx/src/validation/unified/deep-validator.ts
+++ b/packages/shared-docx/src/validation/unified/deep-validator.ts
@@ -18,12 +18,93 @@ const COMPONENT_SCHEMAS: Record<string, TSchema> = Object.fromEntries([
   ['custom', CustomComponentDefinitionSchema],
 ]);
 
+// Where each component embeds full component definitions inside its props
+// (section header/footer, table cell content, …), sourced from the registry so
+// the walk covers exactly what each entry's `createPropsSchema` wires into the
+// live document schema — the declaration and the factory are pinned to each
+// other by embedded-component-regions.test.ts (#292).
+const EMBEDDED_REGIONS = new Map(
+  STANDARD_COMPONENTS_REGISTRY.filter(
+    (c) => (c.embeddedComponents?.length ?? 0) > 0
+  ).map((c) => [c.name, c.embeddedComponents!])
+);
+
 // Root component names that may appear at the top of a document.
 const ROOT_COMPONENT_NAMES = new Set(
   STANDARD_COMPONENTS_REGISTRY.filter((c) =>
     Boolean(c.special?.hasSchemaField)
   ).map((c) => c.name)
 );
+
+// The sibling keys legal NEXT TO `name`/`props` on each component node,
+// mirroring what createComponentSchemaObject puts on the whole-document
+// schema. Per-component props checks never see these positions, so without
+// this list a junk key beside `props` is invisible to the walk and used to
+// fail only via the generic fail-closed net (#292).
+const ALLOWED_SIBLING_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map(
+  STANDARD_COMPONENTS_REGISTRY.map((c) => [
+    c.name,
+    new Set([
+      'name',
+      'id',
+      'enabled',
+      'props',
+      ...(c.hasChildren ? ['children'] : []),
+      ...(c.special?.hasSchemaField ? ['$schema', 'renderer'] : []),
+    ]),
+  ])
+);
+
+// What each legal sibling key must hold, per the whole-document schema.
+// `name` and `children` are typed by their own dedicated checks.
+const SIBLING_KEY_TYPES: Record<string, 'string' | 'boolean'> = {
+  id: 'string',
+  enabled: 'boolean',
+  $schema: 'string',
+  renderer: 'string',
+};
+
+/**
+ * Report sibling-key faults on a component node: keys the whole-document
+ * schema does not define, and known keys holding a wrong-typed value (an
+ * `enabled: "yes"` — key presence alone would pass it). Unknown keys are
+ * skipped under `allowUnknownFields`; names outside the registry are skipped
+ * entirely (unknown components and the legacy `custom` shape are reported
+ * through other channels).
+ */
+function collectSiblingKeyErrors(
+  node: Record<string, unknown>,
+  path: string,
+  opts: DeepValidateOptions,
+  errors: ValidationError[]
+): void {
+  const allowed =
+    typeof node.name === 'string'
+      ? ALLOWED_SIBLING_KEYS.get(node.name)
+      : undefined;
+  if (!allowed) return;
+  for (const key of Object.keys(node)) {
+    if (!allowed.has(key)) {
+      if (opts.allowUnknownFields) continue;
+      errors.push({
+        path: `${path}/${key}`,
+        message: `Unknown key "${key}" on component "${node.name}". Allowed keys: ${[
+          ...allowed,
+        ].join(', ')}.`,
+        code: 'unknown_key',
+      });
+      continue;
+    }
+    const expected = SIBLING_KEY_TYPES[key];
+    if (expected && typeof node[key] !== expected) {
+      errors.push({
+        path: `${path}/${key}`,
+        message: `Key "${key}" on component "${node.name}" must be a ${expected}.`,
+        code: 'invalid_type',
+      });
+    }
+  }
+}
 
 /**
  * Options that tune deep validation.
@@ -338,6 +419,10 @@ export function deepValidateDocument(
     });
   }
 
+  // Junk keys next to the root's name/props/children are outside every
+  // per-component props check; report them here.
+  collectSiblingKeyErrors(data, '', opts, allErrors);
+
   // Validate props section when the key is present so explicit `null` (or any
   // falsy non-object) is checked against the component's schema instead of
   // silently passing.
@@ -393,16 +478,13 @@ export function deepValidateDocument(
  *    `section`, `columns` and `text-box` (added by the component registry), so
  *    a bad prop inside a `text-box` or `columns` child is caught however deeply
  *    it is nested; and
- *  - the `header` / `footer` paragraph regions under `props` — typed only
- *    loosely on the section schema (an array of `Type.Any()`, or the
- *    `'linkToPrevious'` literal, which is skipped), so their entries are not
- *    deep-checked by the parent's per-component validation.
+ *  - the embedded-component regions each registry entry declares
+ *    (`embeddedComponents`: section `header`/`footer`, table cell content) —
+ *    positions the static per-component props schemas type loosely, so their
+ *    entries are not deep-checked by the parent's per-component validation.
  *
  * The node's own props are NOT validated here — the caller validates the root
- * props, and every entry is validated as it is visited. `table` and `list`
- * nest their components inside their own recursive props schemas, so those are
- * already covered by `validateComponentProps` and are intentionally not
- * re-walked here.
+ * props, and every entry is validated as it is visited.
  */
 function walkComponentTree(
   node: any,
@@ -452,6 +534,9 @@ function walkComponentTree(
     // nor misreported as unknown.
     if (opts.knownCustomNames?.has(child.name)) return;
 
+    // Junk keys next to name/props are outside the props check below.
+    collectSiblingKeyErrors(child, childPath, opts, errors);
+
     // Validate props against the component's schema. When props is omitted,
     // validate an empty object so the schema decides whether props are
     // required (e.g. `section` needs none; `heading` requires text+level).
@@ -478,45 +563,39 @@ function walkComponentTree(
     walkComponentTree(child, childPath, opts, errors);
   };
 
-  // header/footer entries are validated strictly: the static section schema
-  // types them as `Type.Any()`, so the editor's whole-tree schema (where they
-  // resolve to the component union) is stricter than the per-component check —
-  // the walk closes that gap, flagging non-component entries too. A bare
-  // `'linkToPrevious'` value is not an array, so it is skipped here.
-  for (const region of ['header', 'footer'] as const) {
-    const entries = node.props?.[region];
-    if (Array.isArray(entries)) {
-      entries.forEach((child: any, i: number) =>
-        validateEntry(child, `${path}/props/${region}/${i}`, true)
+  // Visit every embedded-component region this component declares in the
+  // registry. A value of another legal shape at the position (a string cell
+  // content, a `'linkToPrevious'` header) simply fails the arity guard and is
+  // not walked.
+  const regions =
+    typeof node.name === 'string' ? EMBEDDED_REGIONS.get(node.name) : undefined;
+  if (regions && node.props && typeof node.props === 'object') {
+    for (const region of regions) {
+      resolveRegionValues(
+        node.props,
+        region.path,
+        `${path}/props`,
+        (value, valuePath) => {
+          if (region.arity === 'component-array') {
+            if (Array.isArray(value)) {
+              value.forEach((child: any, i: number) =>
+                validateEntry(
+                  child,
+                  `${valuePath}/${i}`,
+                  region.reportStructure
+                )
+              );
+            }
+          } else if (
+            value &&
+            typeof value === 'object' &&
+            !Array.isArray(value)
+          ) {
+            validateEntry(value, valuePath, region.reportStructure);
+          }
+        }
       );
     }
-  }
-
-  // `table` nests its cell content under `props` (not the shared `children`
-  // field), and the static table schema types that content loosely — the
-  // cell-content ref accepts any props object, just like the `Type.Any()`
-  // header/footer above. So a bad prop deep in a cell (e.g. `font.size` over the
-  // cap) slips past the per-component table check; walk each content component
-  // so its props are validated against the real schema. Structural problems
-  // with a cell are already reported by the table's own props validation, hence
-  // the lenient (`false`) entry check to avoid double-reporting.
-  if (node.name === 'table' && Array.isArray(node.props?.columns)) {
-    node.props.columns.forEach((col: any, c: number) => {
-      if (!col || typeof col !== 'object') return;
-      const base = `${path}/props/columns/${c}`;
-      const headerContent = col.header?.content;
-      if (headerContent && typeof headerContent === 'object') {
-        validateEntry(headerContent, `${base}/header/content`, false);
-      }
-      if (Array.isArray(col.cells)) {
-        col.cells.forEach((cell: any, r: number) => {
-          const content = cell?.content;
-          if (content && typeof content === 'object') {
-            validateEntry(content, `${base}/cells/${r}/content`, false);
-          }
-        });
-      }
-    });
   }
 
   if (Array.isArray(node.children)) {
@@ -537,6 +616,37 @@ function walkComponentTree(
       code: 'invalid_type',
     });
   }
+}
+
+/**
+ * Resolve an embedded-region path over a props value and call `visit` with
+ * each terminal value. Fixed segments descend into objects; `'*'` fans out
+ * over every element of an array. A segment that does not resolve (missing
+ * key, `'*'` over a non-array, descent into a non-object) ends that branch
+ * silently — the shape is either legal (an optional region) or already
+ * reported by the owning component's props validation.
+ */
+function resolveRegionValues(
+  value: any,
+  segments: readonly string[],
+  path: string,
+  visit: (value: any, path: string) => void
+): void {
+  if (segments.length === 0) {
+    visit(value, path);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+
+  const [head, ...rest] = segments;
+  if (head === '*') {
+    if (!Array.isArray(value)) return;
+    value.forEach((item, i) =>
+      resolveRegionValues(item, rest, `${path}/${i}`, visit)
+    );
+    return;
+  }
+  resolveRegionValues(value[head!], rest, `${path}/${head}`, visit);
 }
 
 /**

--- a/packages/shared-docx/src/validation/unified/document-validator.ts
+++ b/packages/shared-docx/src/validation/unified/document-validator.ts
@@ -3,11 +3,16 @@
  * Single source of truth for all document validation
  */
 
-import type { Static } from '@sinclair/typebox';
+import { Type, type Static, type TSchema } from '@sinclair/typebox';
+import { Value } from '@sinclair/typebox/value';
 import {
   ComponentDefinitionSchema,
   StandardComponentDefinitionSchema,
 } from '../../schemas/components';
+import {
+  createComponentSchemaObject,
+  STANDARD_COMPONENTS_REGISTRY,
+} from '../../schemas/component-registry';
 import { extractStandardComponentNames } from '@json-to-office/shared';
 import {
   comprehensiveValidateDocument,
@@ -78,6 +83,145 @@ function collectSemanticConflicts(document: unknown): ValidationError[] {
   return SEMANTIC_COLLECTORS.flatMap(({ collect }) => collect(document));
 }
 
+/** True when any node anywhere in the tree is a registered plugin component. */
+function referencesCustomComponent(node: unknown, names: Set<string>): boolean {
+  if (Array.isArray(node)) {
+    return node.some((item) => referencesCustomComponent(item, names));
+  }
+  if (!node || typeof node !== 'object') return false;
+  const record = node as Record<string, unknown>;
+  if (typeof record.name === 'string' && names.has(record.name)) return true;
+  return Object.values(record).some((value) =>
+    referencesCustomComponent(value, names)
+  );
+}
+
+/**
+ * The whole-document schema with every container's children relaxed to the
+ * full component union — and ONLY the children.
+ *
+ * Stage 1 narrows each container to its registry `allowedChildren` (docx →
+ * section only, …) as authoring guidance, but the pipeline accepts and renders
+ * looser nesting — a heading directly under the root is a pinned behavior. A
+ * document that fails stage 1 but passes this schema failed on containment
+ * alone.
+ *
+ * The recursive ref is passed as BOTH the children union and the props
+ * factories' `selfRef`, so embedded regions (section header/footer, table
+ * cell content) keep their live component typing here. Passing it only as
+ * children once left those factories on the static schemas, whose regions are
+ * `Type.Any()` — the gate then also relaxed embedded-region typing and
+ * re-admitted a wrong-typed sibling key inside a header. Built lazily: only
+ * the empty-walk path below ever needs it.
+ */
+let containmentRelaxedSchema: TSchema | undefined;
+function getContainmentRelaxedSchema(): TSchema {
+  containmentRelaxedSchema ??= Type.Recursive((This) =>
+    Type.Union(
+      STANDARD_COMPONENTS_REGISTRY.map((component) =>
+        createComponentSchemaObject(component, This, This)
+      )
+    )
+  );
+  return containmentRelaxedSchema;
+}
+
+/**
+ * Decide a document that failed stage 1 (the whole-document TypeBox check)
+ * while the deep walk found nothing actionable.
+ *
+ * Stage 1 has exactly three known false-reject classes, each handled by one
+ * gate below:
+ *
+ *  - `allowUnknownFields` — the whole-document schema is
+ *    additionalProperties:false throughout, so the unknown keys the caller
+ *    asked to tolerate always fail it. The deep walk has already re-checked
+ *    every component with unknown props stripped, so its empty result is the
+ *    leniency working as designed. Residual risk, documented: under this
+ *    option a walk blind spot is still invisible — the caller opted into
+ *    unknown content being ignored.
+ *  - registered plugin components (`knownCustomNames`) — the static document
+ *    schema has no plugin branch, so a document that uses one always fails
+ *    stage 1. The walk skipped those nodes for the plugin layer to validate
+ *    version-aware. Applies only when the document actually uses a registered
+ *    name; registering plugins must not loosen validation of documents that
+ *    never mention them. Residual risk, documented: in a document that does
+ *    use one, leniency and a walk blind spot cannot be told apart.
+ *  - `allowedChildren` containment — stage 1 narrows container children as
+ *    authoring guidance, but the pipeline accepts looser nesting (a heading
+ *    directly under the root renders fine, and tests pin it). This gate is
+ *    precise: the document must pass the containment-relaxed whole-document
+ *    schema, so junk that stage 1 rejected for any other reason still fails.
+ *
+ * Otherwise the empty walk means a walk blind spot, and the document fails
+ * CLOSED, keeping stage 1's own generic error. Historically this flipped to
+ * valid instead (938bdda, when stage 1's false rejects were the rule), which
+ * silently accepted invalid documents — e.g. an unknown key next to
+ * `name`/`props`, a position no per-component props check ever sees (#292).
+ */
+function resolveEmptyWalk(
+  document: unknown,
+  stageOneErrors: ValidationError[],
+  options?: ValidationOptions
+): { valid: boolean; errors: ValidationError[] } {
+  if (
+    options?.allowUnknownFields === true ||
+    (options?.knownCustomNames !== undefined &&
+      options.knownCustomNames.size > 0 &&
+      referencesCustomComponent(document, options.knownCustomNames)) ||
+    Value.Check(getContainmentRelaxedSchema(), document)
+  ) {
+    return { valid: true, errors: [] };
+  }
+
+  const errors =
+    stageOneErrors.length > 0
+      ? stageOneErrors
+      : [
+          {
+            path: 'root',
+            message: "Document does not match the 'docx' document schema.",
+            code: 'invalid_document',
+          },
+        ];
+  return {
+    valid: false,
+    errors: [
+      ...errors,
+      {
+        path: 'root',
+        message:
+          'The document was rejected by the whole-document schema, but deep validation ' +
+          'could not localize the fault. Common causes: an unknown key next to "name", ' +
+          '"props" or "children" on some component, or a value at a position the ' +
+          'schema does not declare.',
+        code: 'unlocalized_schema_error',
+      },
+    ],
+  };
+}
+
+/**
+ * Stage 2 for a document stage 1 rejected: deep-walk it for path-addressed
+ * errors; when the walk comes back empty, let resolveEmptyWalk decide between
+ * the audited leniencies and failing closed. Shared by both entry points
+ * below so the two cannot drift.
+ */
+function deepValidateRejected(
+  document: unknown,
+  stageOneErrors: ValidationError[],
+  options?: ValidationOptions
+): { valid: boolean; errors: ValidationError[] } {
+  const errors = comprehensiveValidateDocument(document, stageOneErrors, {
+    allowUnknownFields: options?.allowUnknownFields,
+    knownCustomNames: options?.knownCustomNames,
+  });
+  if (errors.length === 0) {
+    return resolveEmptyWalk(document, stageOneErrors, options);
+  }
+  return { valid: false, errors };
+}
+
 /**
  * Validate a document/report component definition
  */
@@ -95,15 +239,11 @@ export function validateDocument(
   let finalErrors = result.errors || [];
   let finalValid = result.valid;
   if (!result.valid && data) {
-    finalErrors = comprehensiveValidateDocument(data, result.errors, {
-      allowUnknownFields: options?.allowUnknownFields,
-      knownCustomNames: options?.knownCustomNames,
-    });
-    // If TypeBox's union check produced only generic catch-all errors and the
-    // deep validator finds nothing actionable, treat the document as valid.
-    if (finalErrors.length === 0) {
-      finalValid = true;
-    }
+    ({ valid: finalValid, errors: finalErrors } = deepValidateRejected(
+      data,
+      result.errors || [],
+      options
+    ));
   }
 
   // Semantic rules run on every document, valid or not: they describe payloads
@@ -163,13 +303,11 @@ export function validateJsonDocument(
   let finalErrors = result.errors || [];
   let finalValid = result.valid;
   if (!result.valid && result.parsed) {
-    finalErrors = comprehensiveValidateDocument(result.parsed, result.errors, {
-      allowUnknownFields: options?.allowUnknownFields,
-      knownCustomNames: options?.knownCustomNames,
-    });
-    if (finalErrors.length === 0) {
-      finalValid = true;
-    }
+    ({ valid: finalValid, errors: finalErrors } = deepValidateRejected(
+      result.parsed,
+      result.errors || [],
+      options
+    ));
   }
 
   // Semantic rules run on every document, valid or not: they describe payloads

--- a/packages/shared-pptx/src/__tests__/document-validator.test.ts
+++ b/packages/shared-pptx/src/__tests__/document-validator.test.ts
@@ -501,3 +501,91 @@ describe('theme validation', () => {
     expect(result.errors.length).toBeGreaterThan(0);
   });
 });
+
+describe('wrong-typed sibling keys are rejected (#292 parity)', () => {
+  // Key PRESENCE next to name/props has always been checked here, but the
+  // value's type was not: `enabled: "yes"` or `id: 7` passed the walk (the
+  // only validator — there is no whole-document stage to catch it) and
+  // rendered, while the published schema types both fields. These pin the
+  // walk to the published schema's sibling typing.
+  const text = { name: 'text', props: { text: 'hi', x: 1, y: 1 } };
+
+  it('rejects a non-boolean enabled on the root', () => {
+    const result = validate.document({
+      ...deck([slide([text])]),
+      enabled: 'yes',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.path === '/enabled')).toBe(true);
+  });
+
+  it('rejects a non-boolean enabled on a nested component', () => {
+    const result = validate.document(
+      deck([slide([{ ...text, enabled: 'yes' }])])
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.path === '/children/0/children/0/enabled')
+    ).toBe(true);
+  });
+
+  it('rejects a non-string id on a nested component', () => {
+    const result = validate.document(deck([slide([{ ...text, id: 7 }])]));
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.path === '/children/0/children/0/id')
+    ).toBe(true);
+  });
+
+  it('rejects a non-string $schema on the root', () => {
+    const result = validate.document({
+      ...deck([slide([text])]),
+      $schema: 123,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.path === '/$schema')).toBe(true);
+  });
+
+  it('rejects a wrong-typed enabled inside a placeholder value', () => {
+    const result = validate.document(
+      deck([
+        slide([], { placeholders: { title: { ...text, enabled: 'yes' } } }),
+      ])
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) => e.path === '/children/0/props/placeholders/title/enabled'
+      )
+    ).toBe(true);
+  });
+
+  it('rejects a non-string version on a plugin component', () => {
+    const result = validatePresentationDocument(
+      deck([slide([{ name: 'my-widget', props: {}, version: 2 }])]),
+      { knownCustomNames: new Set(['my-widget']) }
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.path === '/children/0/children/0/version')
+    ).toBe(true);
+  });
+
+  it('still accepts well-typed sibling keys everywhere', () => {
+    const doc = {
+      ...deck([
+        {
+          ...slide([{ ...text, id: 't1', enabled: true }]),
+          id: 's1',
+          enabled: true,
+        },
+      ]),
+      $schema: 'https://example.com/schema.json',
+      enabled: true,
+      id: 'root',
+    };
+    const result = validateStrict.document(doc);
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/shared-pptx/src/validation/unified/deep-validator.ts
+++ b/packages/shared-pptx/src/validation/unified/deep-validator.ts
@@ -49,6 +49,49 @@ const CUSTOM_COMPONENT_OBJECT_KEYS = new Set([
 const ROOT_OBJECT_KEYS = new Set([...COMPONENT_OBJECT_KEYS, '$schema']);
 ROOT_OBJECT_KEYS.add('renderer');
 
+// What each legal component-object key must hold, per the published schema.
+// `name`, `props` and `children` are typed by their own dedicated checks, and
+// `renderer` by the renderer collector (whose enum message beats a bare type
+// check). Without this, key PRESENCE passed the walk while the value's type
+// went unchecked — `enabled: "yes"` validated and rendered (#292 parity).
+const SIBLING_KEY_TYPES: Record<string, 'string' | 'boolean'> = {
+  id: 'string',
+  enabled: 'boolean',
+  $schema: 'string',
+  version: 'string',
+};
+
+/**
+ * Report component-object key faults at `path`: keys outside `allowedKeys`,
+ * and allowed keys holding a wrong-typed value.
+ */
+function collectSiblingKeyErrors(
+  node: Record<string, unknown>,
+  path: string,
+  allowedKeys: ReadonlySet<string>,
+  label: string,
+  errors: ValidationError[]
+): void {
+  for (const key of Object.keys(node)) {
+    if (!allowedKeys.has(key)) {
+      errors.push({
+        path: `${path}/${key}`,
+        message: `Unknown field "${key}" on ${label}`,
+        code: 'unknown_field',
+      });
+      continue;
+    }
+    const expected = SIBLING_KEY_TYPES[key];
+    if (expected && typeof node[key] !== expected) {
+      errors.push({
+        path: `${path}/${key}`,
+        message: `Field "${key}" on ${label} must be a ${expected}`,
+        code: 'invalid_type',
+      });
+    }
+  }
+}
+
 /**
  * Options that tune deep validation.
  *
@@ -100,15 +143,13 @@ export function deepValidatePresentation(
     });
   }
 
-  for (const key of Object.keys(data)) {
-    if (!ROOT_OBJECT_KEYS.has(key)) {
-      allErrors.push({
-        path: `/${key}`,
-        message: `Unknown field "${key}" on the root component`,
-        code: 'unknown_field',
-      });
-    }
-  }
+  collectSiblingKeyErrors(
+    data,
+    '',
+    ROOT_OBJECT_KEYS,
+    'the root component',
+    allErrors
+  );
 
   // Validate props when the key is present so explicit `null` (or any falsy
   // non-object) is checked against the component's schema instead of silently
@@ -200,15 +241,13 @@ function walkComponentTree(
       ? CUSTOM_COMPONENT_OBJECT_KEYS
       : COMPONENT_OBJECT_KEYS;
 
-    for (const key of Object.keys(child)) {
-      if (!allowedObjectKeys.has(key)) {
-        errors.push({
-          path: `${childPath}/${key}`,
-          message: `Unknown field "${key}" on component "${child.name}"`,
-          code: 'unknown_field',
-        });
-      }
-    }
+    collectSiblingKeyErrors(
+      child,
+      childPath,
+      allowedObjectKeys,
+      `component "${child.name}"`,
+      errors
+    );
 
     if (isCustomComponent) {
       // What the props *hold* is the plugin layer's call — it alone knows the
@@ -306,17 +345,24 @@ function walkComponentTree(
     }
   };
 
-  // A slide's `placeholders` record maps placeholder names to full components
-  // ({ "title": { "name": "text", ... } }). The static SlidePropsSchema does
-  // not include the field (it is injected with the recursive ref at schema
-  // generation time), so validateComponentProps strips it before checking the
-  // slide's own props — each value is validated here instead.
+  // A `placeholders` record maps placeholder names to full components
+  // ({ "title": { "name": "text", ... } }). The registry's `hasPlaceholders`
+  // flag is what injects the field into the published schema at generation
+  // time (createPptxComponentSchemaObject) — the static props schema does not
+  // include it, so validateComponentProps strips it before checking the
+  // component's own props and each value is validated here instead. Reading
+  // the same flag keeps this walk covering exactly the components whose
+  // published schema accepts placeholders; only `slide` carries it today.
   //
-  // A placeholder holds what the slide itself holds: filling one with a
+  // A placeholder holds what the container itself holds: filling one with a
   // `slide` or the `pptx` root is not a component with no position, it is a
   // container nested where no container can go. The published schema narrows
   // the record to the same union it narrows `children` to, so both refuse it.
-  if (node.name === 'slide' && node.props && typeof node.props === 'object') {
+  if (
+    parentDef?.hasPlaceholders &&
+    node.props &&
+    typeof node.props === 'object'
+  ) {
     const placeholders = node.props.placeholders;
     if (
       placeholders &&
@@ -381,12 +427,14 @@ function validateComponentProps(
     return errors;
   }
 
-  // A slide's `placeholders` field is injected at schema-generation time and
-  // absent from the static props schema; its values are walked separately, so
-  // strip it here to avoid a false additionalProperties rejection.
+  // A `placeholders` field on a `hasPlaceholders` component is injected at
+  // schema-generation time and absent from the static props schema; its
+  // values are walked separately, so strip it here to avoid a false
+  // additionalProperties rejection. Keyed on the registry flag, like the
+  // schema injection and the walk.
   let toCheck = props;
   if (
-    componentName === 'slide' &&
+    getPptxStandardComponent(componentName)?.hasPlaceholders &&
     props &&
     typeof props === 'object' &&
     'placeholders' in props


### PR DESCRIPTION
Three commits, two related bodies of work. The `#292` validation commits were
already sitting unpushed on `main` and are what makes the suites below green —
they're carried here rather than stranded.

## 1. Bundled template fonts pass safe-mode validation (new)

`vermilion-annual-report` ships its fonts as `fontRegistry` `kind:'file'`
sources. Safe mode rejects those — *"Unsafe outbound source … local file
sources are disabled for HTTP requests"* — so **every hosted playground
generation of that template 400'd.**

The template-media inliner already converted a discovered document's relative
image paths to data URLs ahead of source validation; it never touched font
sources. Now it rewrites contained `{kind:'file', path}` → `{kind:'data', data}`,
so the fonts clear the policy and travel to the remote rasterizer. Resolved
bytes are identical to the local file path, so the LibreOffice preview stages
the same faces.

- Image and font MIME tables are now separate (`.ttf/.otf/.woff/.woff2`).
- The extension gate moved **ahead of the cache** — a cached verdict for a path
  must not depend on which table asked (an `.otf` referenced as an image is not
  inlineable; the same file as a font source is).
- The leftover `path` is deleted: `DataFontSourceSchema` is
  `additionalProperties: false` and would fail structural validation downstream.
- Containment, size and budget rules are unchanged; anything outside `baseDir`
  still falls through to the outbound-source policy.

**Renames used to break templates too.** `options.sourceName` was the *display*
name, which the user is free to change. Documents now carry a `templateSource`
provenance field, set when a discovered document is added, preserved across
rename, and read through a new `useResolveSourceName()` hook — an imperative
store read, so callbacks holding it don't re-create on every edit. Documents
predating the field fall back to the display name.

### Tests

- `bundled-templates-safe-mode.test.ts` runs **every** bundled template through
  inlining + safe-mode validation, against the allowlist parsed out of
  `render.yaml` (asserting every service agrees, so a template can't pass on one
  deployment and 400 on another). It carries an anti-vacuity guard: raw
  vermilion must still throw `/local file sources are disabled/`, and inlining
  must be what fixes it.
- `documents-template-source.test.ts` pins provenance recording, rename
  survival, and the display-name fallback.

## 2. docx/pptx validation parity (#292) — previously unpushed

`c6c2a98` and `2e43391`, already committed locally: registry-driven deep walk,
gated rescue, sibling value types, registry-driven placeholders, and unknown-key
guards on both sides.

> Worth knowing: **`origin/main` is currently red without these.** 11 failures
> across `generator-warnings`, `generator-document-registry`,
> `supplemental-warnings` and `format-generate-warnings` — every
> `props.fontRegistry` document fails validation. Verified on a pristine
> checkout. That's why this PR isn't just the font fix.

## Verification

Per-package (the workspace-wide run throws spurious 5s timeouts on this
machine), all green:

| package | tests |
| --- | --- |
| `jto` | 455 |
| `shared-docx` | 298 |
| `shared-pptx` | 115 |
| `core-docx` | 1951 |
| `core-pptx` | 762 |

Plus `typecheck`, `eslint` and `prettier --check` clean on the changed files.

Patch changeset included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bundled playground templates now support file-based fonts in safe mode.
  * Renamed documents created from templates continue resolving images and fonts correctly.
  * Generated DOCX and PPTX filenames now use document titles where available.

* **Bug Fixes**
  * Improved DOCX and PPTX validation rejects unknown fields and incorrectly typed values with clearer, path-specific errors.
  * Validation and generation now apply consistent safeguards across nested components and placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->