### PR TITLE
feat(mcp): disk-backed workspaces so a lost session keeps its revisions (#290)

### DIFF
--- a/.changeset/mcp-disk-backed-workspaces.md
+++ b/.changeset/mcp-disk-backed-workspaces.md
@@ -1,0 +1,30 @@
+---
+'@json-to-office/mcp-server': minor
+---
+
+MCP workspaces can now be disk-backed, so a lost client session no longer
+destroys the revisions it was holding (#290). Workspaces were memory-only:
+`entries`, `tombstones` and every pinned snapshot lived in `Map`s built per
+connection, so a host session reset, a client restart or a crash silently
+discarded all of it — in the field report this came from, five revisions of
+authoring went while the server process itself stayed alive and idle.
+
+Start the server with `--workspace-dir` (or `JTO_MCP_WORKSPACE_DIR`) and each
+committed revision is mirrored under that root before the tool answers. Memory
+stays the fast path; disk is durability. A reconnecting client calls
+`jto_workspace_list`, gets back every handle under the root — including ones
+this connection never opened — and reads or patches them as usual, with the
+document loaded on demand. The idle TTL still releases memory but no longer
+loses anything, and `jto_workspace_close` still destroys the work, on disk too.
+
+Off by default, so nothing changes for a connection that does not configure a
+root: handles stay memory-only and end with the connection.
+
+The root is bounded — 32 workspaces (least-recently-updated evicted first), 9
+revision files each (the head plus its pins), 16 MiB per revision — and a
+revision that cannot be written comes back as a `W_WORKSPACE_NOT_PERSISTED`
+warning with the edit applied, so durability degrades loudly rather than
+silently. Writes are atomic and ordered so the metadata never names a revision
+file that is not there. A `workspace` record gains `persisted`,
+`jto_workspace_list` gains `persistence`, and `jto_info.workspaces` gains
+`persistent` and `root`.

--- a/.changeset/mcp-disk-backed-workspaces.md
+++ b/.changeset/mcp-disk-backed-workspaces.md
@@ -25,6 +25,8 @@ revision files each (the head plus its pins), 16 MiB per revision — and a
 revision that cannot be written comes back as a `W_WORKSPACE_NOT_PERSISTED`
 warning with the edit applied, so durability degrades loudly rather than
 silently. Writes are atomic and ordered so the metadata never names a revision
-file that is not there. A `workspace` record gains `persisted`,
+file that is not there, and a close that cannot delete the durable copy fails
+with `E_WORKSPACE_NOT_CLOSED` and releases nothing, rather than reporting a
+destruction that did not happen. A `workspace` record gains `persisted`,
 `jto_workspace_list` gains `persistence`, and `jto_info.workspaces` gains
 `persistent` and `root`.

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -86,7 +86,7 @@ claude mcp add json-to-office -s user \
 
 After a reconnect the agent calls `jto_workspace_list` and gets its handles back — including ones opened by the connection that died — then reads or patches them as usual. Memory stays the fast path; the disk copy only loads when a handle is actually used. Closing a workspace still destroys it, on disk as well, and a revision that could not be written comes back as a `W_WORKSPACE_NOT_PERSISTED` warning with the edit applied. `jto_info.workspaces.persistent` says which mode a connection is in.
 
-The directory holds document JSON in the clear (owner-only), so point it somewhere you would be comfortable leaving drafts. Give each client its own root: two connections sharing one share its handles, and `baseRevision` guards a write against the connection that made it, not against another one editing the same handle at the same time.
+The directory holds document JSON in the clear, so point it somewhere private and check its permissions yourself: the server creates a new root `0o700` and writes files `0o600`, but it leaves an existing directory's permissions alone, and Windows does not enforce those bits. Give each client its own root: two connections sharing one share its handles, and `baseRevision` guards a write against the connection that made it, not against another one editing the same handle at the same time.
 
 ## What the agent gets
 

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -65,13 +65,36 @@ claude mcp add json-to-office -s user \
 
 In Claude Desktop and Cursor the equivalent is an `"env"` object beside `"command"`.
 
+## Workspaces that survive a lost session
+
+A workspace holds a document server-side so the agent patches it instead of resending it. By default it lives in memory and belongs to one connection: whatever ends the connection — a client restart, a host session reset, a crash — takes the open documents with it, however many revisions of authoring they held.
+
+Give the server a workspace directory and every committed revision is mirrored there instead:
+
+```bash
+claude mcp add json-to-office -s user \
+  -e JTO_MCP_OUTPUT_DIR=$HOME/Documents/jto-out \
+  -e JTO_MCP_WORKSPACE_DIR=$HOME/Documents/jto-workspaces \
+  -- npx -y @json-to-office/mcp-server
+```
+
+| Setting                  | Effect                                                        |
+| ------------------------ | ------------------------------------------------------------- |
+| `--workspace-dir <path>` | Workspace revisions are mirrored here. Highest precedence.    |
+| `JTO_MCP_WORKSPACE_DIR`  | The same, when the flag is absent.                            |
+| _(neither)_              | Memory-only handles, ending with the connection. The default. |
+
+After a reconnect the agent calls `jto_workspace_list` and gets its handles back — including ones opened by the connection that died — then reads or patches them as usual. Memory stays the fast path; the disk copy only loads when a handle is actually used. Closing a workspace still destroys it, on disk as well, and a revision that could not be written comes back as a `W_WORKSPACE_NOT_PERSISTED` warning with the edit applied. `jto_info.workspaces.persistent` says which mode a connection is in.
+
+The directory holds document JSON in the clear (owner-only), so point it somewhere you would be comfortable leaving drafts. Give each client its own root: two connections sharing one share its handles, and `baseRevision` guards a write against the connection that made it, not against another one editing the same handle at the same time.
+
 ## What the agent gets
 
 Thirteen tools and nine `jto://` resources. The [package README](https://github.com/Wiseair-srl/json-to-office/tree/main/packages/mcp-server#tools) documents every input and output field; the shape of the loop is:
 
 **Discover.** `jto_info` reports versions, formats, renderer ids, the output root and whether preview can run here. `jto_discover` lists components, renderer profiles, themes and starter documents; `jto_describe_component` returns one component's exact schema, with nested components collapsed to names so nothing pulls a megabyte of schema through the model.
 
-**Author and repair.** `jto_validate` returns path-addressed diagnostics — RFC 6901 pointers into the document you sent, usable directly as patch targets. Beside structural errors it reports [design-quality findings](/guide/design-quality) (`W_QUALITY_*`) with category, certainty, and evidence. They advise by default; pass `quality.policy.gate` to make the selected severity block `ok`. Optional workspaces (`jto_workspace_create`, `_inspect`, `_patch`, `_snapshot`, `_list`, `_close`) hold a document server-side so an agent can send an RFC 6902 patch instead of resending the whole tree.
+**Author and repair.** `jto_validate` returns path-addressed diagnostics — RFC 6901 pointers into the document you sent, usable directly as patch targets. Beside structural errors it reports [design-quality findings](/guide/design-quality) (`W_QUALITY_*`) with category, certainty, and evidence. They advise by default; pass `quality.policy.gate` to make the selected severity block `ok`. Optional workspaces (`jto_workspace_create`, `_inspect`, `_patch`, `_snapshot`, `_list`, `_close`) hold a document server-side so an agent can send an RFC 6902 patch instead of resending the whole tree; with a [workspace directory](#workspaces-that-survive-a-lost-session) configured they outlive the connection.
 
 **Look.** `jto_preview` renders selected pages to PNG and hands them back as image blocks. This is the part that has no CLI equivalent worth the name: a model reasoning about whether a table overflowed is guessing, and a model looking at the page is not.
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -80,13 +80,16 @@ Pin a version by asking for one — `npx -y @json-to-office/mcp-server@1.0.0` �
 
 ## Options
 
-| Flag / variable       | Meaning                                                          |
-| --------------------- | ---------------------------------------------------------------- |
-| `--output-dir <path>` | Where generated files are written. Highest precedence.           |
-| `JTO_MCP_OUTPUT_DIR`  | Same, when the flag is absent.                                   |
-| _(neither)_           | A per-connection directory under the system temp dir.            |
-| `LIBREOFFICE_PATH`    | LibreOffice binary, for preview and the docx `visual` component. |
-| `PDFTOPPM_PATH`       | poppler `pdftoppm` binary, for preview.                          |
+| Flag / variable          | Meaning                                                                           |
+| ------------------------ | --------------------------------------------------------------------------------- |
+| `--output-dir <path>`    | Where generated files are written. Highest precedence.                            |
+| `JTO_MCP_OUTPUT_DIR`     | Same, when the flag is absent.                                                    |
+| _(neither output flag)_  | A per-connection directory under the system temp dir.                             |
+| `--workspace-dir <path>` | Where workspace revisions are mirrored, so they outlive the connection.           |
+| `JTO_MCP_WORKSPACE_DIR`  | Same, when the flag is absent.                                                    |
+| _(neither ws flag)_      | Workspaces are memory-only: handles end with the connection. This is the default. |
+| `LIBREOFFICE_PATH`       | LibreOffice binary, for preview and the docx `visual` component.                  |
+| `PDFTOPPM_PATH`          | poppler `pdftoppm` binary, for preview.                                           |
 
 ## Contracts
 
@@ -102,7 +105,7 @@ Pin a version by asking for one — `npx -y @json-to-office/mcp-server@1.0.0` �
 
 ## The loop this server expects
 
-1. **`jto_info`** — what this host can actually do: versions, formats and their renderer ids, the output root, whether workspaces are on, and whether preview has its binaries.
+1. **`jto_info`** — what this host can actually do: versions, formats and their renderer ids, the output root, whether workspaces are on and whether they survive a lost connection, and whether preview has its binaries.
 2. **`jto_discover`** (or the `jto://catalog` resource) — components per format, renderer profiles, built-in themes, and starter documents to copy. **`jto_describe_component`** for the exact schema of the one component you are about to write.
 3. **Author** — start from a starter, or `jto_workspace_create` and patch content in.
 4. **`jto_validate`** after each edit, not once at the end. Diagnostics are path-addressed, so a pointer is a patch target.
@@ -140,7 +143,7 @@ Call this first.
 
 **In** — `includePreviewDependencies` (boolean, default true): probe the filesystem for LibreOffice and poppler.
 
-**Out** — `server` `{name, package, version, protocolTransport}`; `runtime` `{node, platform, arch}`; `packages` (installed versions of `jto-ops`, `shared*`, `core-docx`, `core-pptx` — a render is a function of the document plus these); `formats[]` `{name, extension, label, rendererIds}` with defaults first; `workspaces` `{available, open}`; `output` `{root, ephemeral, maxInlineArtifactBytes}`; `previewDependencies` `{libreoffice, pdftoppm}`, each `{available, path?, envVar, searched[]}`, absent when not probed.
+**Out** — `server` `{name, package, version, protocolTransport}`; `runtime` `{node, platform, arch}`; `packages` (installed versions of `jto-ops`, `shared*`, `core-docx`, `core-pptx` — a render is a function of the document plus these); `formats[]` `{name, extension, label, rendererIds}` with defaults first; `workspaces` `{available, open, persistent, root?}`; `output` `{root, ephemeral, maxInlineArtifactBytes}`; `previewDependencies` `{libreoffice, pdftoppm}`, each `{available, path?, envVar, searched[]}`, absent when not probed.
 
 The probe is a PATH walk, not a `--version` spawn: `jto_info` is a per-connection discovery call and a cold `soffice --version` costs about a second. It therefore reports a binary that exists, not a binary that works; a real preview settles the rest.
 
@@ -204,9 +207,19 @@ Both sides are validated before the walk, and their diagnostics are tagged with 
 
 ### Workspaces
 
-Optional, and an optimization rather than a second source of truth: the JSON stays authoritative, and every tool that takes a `handle` also takes inline `document`. The point is the round trip you do not make — open a document once, patch the two paths a diagnostic pointed at, validate or preview by handle, without putting the whole tree back through the model. Handles are memory-only and scoped to one stdio connection.
+Optional, and an optimization rather than a second source of truth: the JSON stays authoritative, and every tool that takes a `handle` also takes inline `document`. The point is the round trip you do not make — open a document once, patch the two paths a diagnostic pointed at, validate or preview by handle, without putting the whole tree back through the model. By default handles are memory-only and scoped to one stdio connection.
 
 Default budget per connection: 16 open documents, 16 MiB per document, 64 MiB in total, 8 pinned revisions each, and a 30-minute idle TTL that any use resets. Capacity overflow refuses with `E_WORKSPACE_LIMIT`; it never evicts another live workspace or an older pin. `jto_workspace_list` reports the live figures.
+
+**Surviving a lost session.** Start the server with `--workspace-dir` (or `JTO_MCP_WORKSPACE_DIR`) and every committed revision is mirrored there, so a client restart, a host session reset or a crash no longer takes the authoring with it. Memory stays the fast path; disk is durability. On a connection that has it:
+
+- Each `jto_workspace_create`, `jto_workspace_patch` and `jto_workspace_snapshot` writes before it answers, and the `workspace` record carries `persisted`.
+- `jto_workspace_list` reports every workspace under the root, including ones this connection never opened — that is how a reconnecting agent gets its handles back. `jto_workspace_inspect` (and any other handle-taking tool) then loads the document on demand.
+- The idle TTL still releases memory, but no longer loses anything: the handle comes back from disk on next use.
+- `jto_workspace_close` deletes the durable copy too. It is the one operation that is meant to destroy work, so it still does.
+- The root is bounded: 32 workspaces (least-recently-updated dropped first), 9 revision files per workspace — the head plus its pins — and 16 MiB per revision. A revision that cannot be written comes back with a `W_WORKSPACE_NOT_PERSISTED` warning and the edit still applies: durability degrades loudly, never silently, and never at the cost of the edit.
+
+Handles become cross-connection when this is on, so point it at a directory you would be comfortable leaving documents in — it holds the JSON in the clear, owner-only, until something closes the workspace or the workspace ceiling evicts it. Two connections sharing a root also share its handles, and each keeps its own memory copy: `baseRevision` still guards a write against the connection that made it, not against another one editing the same handle at the same time. One root per client is the arrangement this is built for.
 
 **`jto_workspace_create`** — in: `format` (required), `document` (omit to open an empty skeleton and patch into it), `title` (your own label). Out: `workspace`. Nothing is validated here.
 
@@ -216,11 +229,11 @@ Default budget per connection: 16 open documents, 16 MiB per document, 64 MiB in
 
 **`jto_workspace_snapshot`** — in: `handle` (required), `filename` (write the JSON under the output root instead of returning it inline). Out: `workspace`, `document` or `artifact`. Pins the revision so `jto_workspace_inspect` can still read that exact tree after later patches; a full pin budget downgrades to an export with a `W_SNAPSHOT_NOT_PINNED` warning.
 
-**`jto_workspace_list`** — no input. Out: `workspaces[]`, `available`, `limits`, `usage` `{workspaces, bytes}`. The cheapest way back after losing track of a handle.
+**`jto_workspace_list`** — no input. Out: `workspaces[]`, `available`, `limits`, `usage` `{workspaces, bytes}`, and `persistence` `{root, maxWorkspaces, maxRevisionsPerWorkspace, maxEntryBytes}` when the connection has a workspace directory. The cheapest way back after losing track of a handle — including across a reconnect.
 
-**`jto_workspace_close`** — in: `handle` (required). Out: `handle`, `closed`. Idempotent; closing something already gone reports `closed: false` rather than failing. Not recoverable — snapshot first.
+**`jto_workspace_close`** — in: `handle` (required). Out: `handle`, `closed`. Idempotent; closing something already gone reports `closed: false` rather than failing. Not recoverable — it removes the durable copy as well, so snapshot first.
 
-A `workspace` record is `{handle, format, revision, bytes, createdAt, updatedAt, title?, pinnedRevisions[]}`.
+A `workspace` record is `{handle, format, revision, bytes, createdAt, updatedAt, title?, pinnedRevisions[], persisted?}`.
 
 ## Resources
 
@@ -310,6 +323,7 @@ The cores name their generation warnings in a dialect of their own too — bare 
 | `W_BLANK_DOCUMENT`                 | A workspace was opened on an empty skeleton, with no content yet.                                           |
 | `W_PATH_NOT_FOUND`                 | A pointer a read asked for does not resolve in that revision.                                               |
 | `W_SNAPSHOT_NOT_PINNED`            | A snapshot was exported but not pinned: the workspace budget is full.                                       |
+| `W_WORKSPACE_NOT_PERSISTED`        | The edit applied, but the revision did not reach the workspace directory.                                   |
 | `W_GENERATION`                     | A generation warning with no code of its own.                                                               |
 | `W_<CORE_CODE>`                    | A generation warning the core named: `W_FONT_UNRESOLVED`, `W_CHART_NO_DATA`, `W_UNKNOWN_SHAPE` and friends. |
 
@@ -336,7 +350,7 @@ const server = createServer(createToolDeps({ outputDir: './out' }));
 await server.connect(myTransport);
 ```
 
-`setWorkspaceStore` before `createServer` installs your own store — with tighter limits, or `unavailableWorkspaceStore` to switch workspaces off entirely.
+`setWorkspaceStore` before `createServer` installs your own store — with tighter limits, or `unavailableWorkspaceStore` to switch workspaces off entirely. `createToolDeps({ workspaceDir })`, or a `workspacePersistence` you build with `createWorkspacePersistenceAt`, gives the connection's own store disk backing instead.
 
 ## License
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -219,7 +219,7 @@ Default budget per connection: 16 open documents, 16 MiB per document, 64 MiB in
 - `jto_workspace_close` deletes the durable copy too. It is the one operation that is meant to destroy work, so it still does.
 - The root is bounded: 32 workspaces (least-recently-updated dropped first), 9 revision files per workspace — the head plus its pins — and 16 MiB per revision. A revision that cannot be written comes back with a `W_WORKSPACE_NOT_PERSISTED` warning and the edit still applies: durability degrades loudly, never silently, and never at the cost of the edit.
 
-Handles become cross-connection when this is on, so point it at a directory you would be comfortable leaving documents in — it holds the JSON in the clear, owner-only, until something closes the workspace or the workspace ceiling evicts it. Two connections sharing a root also share its handles, and each keeps its own memory copy: `baseRevision` still guards a write against the connection that made it, not against another one editing the same handle at the same time. One root per client is the arrangement this is built for.
+Handles become cross-connection when this is on, so point it at a directory you would be comfortable leaving documents in: it holds the JSON in the clear until something closes the workspace or the workspace ceiling evicts it. The server creates the root `0o700` and writes files `0o600`, but it does not touch the permissions of a directory that already exists, and Windows does not honour those bits at all — so pick a private location and check its ACLs rather than relying on the server for that. Two connections sharing a root also share its handles, and each keeps its own memory copy: `baseRevision` still guards a write against the connection that made it, not against another one editing the same handle at the same time. One root per client is the arrangement this is built for.
 
 **`jto_workspace_create`** — in: `format` (required), `document` (omit to open an empty skeleton and patch into it), `title` (your own label). Out: `workspace`. Nothing is validated here.
 
@@ -299,6 +299,7 @@ The cores name their generation warnings in a dialect of their own too — bare 
 | `E_WORKSPACES_UNAVAILABLE`         | Workspaces are switched off for this connection.                                                            |
 | `E_WORKSPACE_EVICTED`              | The handle was released by the idle TTL.                                                                    |
 | `E_WORKSPACE_LIMIT`                | The connection's workspace or byte budget is full.                                                          |
+| `E_WORKSPACE_NOT_CLOSED`           | The durable copy could not be deleted, so nothing was closed. The workspace is still open.                  |
 | `E_DOCUMENT_TOO_LARGE`             | One document is over `maxDocumentBytes`.                                                                    |
 | `E_PATCH_SYNTAX`                   | An operation is malformed.                                                                                  |
 | `E_INVALID_POINTER`                | A JSON Pointer is not RFC 6901.                                                                             |

--- a/packages/mcp-server/src/__tests__/fixtures/stdio-harness.ts
+++ b/packages/mcp-server/src/__tests__/fixtures/stdio-harness.ts
@@ -130,6 +130,8 @@ export interface StdioSession {
   client: Client;
   /** The `--output-dir` the server was started with. */
   outputRoot: string;
+  /** The `--workspace-dir` it was started with, when it was given one. */
+  workspaceRoot?: string;
   /** Everything the child has written to stderr so far. */
   stderr(): string;
   close(): Promise<void>;
@@ -143,6 +145,12 @@ export interface SessionOptions {
   versionNegotiation?: { mode: 'legacy' | 'auto' | { pin: string } };
   /** Reuse an existing output root instead of making one. */
   outputRoot?: string;
+  /**
+   * Start with `--workspace-dir`, so workspace revisions outlive the child
+   * process (#290). The caller owns the directory: pointing two sessions at
+   * the same one is how a reconnect is simulated.
+   */
+  workspaceRoot?: string;
 }
 
 /**
@@ -161,7 +169,14 @@ export async function openSession(
 
   const transport = new StdioClientTransport({
     command: process.execPath,
-    args: [cliPath, '--output-dir', outputRoot],
+    args: [
+      cliPath,
+      '--output-dir',
+      outputRoot,
+      ...(options.workspaceRoot
+        ? ['--workspace-dir', options.workspaceRoot]
+        : []),
+    ],
     stderr: 'pipe',
   });
 
@@ -181,6 +196,9 @@ export async function openSession(
   return {
     client,
     outputRoot,
+    ...(options.workspaceRoot !== undefined && {
+      workspaceRoot: options.workspaceRoot,
+    }),
     stderr: () => stderr,
     close: async () => {
       await client.close();

--- a/packages/mcp-server/src/__tests__/server.test.ts
+++ b/packages/mcp-server/src/__tests__/server.test.ts
@@ -143,7 +143,13 @@ describe('jto_info', () => {
       expect(format.rendererIds.length).toBeGreaterThan(0);
     }
 
-    expect(info.workspaces).toEqual({ available: true, open: 0 });
+    // `persistent: false` is the default: handles live in memory until a
+    // workspace directory is configured (#290).
+    expect(info.workspaces).toEqual({
+      available: true,
+      open: 0,
+      persistent: false,
+    });
     expect(info.output.root).toBe(path.join(scratch, 'out'));
     expect(info.output.maxInlineArtifactBytes).toBe(4 * 1024 * 1024);
   });

--- a/packages/mcp-server/src/__tests__/stdio-workspace-recovery.test.ts
+++ b/packages/mcp-server/src/__tests__/stdio-workspace-recovery.test.ts
@@ -1,0 +1,190 @@
+/**
+ * The reported failure, reproduced and then fixed (#290).
+ *
+ * A 2026-08 field report lost five revisions of authoring when the host client
+ * reset its session. The server was healthy the whole time — the documents
+ * simply lived in the memory of a connection that no longer existed. That is a
+ * claim about what survives a PROCESS, so this suite spawns two of them: one
+ * that authors and is then killed, and a second that is handed nothing but the
+ * same `--workspace-dir` and has to find the work again.
+ *
+ * The in-process suite (`workspace-persistence.test.ts`) covers the store's
+ * semantics. What is only true here is that the flag reaches the store at all,
+ * and that a genuinely dead child takes nothing with it.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs/promises';
+
+import {
+  callTool,
+  makeScratch,
+  openSession,
+  type StdioSession,
+} from './fixtures/stdio-harness.js';
+
+const CONNECT_TIMEOUT_MS = 120_000;
+const JOURNEY_TIMEOUT_MS = 180_000;
+
+/** The five revisions the report lost, as headings appended one at a time. */
+const HEADINGS = ['Scope', 'Method', 'Findings', 'Risks', 'Next steps'];
+
+let workspaceRoot: string;
+let outputRoot: string;
+let handle: string;
+
+async function connect(): Promise<StdioSession> {
+  return openSession({ outputRoot, workspaceRoot });
+}
+
+beforeAll(async () => {
+  outputRoot = await makeScratch('jto-mcp-recover-out');
+  workspaceRoot = await makeScratch('jto-mcp-recover-ws');
+}, CONNECT_TIMEOUT_MS);
+
+afterAll(async () => {
+  await fs.rm(outputRoot, { recursive: true, force: true });
+  await fs.rm(workspaceRoot, { recursive: true, force: true });
+});
+
+describe('a workspace outliving the session that made it', () => {
+  it(
+    'authors five revisions, then loses the connection',
+    async () => {
+      const session = await connect();
+
+      const info = (await callTool(session, 'jto_info', {
+        includePreviewDependencies: false,
+      })) as any;
+      expect(info.workspaces).toMatchObject({
+        available: true,
+        persistent: true,
+        root: workspaceRoot,
+      });
+
+      const created = (await callTool(session, 'jto_workspace_create', {
+        format: 'docx',
+        title: 'Field report',
+        document: { name: 'docx', props: {}, children: [] },
+      })) as any;
+      expect(created.ok).toBe(true);
+      handle = created.workspace.handle;
+      expect(created.workspace.persisted).toBe(true);
+
+      for (const [index, text] of HEADINGS.entries()) {
+        const patched = (await callTool(session, 'jto_workspace_patch', {
+          handle,
+          baseRevision: index + 1,
+          operations: [
+            {
+              op: 'add',
+              path: '/children/-',
+              value: { name: 'heading', props: { text, level: 2 } },
+            },
+          ],
+        })) as any;
+        expect(patched.ok).toBe(true);
+        expect(patched.workspace.revision).toBe(index + 2);
+      }
+
+      // No close, no snapshot, no export — exactly what the report described.
+      // `close` here tears the child process down with the transport.
+      await session.close();
+    },
+    JOURNEY_TIMEOUT_MS
+  );
+
+  it(
+    'finds the handle again from a new process, and keeps working on it',
+    async () => {
+      const session = await connect();
+      try {
+        // The agent has lost everything it knew, including the handle.
+        const listed = (await callTool(
+          session,
+          'jto_workspace_list',
+          {}
+        )) as any;
+        expect(listed.ok).toBe(true);
+        expect(listed.persistence).toMatchObject({ root: workspaceRoot });
+
+        const recovered = listed.workspaces.find(
+          (workspace: any) => workspace.handle === handle
+        );
+        expect(recovered).toMatchObject({
+          handle,
+          format: 'docx',
+          title: 'Field report',
+          revision: HEADINGS.length + 1,
+          persisted: true,
+        });
+
+        const read = (await callTool(session, 'jto_workspace_inspect', {
+          handle,
+        })) as any;
+        expect(read.ok).toBe(true);
+        expect(
+          read.document.children.map((child: any) => child.props.text)
+        ).toEqual(HEADINGS);
+
+        // A recovered handle is an ordinary handle: every document-taking tool
+        // reads it the same way, and it is still writable.
+        const validated = (await callTool(session, 'jto_validate', {
+          format: 'docx',
+          handle,
+        })) as any;
+        expect(validated.source).toMatchObject({
+          origin: 'workspace',
+          handle,
+          revision: HEADINGS.length + 1,
+        });
+
+        const patched = (await callTool(session, 'jto_workspace_patch', {
+          handle,
+          baseRevision: HEADINGS.length + 1,
+          operations: [{ op: 'add', path: '/props/title', value: 'Recovered' }],
+        })) as any;
+        expect(patched.workspace.revision).toBe(HEADINGS.length + 2);
+      } finally {
+        await session.close();
+      }
+    },
+    JOURNEY_TIMEOUT_MS
+  );
+
+  it(
+    'forgets it for good once the agent closes it',
+    async () => {
+      const closing = await connect();
+      try {
+        const closed = (await callTool(closing, 'jto_workspace_close', {
+          handle,
+        })) as any;
+        expect(closed.closed).toBe(true);
+      } finally {
+        await closing.close();
+      }
+
+      const session = await connect();
+      try {
+        const listed = (await callTool(
+          session,
+          'jto_workspace_list',
+          {}
+        )) as any;
+        expect(
+          listed.workspaces.map((workspace: any) => workspace.handle)
+        ).not.toContain(handle);
+
+        const read = (await callTool(session, 'jto_workspace_inspect', {
+          handle,
+        })) as any;
+        expect(read.ok).toBe(false);
+        expect(read.diagnostics[0].code).toBe('E_UNKNOWN_HANDLE');
+      } finally {
+        await session.close();
+      }
+    },
+    JOURNEY_TIMEOUT_MS
+  );
+});

--- a/packages/mcp-server/src/__tests__/stdio-workspace-recovery.test.ts
+++ b/packages/mcp-server/src/__tests__/stdio-workspace-recovery.test.ts
@@ -52,44 +52,47 @@ describe('a workspace outliving the session that made it', () => {
     'authors five revisions, then loses the connection',
     async () => {
       const session = await connect();
-
-      const info = (await callTool(session, 'jto_info', {
-        includePreviewDependencies: false,
-      })) as any;
-      expect(info.workspaces).toMatchObject({
-        available: true,
-        persistent: true,
-        root: workspaceRoot,
-      });
-
-      const created = (await callTool(session, 'jto_workspace_create', {
-        format: 'docx',
-        title: 'Field report',
-        document: { name: 'docx', props: {}, children: [] },
-      })) as any;
-      expect(created.ok).toBe(true);
-      handle = created.workspace.handle;
-      expect(created.workspace.persisted).toBe(true);
-
-      for (const [index, text] of HEADINGS.entries()) {
-        const patched = (await callTool(session, 'jto_workspace_patch', {
-          handle,
-          baseRevision: index + 1,
-          operations: [
-            {
-              op: 'add',
-              path: '/children/-',
-              value: { name: 'heading', props: { text, level: 2 } },
-            },
-          ],
+      try {
+        const info = (await callTool(session, 'jto_info', {
+          includePreviewDependencies: false,
         })) as any;
-        expect(patched.ok).toBe(true);
-        expect(patched.workspace.revision).toBe(index + 2);
-      }
+        expect(info.workspaces).toMatchObject({
+          available: true,
+          persistent: true,
+          root: workspaceRoot,
+        });
 
-      // No close, no snapshot, no export — exactly what the report described.
-      // `close` here tears the child process down with the transport.
-      await session.close();
+        const created = (await callTool(session, 'jto_workspace_create', {
+          format: 'docx',
+          title: 'Field report',
+          document: { name: 'docx', props: {}, children: [] },
+        })) as any;
+        expect(created.ok).toBe(true);
+        handle = created.workspace.handle;
+        expect(created.workspace.persisted).toBe(true);
+
+        for (const [index, text] of HEADINGS.entries()) {
+          const patched = (await callTool(session, 'jto_workspace_patch', {
+            handle,
+            baseRevision: index + 1,
+            operations: [
+              {
+                op: 'add',
+                path: '/children/-',
+                value: { name: 'heading', props: { text, level: 2 } },
+              },
+            ],
+          })) as any;
+          expect(patched.ok).toBe(true);
+          expect(patched.workspace.revision).toBe(index + 2);
+        }
+      } finally {
+        // No close, no snapshot, no export — exactly what the report
+        // described. This tears the child process down with the transport,
+        // and has to run even when an assertion above did not, or the leaked
+        // server outlives the test that made it.
+        await session.close();
+      }
     },
     JOURNEY_TIMEOUT_MS
   );

--- a/packages/mcp-server/src/__tests__/stdio.test.ts
+++ b/packages/mcp-server/src/__tests__/stdio.test.ts
@@ -165,4 +165,47 @@ describe.skipIf(!built)('stdout hygiene', () => {
       stderr: expect.stringContaining('unknown argument'),
     });
   });
+
+  it.each(['--workspace-dir', '--output-dir'])(
+    'does not let %s swallow the option after it',
+    async (flag) => {
+      // Consuming the next token blindly named a directory after an option
+      // the user meant to RUN, and started a server that never exits instead
+      // of printing the version and stopping.
+      const { stdout } = await run(process.execPath, [
+        cliPath,
+        flag,
+        '--version',
+      ]);
+      expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+|^dev-mode$/);
+    }
+  );
+
+  it.each(['--workspace-dir', '--output-dir'])(
+    'refuses %s when its value is another flag',
+    async (flag) => {
+      await expect(
+        run(process.execPath, [cliPath, flag, '--output-dir=/tmp/jto-x'])
+      ).rejects.toMatchObject({
+        code: 1,
+        stdout: '',
+        stderr: expect.stringContaining(`${flag} needs a directory path`),
+      });
+    }
+  );
+
+  it.each(['--workspace-dir', '--output-dir'])(
+    'refuses a trailing %s with no value',
+    async (flag) => {
+      // Silently falling back to the environment would ignore a flag the user
+      // passed precisely to override it.
+      await expect(
+        run(process.execPath, [cliPath, flag])
+      ).rejects.toMatchObject({
+        code: 1,
+        stdout: '',
+        stderr: expect.stringContaining('needs a directory path'),
+      });
+    }
+  );
 });

--- a/packages/mcp-server/src/__tests__/workspace-persistence.test.ts
+++ b/packages/mcp-server/src/__tests__/workspace-persistence.test.ts
@@ -1,0 +1,553 @@
+/**
+ * What survives the connection (#290).
+ *
+ * The field report this issue came from lost five revisions of authoring to a
+ * host session reset while the server process itself stayed up and idle. So
+ * the load-bearing case here is not "a file appears on disk" — it is that a
+ * SECOND store, built on the same root exactly as a reconnecting client would
+ * get, finds the handle and reads back the revision the first one left. Every
+ * test that matters is written that way.
+ *
+ * The clock is injected, as in `workspace-store.test.ts`: the TTL cases are
+ * about the store's arithmetic, and the persistence root sorts by `updatedAt`,
+ * which a real clock would make order-dependent on how fast the machine is.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  createMemoryWorkspaceStore,
+  WORKSPACE_ERROR_CODES,
+  type MemoryWorkspaceStore,
+  type MemoryWorkspaceStoreOptions,
+} from '../workspace/store.js';
+import {
+  createWorkspacePersistence,
+  createWorkspacePersistenceAt,
+  isPersistableHandle,
+  WORKSPACE_DIR_ENV,
+  type PersistenceLimits,
+} from '../workspace/persistence.js';
+import { ERROR_CODES } from '../lib/errors.js';
+
+const document = () => ({
+  name: 'docx',
+  props: { theme: 'minimal' },
+  children: [{ name: 'heading', props: { text: 'One', level: 1 } }],
+});
+
+let clock = 1_700_000_000_000;
+let root: string;
+let scratch: string;
+
+beforeEach(async () => {
+  clock = 1_700_000_000_000;
+  scratch = await fs.mkdtemp(path.join(os.tmpdir(), 'jto-ws-persist-'));
+  root = path.join(scratch, 'workspaces');
+});
+
+afterEach(async () => {
+  await fs.rm(scratch, { recursive: true, force: true });
+});
+
+/**
+ * A store on the shared root.
+ *
+ * Calling this twice is the whole point: the second one has an empty memory
+ * map and nothing but the directory, which is what a client gets after the
+ * session it was talking to went away.
+ */
+function build(
+  options: MemoryWorkspaceStoreOptions & {
+    limits?: Partial<PersistenceLimits>;
+  } = {}
+): MemoryWorkspaceStore {
+  const { limits, ...storeOptions } = options;
+  return createMemoryWorkspaceStore({
+    now: () => clock,
+    persistence: createWorkspacePersistenceAt(root, limits ?? {}),
+    ...storeOptions,
+  });
+}
+
+function unwrap<T extends { ok: boolean }>(result: T) {
+  if (!result.ok) {
+    throw new Error(
+      `expected success, got ${JSON.stringify((result as any).diagnostics)}`
+    );
+  }
+  return result as Extract<T, { ok: true }>;
+}
+
+function failed(result: { ok: boolean }): {
+  code: string;
+  message: string;
+  context?: Record<string, unknown>;
+} {
+  expect(result.ok).toBe(false);
+  return (result as any).diagnostics[0];
+}
+
+async function open(store: MemoryWorkspaceStore, doc: unknown = document()) {
+  return unwrap(await store.create({ format: 'docx', document: doc })).record;
+}
+
+async function setTitle(
+  store: MemoryWorkspaceStore,
+  handle: string,
+  text: string
+) {
+  return unwrap(
+    await store.patch({
+      handle,
+      operations: [{ op: 'add', path: '/props/title', value: text }],
+    })
+  ).record;
+}
+
+/** Directory names under the root, whatever state they are in. */
+async function handles(): Promise<string[]> {
+  try {
+    return (await fs.readdir(root)).sort();
+  } catch {
+    return [];
+  }
+}
+
+describe('surviving the connection', () => {
+  it('is durable from the opening revision, not from the first patch', async () => {
+    // The record has to report what actually happened to THIS call: a create
+    // that says `persisted` before its own write has landed is a claim the
+    // agent cannot check, and was a real bug here.
+    const store = build();
+    const record = await open(store);
+    expect(record.revision).toBe(1);
+    expect(record.persisted).toBe(true);
+    expect(await handles()).toEqual([record.handle]);
+  });
+
+  it('reads back the revision a lost session left behind', async () => {
+    const first = build();
+    const { handle } = await open(first);
+    await setTitle(first, handle, 'Draft');
+    const before = await setTitle(first, handle, 'Second draft');
+    expect(before.revision).toBe(3);
+    expect(before.persisted).toBe(true);
+
+    // The connection ends here. Nothing is closed, nothing is exported: the
+    // client simply goes away, which is exactly the reported failure.
+    const reconnected = build();
+    const read = unwrap(await reconnected.get(handle));
+    expect(read.record.revision).toBe(3);
+    expect((read.document as any).props.title).toBe('Second draft');
+  });
+
+  it('offers the handles back through list, without being told them', async () => {
+    const first = build();
+    const a = await open(first);
+    clock += 1_000;
+    const b = unwrap(
+      await first.create({
+        format: 'pptx',
+        document: { name: 'pptx' },
+        title: 'Deck',
+      })
+    ).record;
+
+    const reconnected = build();
+    const listed = unwrap(await reconnected.list());
+    const found = new Map(
+      listed.records.map((record) => [record.handle, record])
+    );
+    expect([...found.keys()].sort()).toEqual([a.handle, b.handle].sort());
+    expect(found.get(b.handle)).toMatchObject({
+      format: 'pptx',
+      title: 'Deck',
+      revision: 1,
+      persisted: true,
+    });
+  });
+
+  it('keeps patching from where the previous connection stopped', async () => {
+    const first = build();
+    const { handle } = await open(first);
+    await setTitle(first, handle, 'Draft');
+
+    const reconnected = build();
+    const patched = unwrap(
+      await reconnected.patch({
+        handle,
+        operations: [{ op: 'add', path: '/props/author', value: 'Wiseair' }],
+        // The revision the client last saw: a resumed workspace has to honour
+        // a conditional write, or resuming is not the same as continuing.
+        baseRevision: 2,
+      })
+    ).record;
+    expect(patched.revision).toBe(3);
+
+    const third = build();
+    expect((unwrap(await third.get(handle)).document as any).props).toEqual({
+      theme: 'minimal',
+      title: 'Draft',
+      author: 'Wiseair',
+    });
+  });
+
+  it('carries pinned revisions across, readable by number', async () => {
+    const first = build();
+    const { handle } = await open(first);
+    await setTitle(first, handle, 'Pinned');
+    const pinned = unwrap(await first.snapshot(handle)).record;
+    expect(pinned.pinnedRevisions).toEqual([2]);
+    await setTitle(first, handle, 'Later');
+
+    const reconnected = build();
+    const record = unwrap(await reconnected.get(handle)).record;
+    expect(record.revision).toBe(3);
+    expect(record.pinnedRevisions).toEqual([2]);
+
+    const old = unwrap(await reconnected.get(handle, { revision: 2 }));
+    expect((old.document as any).props.title).toBe('Pinned');
+    expect(old.record.revision).toBe(2);
+  });
+
+  it('keeps a pin taken at the head, which is where a snapshot is taken', async () => {
+    const first = build();
+    const { handle } = await open(first);
+    expect(unwrap(await first.snapshot(handle)).record.pinnedRevisions).toEqual(
+      [1]
+    );
+
+    const reconnected = build();
+    expect(
+      unwrap(await reconnected.get(handle)).record.pinnedRevisions
+    ).toEqual([1]);
+  });
+
+  it('recovers a handle the idle TTL released, instead of losing it', async () => {
+    const store = build({ idleTtlMs: 60_000 });
+    const { handle } = await open(store);
+    await setTitle(store, handle, 'Still here');
+    clock += 60_001;
+
+    // Same store, same process: the sweep has dropped it out of memory, and
+    // the disk copy is what makes that an eviction rather than a loss.
+    const read = unwrap(await store.get(handle));
+    expect(read.record.revision).toBe(2);
+    expect((read.document as any).props.title).toBe('Still here');
+  });
+
+  it('still lists a workspace the TTL swept', async () => {
+    const store = build({ idleTtlMs: 60_000 });
+    const { handle } = await open(store);
+    clock += 60_001;
+
+    const listed = unwrap(await store.list());
+    expect(listed.records.map((record) => record.handle)).toEqual([handle]);
+  });
+
+  it('leaves nothing behind, and says nothing about disk, without a root', async () => {
+    const store = createMemoryWorkspaceStore({ now: () => clock });
+    const record = await open(store);
+    expect(record.persisted).toBeUndefined();
+    expect(store.persistence).toBeUndefined();
+    expect(await handles()).toEqual([]);
+
+    const other = createMemoryWorkspaceStore({ now: () => clock });
+    expect(failed(await other.get(record.handle)).code).toBe(
+      ERROR_CODES.UNKNOWN_HANDLE
+    );
+  });
+
+  it('publishes the root it is writing to', async () => {
+    const store = build();
+    expect(store.persistence?.root).toBe(root);
+    expect(store.persistence?.limits.maxWorkspaces).toBeGreaterThan(0);
+  });
+});
+
+describe('closing', () => {
+  it('destroys the durable copy too', async () => {
+    const first = build();
+    const { handle } = await open(first);
+    expect(unwrap(await first.close(handle)).closed).toBe(true);
+    expect(await handles()).toEqual([]);
+
+    const reconnected = build();
+    expect(unwrap(await reconnected.list()).records).toEqual([]);
+    expect(failed(await reconnected.get(handle)).code).toBe(
+      ERROR_CODES.UNKNOWN_HANDLE
+    );
+  });
+
+  it('closes a handle it only ever saw on disk', async () => {
+    const first = build();
+    const { handle } = await open(first);
+
+    const reconnected = build();
+    expect(unwrap(await reconnected.close(handle)).closed).toBe(true);
+    expect(await handles()).toEqual([]);
+    // And is still idempotent from there.
+    expect(unwrap(await reconnected.close(handle)).closed).toBe(false);
+  });
+
+  it('keeps the disk when a host reclaims memory with closeAll', async () => {
+    const store = build();
+    const { handle } = await open(store);
+    await setTitle(store, handle, 'Kept');
+
+    // The asymmetry with `close` is the point: this is memory management, and
+    // #290 is about an event that ends a connection not destroying revisions.
+    await store.closeAll();
+    expect(store.usage()).toEqual({ workspaces: 0, bytes: 0 });
+
+    const read = unwrap(await store.get(handle));
+    expect((read.document as any).props.title).toBe('Kept');
+  });
+});
+
+describe('bounds', () => {
+  it('keeps the root under its workspace ceiling, stalest first', async () => {
+    const store = build({ limits: { maxWorkspaces: 2 } });
+    const first = await open(store);
+    clock += 1_000;
+    const second = await open(store);
+    clock += 1_000;
+    const third = await open(store);
+
+    expect((await handles()).sort()).toEqual(
+      [second.handle, third.handle].sort()
+    );
+
+    // Dropped from disk, still resident: the ceiling bounds durability, not
+    // the live workspace the agent is holding.
+    const reconnected = build({ limits: { maxWorkspaces: 2 } });
+    expect(failed(await reconnected.get(first.handle)).code).toBe(
+      ERROR_CODES.UNKNOWN_HANDLE
+    );
+  });
+
+  it('keeps only the retained revisions per workspace', async () => {
+    const store = build({ limits: { maxRevisionsPerWorkspace: 2 } });
+    const { handle } = await open(store);
+    await store.snapshot(handle); // pins 1
+    await setTitle(store, handle, 'two');
+    await store.snapshot(handle); // pins 2
+    await setTitle(store, handle, 'three');
+
+    const files = (await fs.readdir(path.join(root, handle))).sort();
+    expect(files).toEqual(['meta.json', 'rev-2.json', 'rev-3.json']);
+
+    const reconnected = build();
+    const record = unwrap(await reconnected.get(handle)).record;
+    expect(record.revision).toBe(3);
+    // Only the pin that was actually kept is advertised.
+    expect(record.pinnedRevisions).toEqual([2]);
+  });
+
+  it('warns rather than fails when a revision is too large to persist', async () => {
+    const store = build({ limits: { maxEntryBytes: 200 } });
+    const created = unwrap(
+      await store.create({
+        format: 'docx',
+        document: { name: 'docx', children: ['x'.repeat(500)] },
+      })
+    );
+
+    expect(created.record.persisted).toBe(false);
+    expect(created.warnings?.[0]).toMatchObject({
+      severity: 'warning',
+      code: WORKSPACE_ERROR_CODES.NOT_PERSISTED,
+    });
+    expect(created.warnings?.[0].message).toMatch(/persistence limit/);
+    expect(await handles()).toEqual([]);
+
+    // The workspace itself is entirely usable; only durability was refused.
+    expect(unwrap(await store.get(created.record.handle)).record.revision).toBe(
+      1
+    );
+  });
+
+  it('refuses to restore into a full memory budget, and keeps the disk copy', async () => {
+    const small = { name: 'docx' };
+    const bytes = Buffer.byteLength(JSON.stringify(small));
+    const first = build();
+    const stored = await open(first, small);
+
+    const tight = build({ maxTotalBytes: bytes - 1 });
+    const problem = failed(await tight.get(stored.handle));
+    expect(problem.code).toBe(WORKSPACE_ERROR_CODES.LIMIT);
+    expect(problem.context).toMatchObject({ handle: stored.handle });
+
+    // Nothing was thrown away: a roomier connection still finds it.
+    const roomy = build();
+    expect(unwrap(await roomy.get(stored.handle)).document).toEqual(small);
+  });
+});
+
+describe('a directory it did not write', () => {
+  it('ignores a workspace whose metadata is corrupt', async () => {
+    const first = build();
+    const { handle } = await open(first);
+    await fs.writeFile(
+      path.join(root, handle, 'meta.json'),
+      '{ not json',
+      'utf8'
+    );
+
+    const reconnected = build();
+    expect(unwrap(await reconnected.list()).records).toEqual([]);
+    expect(failed(await reconnected.get(handle)).code).toBe(
+      ERROR_CODES.UNKNOWN_HANDLE
+    );
+  });
+
+  it('ignores a workspace whose metadata names a format it does not have', async () => {
+    const first = build();
+    const { handle } = await open(first);
+    const meta = JSON.parse(
+      await fs.readFile(path.join(root, handle, 'meta.json'), 'utf8')
+    );
+    await fs.writeFile(
+      path.join(root, handle, 'meta.json'),
+      JSON.stringify({ ...meta, format: 'xlsx' }),
+      'utf8'
+    );
+
+    expect(unwrap(await build().list()).records).toEqual([]);
+  });
+
+  it('discards a half-restored workspace whose document is missing', async () => {
+    const first = build();
+    const { handle } = await open(first);
+    await fs.rm(path.join(root, handle, 'rev-1.json'));
+
+    const reconnected = build();
+    expect(failed(await reconnected.get(handle)).code).toBe(
+      ERROR_CODES.UNKNOWN_HANDLE
+    );
+    // And it stops being offered, rather than staying in `list` as a handle
+    // that fails on every use.
+    expect(await handles()).toEqual([]);
+  });
+
+  it('never lets a handle name a directory of its own choosing', async () => {
+    expect(isPersistableHandle('ws_abc-DEF_123')).toBe(true);
+    for (const hostile of [
+      '../escape',
+      'a/b',
+      'a\\b',
+      '.',
+      '..',
+      '',
+      'ws\0null',
+    ]) {
+      expect(isPersistableHandle(hostile)).toBe(false);
+    }
+
+    const store = build({ newHandle: () => '../escaped' });
+    const created = unwrap(
+      await store.create({ format: 'docx', document: document() })
+    );
+    expect(created.record.persisted).toBe(false);
+    expect(created.warnings?.[0].code).toBe(
+      WORKSPACE_ERROR_CODES.NOT_PERSISTED
+    );
+    expect(await fs.readdir(scratch)).not.toContain('escaped');
+  });
+
+  it('never names a revision file the metadata does not have', async () => {
+    const store = build();
+    const { handle } = await open(store);
+    await store.snapshot(handle);
+    await setTitle(store, handle, 'two');
+    await setTitle(store, handle, 'three');
+
+    const dir = path.join(root, handle);
+    const meta = JSON.parse(
+      await fs.readFile(path.join(dir, 'meta.json'), 'utf8')
+    );
+    for (const revision of [meta.revision, ...meta.pinnedRevisions]) {
+      await expect(
+        fs.access(path.join(dir, `rev-${revision}.json`))
+      ).resolves.toBeUndefined();
+    }
+    // Nothing is left over either.
+    expect(
+      (await fs.readdir(dir)).filter((name) => name.endsWith('.tmp'))
+    ).toEqual([]);
+  });
+});
+
+describe('when the disk refuses', () => {
+  it('commits the edit and says the revision did not reach disk', async () => {
+    // A file where the root's parent directory has to be: `mkdir` cannot
+    // succeed, which is the cheap portable stand-in for a read-only or full
+    // disk.
+    const blocked = path.join(scratch, 'not-a-dir');
+    await fs.writeFile(blocked, 'occupied', 'utf8');
+    const store = createMemoryWorkspaceStore({
+      now: () => clock,
+      persistence: createWorkspacePersistenceAt(
+        path.join(blocked, 'workspaces')
+      ),
+    });
+
+    const created = unwrap(
+      await store.create({ format: 'docx', document: document() })
+    );
+    expect(created.record.persisted).toBe(false);
+    const warning = created.warnings?.[0];
+    expect(warning?.code).toBe(WORKSPACE_ERROR_CODES.NOT_PERSISTED);
+    expect(warning?.severity).toBe('warning');
+    expect(warning?.suggestion).toMatch(/jto_workspace_snapshot/);
+
+    // The edit itself landed, and keeps landing.
+    const patched = unwrap(
+      await store.patch({
+        handle: created.record.handle,
+        operations: [{ op: 'add', path: '/props/title', value: 'Draft' }],
+      })
+    );
+    expect(patched.record.revision).toBe(2);
+    expect(patched.warnings?.[0].code).toBe(
+      WORKSPACE_ERROR_CODES.NOT_PERSISTED
+    );
+  });
+});
+
+describe('configuration', () => {
+  it('is off unless a root is named', () => {
+    expect(createWorkspacePersistence({ env: {} })).toBeUndefined();
+    expect(
+      createWorkspacePersistence({ env: { [WORKSPACE_DIR_ENV]: '   ' } })
+    ).toBeUndefined();
+  });
+
+  it('takes the environment, and the flag over it', () => {
+    const fromEnv = createWorkspacePersistence({
+      env: { [WORKSPACE_DIR_ENV]: root },
+    });
+    expect(fromEnv?.root).toBe(root);
+
+    const flagged = path.join(scratch, 'flagged');
+    const fromFlag = createWorkspacePersistence({
+      flagDir: flagged,
+      env: { [WORKSPACE_DIR_ENV]: root },
+    });
+    expect(fromFlag?.root).toBe(flagged);
+  });
+
+  it('resolves a relative root against the working directory', () => {
+    const persistence = createWorkspacePersistence({ flagDir: 'ws-relative' });
+    expect(persistence?.root).toBe(path.resolve('ws-relative'));
+  });
+
+  it('does not create the root until something is written', async () => {
+    createWorkspacePersistenceAt(root);
+    await expect(fs.access(root)).rejects.toThrow();
+  });
+});

--- a/packages/mcp-server/src/__tests__/workspace-persistence.test.ts
+++ b/packages/mcp-server/src/__tests__/workspace-persistence.test.ts
@@ -13,7 +13,7 @@
  * which a real clock would make order-dependent on how fast the machine is.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
@@ -307,6 +307,43 @@ describe('closing', () => {
     const read = unwrap(await store.get(handle));
     expect((read.document as any).props.title).toBe('Kept');
   });
+
+  it('still lists the handle after closeAll, which is the way back to it', async () => {
+    const store = build();
+    const { handle } = await open(store);
+    await store.closeAll();
+
+    // `list` hides handles that were closed on purpose. A host reclaiming
+    // memory is not that, and hiding these would leave the recovery path
+    // pointing at nothing.
+    const listed = unwrap(await store.list());
+    expect(listed.records.map((record) => record.handle)).toEqual([handle]);
+  });
+
+  it('reports nothing closed, and keeps the workspace, when the disk refuses', async () => {
+    const store = build();
+    const { handle } = await open(store);
+
+    // A directory that cannot be removed, which is what a permission problem
+    // or a Windows file lock looks like from here.
+    const persistence = createWorkspacePersistenceAt(root);
+    const removal = vi
+      .spyOn(persistence, 'remove')
+      .mockRejectedValue(new Error('EPERM: operation not permitted'));
+    const guarded = createMemoryWorkspaceStore({
+      now: () => clock,
+      persistence,
+    });
+
+    const problem = failed(await guarded.close(handle));
+    expect(problem.code).toBe(WORKSPACE_ERROR_CODES.NOT_CLOSED);
+    expect(problem.message).toMatch(/still open and still on disk/);
+    removal.mockRestore();
+
+    // Nothing was released on the strength of a delete that did not happen.
+    expect(unwrap(await store.get(handle)).record.handle).toBe(handle);
+    expect(await handles()).toEqual([handle]);
+  });
 });
 
 describe('bounds', () => {
@@ -457,6 +494,52 @@ describe('a directory it did not write', () => {
       WORKSPACE_ERROR_CODES.NOT_PERSISTED
     );
     expect(await fs.readdir(scratch)).not.toContain('escaped');
+  });
+
+  it('writes its own document rather than trusting a revision number', async () => {
+    // Two connections on one root, both resuming revision 1 and both
+    // committing revision 2. The file name collides; the content does not.
+    // Trusting the name put one store's document under the other's metadata,
+    // which is worse than either of them simply losing.
+    const first = build();
+    const { handle } = await open(first);
+
+    const second = build();
+    await setTitle(second, handle, 'from second');
+    await setTitle(first, handle, 'from first');
+
+    const reconnected = build();
+    const read = unwrap(await reconnected.get(handle));
+    expect(read.record.revision).toBe(2);
+    // Last writer wins, whole: the document belongs to the metadata beside it.
+    expect((read.document as any).props.title).toBe('from first');
+    expect(read.record.bytes).toBe(
+      Buffer.byteLength(JSON.stringify(read.document))
+    );
+  });
+
+  it('reaps a temporary file an interrupted write left behind', async () => {
+    const store = build();
+    const { handle } = await open(store);
+    const dir = path.join(root, handle);
+
+    const debris = path.join(dir, 'rev-9.json.deadbeef.tmp');
+    await fs.writeFile(debris, '{"name":"docx"}', 'utf8');
+    const live = path.join(dir, 'rev-9.json.feedface.tmp');
+    await fs.writeFile(live, '{"name":"docx"}', 'utf8');
+
+    // Only one of them looks like a write that died: a `.tmp` exists for
+    // milliseconds, so an hour old is debris and anything newer may still
+    // belong to a write in flight on a shared root.
+    const old = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    await fs.utimes(debris, old, old);
+
+    await setTitle(store, handle, 'sweeps on write');
+
+    const left = (await fs.readdir(dir)).filter((name) =>
+      name.endsWith('.tmp')
+    );
+    expect(left).toEqual([path.basename(live)]);
   });
 
   it('never names a revision file the metadata does not have', async () => {

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -24,22 +24,56 @@ interface ParsedArgs {
   version: boolean;
   help: boolean;
   unknown: string[];
+  /** Flags that were given without a usable value. */
+  missingValue: string[];
+}
+
+/**
+ * A directory-valued flag, or a complaint.
+ *
+ * The naive `argv[++index]` swallows whatever comes next, so
+ * `--workspace-dir --version` silently starts a server whose workspace root is
+ * named "--version" and never prints the version — a path the user did not
+ * choose, made out of an option they did. The end of the argument list is the
+ * same defect with a quieter ending: an `undefined` value falls through to the
+ * environment, so a flag that was meant to be authoritative is simply ignored.
+ * Both are refusals here.
+ */
+function takeValue(
+  argv: readonly string[],
+  index: number
+): { value: string } | undefined {
+  const next = argv[index];
+  if (next === undefined || next.startsWith('-') || next.trim() === '') {
+    return undefined;
+  }
+  return { value: next };
 }
 
 export function parseArgs(argv: readonly string[]): ParsedArgs {
-  const parsed: ParsedArgs = { version: false, help: false, unknown: [] };
+  const parsed: ParsedArgs = {
+    version: false,
+    help: false,
+    unknown: [],
+    missingValue: [],
+  };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === '--version' || arg === '-v') {
       parsed.version = true;
     } else if (arg === '--help' || arg === '-h') {
       parsed.help = true;
-    } else if (arg === '--output-dir') {
-      parsed.outputDir = argv[++index];
+    } else if (arg === '--output-dir' || arg === '--workspace-dir') {
+      const taken = takeValue(argv, index + 1);
+      if (!taken) {
+        parsed.missingValue.push(arg);
+        continue;
+      }
+      index += 1;
+      if (arg === '--output-dir') parsed.outputDir = taken.value;
+      else parsed.workspaceDir = taken.value;
     } else if (arg.startsWith('--output-dir=')) {
       parsed.outputDir = arg.slice('--output-dir='.length);
-    } else if (arg === '--workspace-dir') {
-      parsed.workspaceDir = argv[++index];
     } else if (arg.startsWith('--workspace-dir=')) {
       parsed.workspaceDir = arg.slice('--workspace-dir='.length);
     } else {
@@ -93,6 +127,13 @@ function main(argv: readonly string[]): void {
   if (args.unknown.length > 0) {
     process.stderr.write(
       `jto-mcp: unknown argument ${args.unknown[0]}\nRun jto-mcp --help.\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (args.missingValue.length > 0) {
+    process.stderr.write(
+      `jto-mcp: ${args.missingValue[0]} needs a directory path.\nRun jto-mcp --help.\n`
     );
     process.exitCode = 1;
     return;

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -15,10 +15,12 @@ import { serveStdio } from '@modelcontextprotocol/server/stdio';
 import { createServerFactory } from './server.js';
 import { createToolDeps } from './lib/deps.js';
 import { OUTPUT_DIR_ENV } from './lib/output-root.js';
+import { WORKSPACE_DIR_ENV } from './workspace/persistence.js';
 import { SERVER_VERSION } from './lib/version.js';
 
 interface ParsedArgs {
   outputDir?: string;
+  workspaceDir?: string;
   version: boolean;
   help: boolean;
   unknown: string[];
@@ -36,6 +38,10 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
       parsed.outputDir = argv[++index];
     } else if (arg.startsWith('--output-dir=')) {
       parsed.outputDir = arg.slice('--output-dir='.length);
+    } else if (arg === '--workspace-dir') {
+      parsed.workspaceDir = argv[++index];
+    } else if (arg.startsWith('--workspace-dir=')) {
+      parsed.workspaceDir = arg.slice('--workspace-dir='.length);
     } else {
       parsed.unknown.push(arg);
     }
@@ -54,11 +60,16 @@ Options:
   --output-dir <path>  Directory generated files are written to. Overrides
                        ${OUTPUT_DIR_ENV}. Defaults to a per-connection
                        directory under the system temp dir.
+  --workspace-dir <p>  Directory workspace revisions are mirrored to, so a lost
+                       client session does not destroy them. Overrides
+                       ${WORKSPACE_DIR_ENV}. Off by default:
+                       without it, handles live only in memory.
   -v, --version        Print the version and exit.
   -h, --help           Print this help and exit.
 
 Environment:
   ${OUTPUT_DIR_ENV}    Output root, when --output-dir is absent.
+  ${WORKSPACE_DIR_ENV} Workspace root, when --workspace-dir is absent.
   LIBREOFFICE_PATH      LibreOffice binary, for preview.
   PDFTOPPM_PATH         poppler pdftoppm binary, for preview.
 
@@ -89,6 +100,7 @@ function main(argv: readonly string[]): void {
 
   const deps = createToolDeps({
     ...(args.outputDir !== undefined && { outputDir: args.outputDir }),
+    ...(args.workspaceDir !== undefined && { workspaceDir: args.workspaceDir }),
   });
 
   // No diagnostic sink is installed here. `jto-ops` emits its warnings

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -99,6 +99,25 @@ export {
 } from './lib/workspace-store.js';
 
 export {
+  createMemoryWorkspaceStore,
+  DEFAULT_WORKSPACE_LIMITS,
+  WORKSPACE_ERROR_CODES,
+  type MemoryWorkspaceStore,
+  type MemoryWorkspaceStoreOptions,
+  type WorkspaceLimits,
+} from './workspace/store.js';
+
+export {
+  createWorkspacePersistence,
+  createWorkspacePersistenceAt,
+  DEFAULT_PERSISTENCE_LIMITS,
+  WORKSPACE_DIR_ENV,
+  type PersistenceLimits,
+  type WorkspacePersistence,
+  type WorkspacePersistenceOptions,
+} from './workspace/persistence.js';
+
+export {
   getAdapter,
   resetAdapters,
   checkRenderer,

--- a/packages/mcp-server/src/lib/deps.ts
+++ b/packages/mcp-server/src/lib/deps.ts
@@ -11,6 +11,10 @@ import { MAX_INLINE_ARTIFACT_BYTES } from './artifacts.js';
 import { createOutputRoot, type OutputRoot } from './output-root.js';
 import { SERVER_VERSION } from './version.js';
 import { getWorkspaceStore, type WorkspaceStore } from './workspace-store.js';
+import {
+  createWorkspacePersistence,
+  type WorkspacePersistence,
+} from '../workspace/persistence.js';
 
 export interface ToolDeps {
   /** `@json-to-office/mcp-server`'s own version, as reported by `jto_info`. */
@@ -26,6 +30,15 @@ export interface ToolDeps {
    * registered, and a snapshot taken at registration would pin the stand-in.
    */
   workspaces(): WorkspaceStore;
+  /**
+   * Disk backing for that store (#290), when a root was configured.
+   *
+   * Undefined is the default and means memory-only handles. It lives here
+   * rather than inside the store because `tools/workspace.ts` is what builds
+   * the connection's store, and `jto_info` reports the root without touching
+   * one.
+   */
+  workspacePersistence?: WorkspacePersistence;
   /** Ceiling for `outputMode: 'base64'`, in bytes. */
   maxInlineArtifactBytes: number;
 }
@@ -34,6 +47,10 @@ export interface CreateToolDepsOptions {
   /** `--output-dir`, or an already-built root (tests hand one in). */
   outputDir?: string;
   outputRoot?: OutputRoot;
+  /** `--workspace-dir`. Absent, `JTO_MCP_WORKSPACE_DIR` decides. */
+  workspaceDir?: string;
+  /** An already-built persistence layer, for hosts and tests. */
+  workspacePersistence?: WorkspacePersistence;
   env?: NodeJS.ProcessEnv;
   serverVersion?: string;
   workspaces?: () => WorkspaceStore;
@@ -42,6 +59,15 @@ export interface CreateToolDepsOptions {
 }
 
 export function createToolDeps(options: CreateToolDepsOptions = {}): ToolDeps {
+  const workspacePersistence =
+    options.workspacePersistence ??
+    createWorkspacePersistence({
+      ...(options.workspaceDir !== undefined && {
+        flagDir: options.workspaceDir,
+      }),
+      ...(options.env !== undefined && { env: options.env }),
+    });
+
   return {
     serverVersion: options.serverVersion ?? SERVER_VERSION,
     outputRoot:
@@ -52,6 +78,7 @@ export function createToolDeps(options: CreateToolDepsOptions = {}): ToolDeps {
       }),
     getAdapter: options.getAdapter ?? getAdapter,
     workspaces: options.workspaces ?? getWorkspaceStore,
+    ...(workspacePersistence !== undefined && { workspacePersistence }),
     maxInlineArtifactBytes:
       options.maxInlineArtifactBytes ?? MAX_INLINE_ARTIFACT_BYTES,
   };

--- a/packages/mcp-server/src/lib/workspace-store.ts
+++ b/packages/mcp-server/src/lib/workspace-store.ts
@@ -19,10 +19,26 @@
  * failures (see `errors.ts`).
  */
 
-import { ERROR_CODES, failure, type Failure } from './errors.js';
+import {
+  ERROR_CODES,
+  failure,
+  type Diagnostic,
+  type Failure,
+} from './errors.js';
 import type { FormatName } from './adapters.js';
 
-export type WorkspaceResult<T> = ({ ok: true } & T) | Failure;
+/**
+ * A success may still have something to say.
+ *
+ * `warnings` is how a store reports what did not go wrong enough to fail the
+ * call — a revision that did not reach disk (#290) being the case that
+ * matters: the edit landed, the handle works, and the agent still needs to
+ * know it has stopped being recoverable. Tools fold these into the
+ * `diagnostics` of the result they were already returning.
+ */
+export type WorkspaceResult<T> =
+  | ({ ok: true; warnings?: Diagnostic[] } & T)
+  | Failure;
 
 /** RFC 6902 operation. Paths are RFC 6901 pointers — no private dialect (#271). */
 export interface JsonPatchOperation {
@@ -47,6 +63,11 @@ export interface WorkspaceRecord {
   title?: string;
   /** Revisions pinned by `snapshot`, still retrievable through `get`. */
   pinnedRevisions: number[];
+  /**
+   * Whether this revision is on disk and so survives the connection (#290).
+   * Absent when the store has no durable backing at all, which is the default.
+   */
+  persisted?: boolean;
 }
 
 export interface WorkspaceStore {
@@ -122,7 +143,9 @@ export interface WorkspaceStore {
    *
    * A connection's store is reachable only through its `ToolDeps`, so the
    * documents go when the connection's deps do; this is for a host that wants
-   * the memory back at a moment of its own choosing.
+   * the memory back at a moment of its own choosing. It releases memory only —
+   * a durable store keeps its copies, because an event that ends a connection
+   * is exactly what #290 stops being fatal.
    */
   closeAll(): Promise<void>;
 }

--- a/packages/mcp-server/src/tools/info.ts
+++ b/packages/mcp-server/src/tools/info.ts
@@ -308,7 +308,7 @@ export function register(server: McpServer, deps: ToolDeps): void {
     {
       title: 'Server info',
       description:
-        'Versions, supported formats with each renderer and whether its backend loads here, workspace availability, output-root and size limits, and whether the optional host dependencies (LibreOffice and poppler for jto_preview, a Highcharts export server for the DOCX `highcharts` component) are present on this host. Call this first.',
+        'Versions, supported formats with each renderer and whether its backend loads here, workspace availability and whether workspaces survive a lost connection, output-root and size limits, and whether the optional host dependencies (LibreOffice and poppler for jto_preview, a Highcharts export server for the DOCX `highcharts` component) are present on this host. Call this first.',
       annotations: { readOnlyHint: true, openWorldHint: false },
       inputSchema: S<{ includePreviewDependencies?: boolean }>({
         type: 'object',
@@ -398,8 +398,18 @@ export function register(server: McpServer, deps: ToolDeps): void {
               properties: {
                 available: { type: 'boolean' },
                 open: { type: 'integer' },
+                persistent: {
+                  type: 'boolean',
+                  description:
+                    'True when revisions are mirrored to disk and survive a lost connection; false when handles are memory-only, which is the default.',
+                },
+                root: {
+                  type: 'string',
+                  description:
+                    'Directory the revisions are mirrored to, when persistent.',
+                },
               },
-              required: ['available', 'open'],
+              required: ['available', 'open', 'persistent'],
               additionalProperties: false,
             },
             output: {
@@ -598,6 +608,10 @@ export function register(server: McpServer, deps: ToolDeps): void {
               workspaces: {
                 available: store.available,
                 open: listed.ok ? listed.records.length : 0,
+                persistent: deps.workspacePersistence !== undefined,
+                ...(deps.workspacePersistence && {
+                  root: deps.workspacePersistence.root,
+                }),
               },
               output: {
                 root: deps.outputRoot.path,

--- a/packages/mcp-server/src/tools/workspace.ts
+++ b/packages/mcp-server/src/tools/workspace.ts
@@ -55,6 +55,7 @@ import {
   type MemoryWorkspaceStore,
   type WorkspaceLimits,
 } from '../workspace/store.js';
+import type { PersistenceLimits } from '../workspace/persistence.js';
 
 const workspaceSchema = {
   type: 'object' as const,
@@ -83,6 +84,11 @@ const workspaceSchema = {
       description:
         'Revisions kept retrievable by jto_workspace_snapshot; read one back with `revision`.',
     },
+    persisted: {
+      type: 'boolean' as const,
+      description:
+        'True when this revision is mirrored to disk and so survives a lost connection. Absent when this connection has no workspace directory configured.',
+    },
   },
   required: [
     'handle',
@@ -92,6 +98,28 @@ const workspaceSchema = {
     'createdAt',
     'updatedAt',
     'pinnedRevisions',
+  ],
+  additionalProperties: false,
+};
+
+const persistenceSchema = {
+  type: 'object' as const,
+  description:
+    'Where revisions survive the connection. Absent when workspaces are memory-only, which is the default.',
+  properties: {
+    root: { type: 'string' as const },
+    maxWorkspaces: { type: 'integer' as const },
+    maxRevisionsPerWorkspace: {
+      type: 'integer' as const,
+      description: 'Revision files kept per handle: the head plus its pins.',
+    },
+    maxEntryBytes: { type: 'integer' as const },
+  },
+  required: [
+    'root',
+    'maxWorkspaces',
+    'maxRevisionsPerWorkspace',
+    'maxEntryBytes',
   ],
   additionalProperties: false,
 };
@@ -149,10 +177,16 @@ function isMemoryStore(store: WorkspaceStore): store is MemoryWorkspaceStore {
  * process-wide with `setWorkspaceStore` before `createServer` — including
  * `unavailableWorkspaceStore` to switch the feature off, which is why the
  * question asked here is "did the host install one", not "is it available".
+ *
+ * When the connection was given a workspace directory, the store it builds is
+ * disk-backed (#290): handles then outlive the connection, and a client that
+ * reconnects finds them again through `jto_workspace_list`.
  */
 function ensureStore(deps: ToolDeps): void {
   if (deps.workspaces().available || hasWorkspaceStore()) return;
-  const owned = createMemoryWorkspaceStore();
+  const owned = createMemoryWorkspaceStore(
+    deps.workspacePersistence ? { persistence: deps.workspacePersistence } : {}
+  );
   deps.workspaces = () => owned;
 }
 
@@ -206,9 +240,9 @@ export function register(server: McpServer, deps: ToolDeps): void {
           });
           if (!created.ok) return created;
 
-          return success(
-            { workspace: created.record },
-            seeded
+          return success({ workspace: created.record }, [
+            ...(created.warnings ?? []),
+            ...(seeded
               ? [
                   diagnostic(
                     'W_BLANK_DOCUMENT',
@@ -220,8 +254,8 @@ export function register(server: McpServer, deps: ToolDeps): void {
                     }
                   ),
                 ]
-              : []
-          );
+              : []),
+          ]);
         })
       )
   );
@@ -305,18 +339,21 @@ export function register(server: McpServer, deps: ToolDeps): void {
               )
             : [];
 
-          const diagnostics: Diagnostic[] = missingPaths.map((pointer) =>
-            diagnostic(
-              'W_PATH_NOT_FOUND',
-              `${pointer} does not resolve in revision ${read.record.revision}.`,
-              {
-                severity: 'warning',
-                path: pointer,
-                suggestion:
-                  'Read a shorter prefix of the pointer to see what is actually there.',
-              }
-            )
-          );
+          const diagnostics: Diagnostic[] = [
+            ...(read.warnings ?? []),
+            ...missingPaths.map((pointer) =>
+              diagnostic(
+                'W_PATH_NOT_FOUND',
+                `${pointer} does not resolve in revision ${read.record.revision}.`,
+                {
+                  severity: 'warning',
+                  path: pointer,
+                  suggestion:
+                    'Read a shorter prefix of the pointer to see what is actually there.',
+                }
+              )
+            ),
+          ];
 
           return success(
             {
@@ -395,7 +432,7 @@ export function register(server: McpServer, deps: ToolDeps): void {
             }),
           });
           if (!patched.ok) return patched;
-          return success({ workspace: patched.record });
+          return success({ workspace: patched.record }, patched.warnings ?? []);
         })
       )
   );
@@ -446,7 +483,7 @@ export function register(server: McpServer, deps: ToolDeps): void {
           const snapshot = await deps.workspaces().snapshot(args.handle);
           if (!snapshot.ok) return snapshot;
 
-          const diagnostics: Diagnostic[] = [];
+          const diagnostics: Diagnostic[] = [...(snapshot.warnings ?? [])];
           if (
             !snapshot.record.pinnedRevisions.includes(snapshot.record.revision)
           ) {
@@ -497,7 +534,7 @@ export function register(server: McpServer, deps: ToolDeps): void {
     {
       title: 'List open workspaces',
       description:
-        'Every document open on this connection, with its revision and size. Call this to recover handles you no longer have — it is the cheapest way back after losing track of what you opened. An empty list means nothing is open, not that anything failed.',
+        'Every document open on this connection, with its revision and size. Call this to recover handles you no longer have — it is the cheapest way back after losing track of what you opened, including after a reconnect when the server has a workspace directory. An empty list means nothing is open, not that anything failed.',
       annotations: { readOnlyHint: true, openWorldHint: false },
       inputSchema: S<Record<string, never>>({
         type: 'object',
@@ -513,6 +550,7 @@ export function register(server: McpServer, deps: ToolDeps): void {
               'False when this connection has workspaces switched off.',
           },
           limits: limitsSchema,
+          persistence: persistenceSchema,
           usage: {
             type: 'object',
             properties: {
@@ -535,15 +573,28 @@ export function register(server: McpServer, deps: ToolDeps): void {
           const budget: {
             limits?: WorkspaceLimits;
             usage?: ReturnType<MemoryWorkspaceStore['usage']>;
+            persistence?: PersistenceLimits & { root: string };
           } = isMemoryStore(store)
-            ? { limits: store.limits, usage: store.usage() }
+            ? {
+                limits: store.limits,
+                usage: store.usage(),
+                ...(store.persistence && {
+                  persistence: {
+                    root: store.persistence.root,
+                    ...store.persistence.limits,
+                  },
+                }),
+              }
             : {};
 
-          return success({
-            workspaces: listed.records as WorkspaceRecord[],
-            available: store.available,
-            ...budget,
-          });
+          return success(
+            {
+              workspaces: listed.records as WorkspaceRecord[],
+              available: store.available,
+              ...budget,
+            },
+            listed.warnings ?? []
+          );
         })
       )
   );
@@ -553,7 +604,7 @@ export function register(server: McpServer, deps: ToolDeps): void {
     {
       title: 'Close a workspace',
       description:
-        'Release a handle and the memory behind it, including its pinned snapshots. Idempotent: closing a handle that is already gone reports `closed: false` rather than failing. Snapshot anything you still want first — closing is not recoverable.',
+        'Release a handle and everything behind it — the document, its pinned snapshots, and the durable copy when this connection keeps one. Idempotent: closing a handle that is already gone reports `closed: false` rather than failing. Snapshot anything you still want first — closing is not recoverable.',
       annotations: {
         readOnlyHint: false,
         destructiveHint: true,

--- a/packages/mcp-server/src/tools/workspace.ts
+++ b/packages/mcp-server/src/tools/workspace.ts
@@ -63,7 +63,8 @@ const workspaceSchema = {
   properties: {
     handle: {
       type: 'string' as const,
-      description: 'Opaque, valid only on this connection.',
+      description:
+        'Opaque and server-generated. Valid only on this connection, unless the server has a workspace directory — then it survives a reconnect and jto_workspace_list hands it back.',
     },
     format: { type: 'string' as const, enum: [...FORMAT_NAMES] },
     revision: {

--- a/packages/mcp-server/src/workspace/persistence.ts
+++ b/packages/mcp-server/src/workspace/persistence.ts
@@ -54,6 +54,17 @@ const SCHEMA_VERSION = 1;
 const META_FILE = 'meta.json';
 const REVISION_PREFIX = 'rev-';
 const REVISION_SUFFIX = '.json';
+const TEMP_SUFFIX = '.tmp';
+
+/**
+ * How old a `.tmp` has to be before it is treated as debris.
+ *
+ * A temporary revision only exists between `writeFile` and `rename`, which is
+ * milliseconds; an hour is far past any write still in flight, including one
+ * belonging to another process sharing the root. Below that they are left
+ * alone, because deleting a live one would fail somebody else's write.
+ */
+const STALE_TEMP_MS = 60 * 60 * 1000;
 
 /**
  * Handles that may become a directory name.
@@ -145,6 +156,11 @@ export interface WorkspacePersistence {
   /**
    * Forget a workspace durably. Idempotent; answers whether anything was
    * there, which is how `close` reports a handle it only ever saw on disk.
+   *
+   * Throws when the directory is there and could not be deleted. That has to
+   * reach the caller: `jto_workspace_close` promises the document is gone, and
+   * a swallowed failure would report it closed while the JSON stayed readable
+   * by the next connection to use the handle.
    */
   remove(handle: string): Promise<boolean>;
 }
@@ -192,6 +208,27 @@ export function createWorkspacePersistenceAt(
   let ensured: Promise<void> | undefined;
 
   /**
+   * Revision files THIS layer wrote, per handle.
+   *
+   * A revision number is only immutable within one lineage. Two connections
+   * sharing a root can both restore revision N and both commit N+1 with
+   * different content, so "the file is already there" does not mean "the file
+   * is the bytes I am about to write" — trusting that put one store's document
+   * on disk under the other store's metadata, which is a worse failure than
+   * either of them losing. What a file name does prove is that a revision this
+   * layer itself wrote has not changed since, so authorship is what the skip
+   * is keyed on: no redundant writes in the normal single-client case, and a
+   * genuine last-writer-wins when a root is shared.
+   */
+  const authored = new Map<string, Set<number>>();
+
+  function claim(handle: string, revision: number): void {
+    const owned = authored.get(handle) ?? new Set<number>();
+    owned.add(revision);
+    authored.set(handle, owned);
+  }
+
+  /**
    * Create the root once, lazily.
    *
    * Deferred like the output root's: a connection that never opens a
@@ -223,7 +260,7 @@ export function createWorkspacePersistenceAt(
    * because two connections may share a configured root.
    */
   async function writeAtomic(target: string, contents: string): Promise<void> {
-    const temp = `${target}.${randomBytes(6).toString('hex')}.tmp`;
+    const temp = `${target}.${randomBytes(6).toString('hex')}${TEMP_SUFFIX}`;
     try {
       await fs.writeFile(temp, contents, { encoding: 'utf8', mode: 0o600 });
       await fs.rename(temp, target);
@@ -317,17 +354,22 @@ export function createWorkspacePersistenceAt(
       await fs
         .rm(dirFor(victim.handle), { recursive: true, force: true })
         .catch(() => undefined);
+      // Its files are gone, so the claims on them are worthless — and left
+      // here they would be one small `Set` per handle this process has ever
+      // written, for the lifetime of the process.
+      authored.delete(victim.handle);
     }
   }
 
   /**
-   * Delete revision files the metadata no longer names.
+   * Delete revision files the metadata no longer names, and debris.
    *
-   * Half-written `.tmp` files are deliberately left: `revisionOf` does not
-   * match them, and one could belong to a write another connection sharing
-   * this root is in the middle of. A leaked one is reaped with its workspace,
-   * by `remove` or by the workspace ceiling, so it cannot accumulate without
-   * bound.
+   * A `.tmp` only exists between `writeFile` and `rename`, so one that has
+   * been sitting there for an hour belongs to a process that died mid-write.
+   * Left forever they would accumulate one document per interrupted write and
+   * quietly put the workspace over the size bound it advertises; deleted
+   * eagerly they would break a live write from another connection on a shared
+   * root. The age check is what separates the two.
    */
   async function pruneRevisions(
     handle: string,
@@ -339,12 +381,23 @@ export function createWorkspacePersistenceAt(
     } catch {
       return;
     }
+    const owned = authored.get(handle);
     for (const name of names) {
+      const target = path.join(dirFor(handle), name);
+
+      if (name.endsWith(TEMP_SUFFIX)) {
+        if (await isStale(target)) {
+          await fs.rm(target, { force: true }).catch(() => undefined);
+        }
+        continue;
+      }
+
       const revision = revisionOf(name);
       if (revision === undefined || retained.has(revision)) continue;
-      await fs
-        .rm(path.join(dirFor(handle), name), { force: true })
-        .catch(() => undefined);
+      await fs.rm(target, { force: true }).catch(() => undefined);
+      // The bytes are gone, so the claim on them has to go too: a later
+      // revision reusing this number must be written, not skipped.
+      owned?.delete(revision);
     }
   }
 
@@ -391,12 +444,18 @@ export function createWorkspacePersistenceAt(
         pinned.push(pin.revision);
       }
 
+      const owned = authored.get(snapshot.handle);
       for (const document of files) {
-        const target = revisionFile(snapshot.handle, document.revision);
-        // Revisions are immutable, so an existing file is already the right
-        // bytes: only the head is ever new, and re-pinning is metadata.
-        if (await exists(target)) continue;
-        await writeAtomic(target, document.text);
+        // Skipped only when this layer wrote that exact revision itself, which
+        // is the case that repeats: re-persisting on a snapshot, and carrying
+        // pins forward on every later patch. Anything else is written, so the
+        // document on disk always belongs to the metadata written beside it.
+        if (owned?.has(document.revision)) continue;
+        await writeAtomic(
+          revisionFile(snapshot.handle, document.revision),
+          document.text
+        );
+        claim(snapshot.handle, document.revision);
       }
 
       const meta: PersistedMeta & { schema: number } = {
@@ -462,8 +521,14 @@ export function createWorkspacePersistenceAt(
     async remove(handle) {
       if (!isPersistableHandle(handle)) return false;
       const dir = dirFor(handle);
-      if (!(await exists(dir))) return false;
-      await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+      if (!(await exists(dir))) {
+        authored.delete(handle);
+        return false;
+      }
+      // Deliberately unguarded: a failure here means the document is still
+      // readable, and the caller has promised the agent it would not be.
+      await fs.rm(dir, { recursive: true, force: true });
+      authored.delete(handle);
       return true;
     },
   };
@@ -474,6 +539,17 @@ async function exists(target: string): Promise<boolean> {
     await fs.stat(target);
     return true;
   } catch {
+    return false;
+  }
+}
+
+/** Older than a write could plausibly still be in flight for. */
+async function isStale(target: string): Promise<boolean> {
+  try {
+    const { mtimeMs } = await fs.stat(target);
+    return Date.now() - mtimeMs > STALE_TEMP_MS;
+  } catch {
+    // Already gone, or unreadable: either way not ours to delete.
     return false;
   }
 }

--- a/packages/mcp-server/src/workspace/persistence.ts
+++ b/packages/mcp-server/src/workspace/persistence.ts
@@ -1,0 +1,545 @@
+/**
+ * Disk backing for workspaces (#290).
+ *
+ * #271 made the document JSON authoritative and then kept it in exactly one
+ * place: server memory. Anything that ends a connection — a host session
+ * reset, a client restart, a crash — took every revision with it, and
+ * `jto_workspace_snapshot` did not help because the pins lived in the same
+ * `Map`. This module is the durable half: memory stays the fast path and the
+ * only thing tools read from, and every committed revision is mirrored here so
+ * a reconnecting client can resume instead of re-authoring.
+ *
+ * Off unless a root is configured (`--workspace-dir`, `JTO_MCP_WORKSPACE_DIR`),
+ * because turning handles durable turns them cross-connection, and a server
+ * that started leaving documents on a user's disk without being asked would be
+ * a surprise rather than a feature.
+ *
+ * Three properties the layout is chosen for:
+ *
+ * - Crash safety. A revision file is written and renamed into place BEFORE the
+ *   metadata that names it, so `meta.json` never points at bytes that are not
+ *   there. Interrupt this at any point and what is on disk is either the old
+ *   revision or the new one, never half of either.
+ * - Cheap listing. Recovering handles after a reset reads one small
+ *   `meta.json` per workspace; the documents are only paid for when a handle
+ *   is actually used.
+ * - No caller-named paths. A handle is the only thing that reaches the
+ *   filesystem, and it is matched against a whitelist first, so nothing a
+ *   client sends can address a directory of its choosing.
+ *
+ * Nothing here is a tool result, so these functions throw rather than return
+ * diagnostics; the store catches and downgrades a write failure to a warning
+ * (`W_WORKSPACE_NOT_PERSISTED`), because losing durability is worth saying out
+ * loud and is never worth failing an edit over.
+ *
+ * Not a concurrency layer. Individual writes are atomic, so a root two
+ * connections share never tears — but each holds its own memory copy of an
+ * entry, and the second to commit a revision is the one on disk. The intended
+ * arrangement is one root per client, which is what a reconnect is.
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { randomBytes } from 'crypto';
+
+import { FORMAT_NAMES } from '../lib/schema.js';
+import type { FormatName } from '../lib/adapters.js';
+
+/** Env var that names the workspace root, below the `--workspace-dir` flag. */
+export const WORKSPACE_DIR_ENV = 'JTO_MCP_WORKSPACE_DIR';
+
+/** Bumped only if the on-disk shape changes; older directories are ignored. */
+const SCHEMA_VERSION = 1;
+
+const META_FILE = 'meta.json';
+const REVISION_PREFIX = 'rev-';
+const REVISION_SUFFIX = '.json';
+
+/**
+ * Handles that may become a directory name.
+ *
+ * The store's own handles are `ws_<base64url>`, but a host can inject its own
+ * generator and a client can send any string at all — and both end up here as
+ * a path segment. So the shape is whitelisted rather than sanitized: no
+ * separators, no dots, nothing to traverse with.
+ */
+const SAFE_HANDLE = /^[A-Za-z0-9_-]{1,128}$/;
+
+export function isPersistableHandle(handle: string): boolean {
+  return SAFE_HANDLE.test(handle);
+}
+
+export interface PersistenceLimits {
+  /** Workspaces kept on disk; the least recently updated go first. */
+  maxWorkspaces: number;
+  /** Revision files per workspace — the head plus its pinned revisions. */
+  maxRevisionsPerWorkspace: number;
+  /** Ceiling for a single revision file. */
+  maxEntryBytes: number;
+}
+
+/**
+ * Roomier than the memory limits on purpose.
+ *
+ * Memory bounds protect a process; these bound a directory that outlives it,
+ * where the cost of keeping a document is a few hundred kilobytes of disk and
+ * the cost of dropping one is authoring an agent has to redo. `maxWorkspaces`
+ * is twice the memory ceiling so a reconnecting client still finds what the
+ * previous connection had open, and the revision cap is the head plus the
+ * default eight pins, so a default setup never has to discard a pin it took.
+ */
+export const DEFAULT_PERSISTENCE_LIMITS: PersistenceLimits = {
+  maxWorkspaces: 32,
+  maxRevisionsPerWorkspace: 9,
+  maxEntryBytes: 16 * 1024 * 1024,
+};
+
+/** One retained revision: the serialized document and its size. */
+export interface PersistedDocument {
+  revision: number;
+  text: string;
+  bytes: number;
+}
+
+/** What the store hands over to be made durable. */
+export interface PersistedSnapshot {
+  handle: string;
+  format: FormatName;
+  createdAt: number;
+  updatedAt: number;
+  title?: string;
+  /** The current revision. */
+  head: PersistedDocument;
+  /** Revisions pinned by `snapshot`, oldest first. */
+  pins: readonly PersistedDocument[];
+}
+
+/** A workspace as `list` reports it, without paying for the documents. */
+export interface PersistedMeta {
+  handle: string;
+  format: FormatName;
+  revision: number;
+  bytes: number;
+  createdAt: number;
+  updatedAt: number;
+  title?: string;
+  pinnedRevisions: number[];
+}
+
+/** A workspace read back whole, ready to become a live entry again. */
+export interface RestoredWorkspace extends PersistedMeta {
+  head: PersistedDocument;
+  pins: PersistedDocument[];
+}
+
+export interface WorkspacePersistence {
+  /** Absolute path of the root. May not exist on disk until first write. */
+  readonly root: string;
+  readonly limits: PersistenceLimits;
+  /** Mirror a workspace's current state. Overwrites whatever was there. */
+  save(snapshot: PersistedSnapshot): Promise<void>;
+  /** Everything on disk, newest update first. Corrupt entries are skipped. */
+  list(): Promise<PersistedMeta[]>;
+  /** One workspace, documents included, or undefined when it is not there. */
+  load(handle: string): Promise<RestoredWorkspace | undefined>;
+  /**
+   * Forget a workspace durably. Idempotent; answers whether anything was
+   * there, which is how `close` reports a handle it only ever saw on disk.
+   */
+  remove(handle: string): Promise<boolean>;
+}
+
+export interface WorkspacePersistenceOptions
+  extends Partial<PersistenceLimits> {
+  /** `--workspace-dir` value, highest precedence. */
+  flagDir?: string;
+  /** Defaults to `process.env`; injectable so the precedence is testable. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Build the persistence layer, or answer `undefined` when none was configured.
+ *
+ * `undefined` rather than a no-op implementation: the store branches on
+ * whether it has durability at all — to decide what `jto_info` reports and
+ * whether an evicted handle is recoverable — and a stand-in that quietly
+ * discarded writes would make that question unanswerable.
+ */
+export function createWorkspacePersistence(
+  options: WorkspacePersistenceOptions = {}
+): WorkspacePersistence | undefined {
+  const env = options.env ?? process.env;
+  const configured = options.flagDir?.trim() || env[WORKSPACE_DIR_ENV]?.trim();
+  if (!configured) return undefined;
+  return createWorkspacePersistenceAt(path.resolve(configured), options);
+}
+
+/** The same layer on an explicit directory, for hosts and tests. */
+export function createWorkspacePersistenceAt(
+  root: string,
+  limits: Partial<PersistenceLimits> = {}
+): WorkspacePersistence {
+  const bounds: PersistenceLimits = {
+    maxWorkspaces:
+      limits.maxWorkspaces ?? DEFAULT_PERSISTENCE_LIMITS.maxWorkspaces,
+    maxRevisionsPerWorkspace:
+      limits.maxRevisionsPerWorkspace ??
+      DEFAULT_PERSISTENCE_LIMITS.maxRevisionsPerWorkspace,
+    maxEntryBytes:
+      limits.maxEntryBytes ?? DEFAULT_PERSISTENCE_LIMITS.maxEntryBytes,
+  };
+
+  let ensured: Promise<void> | undefined;
+
+  /**
+   * Create the root once, lazily.
+   *
+   * Deferred like the output root's: a connection that never opens a
+   * workspace should not leave a directory behind. 0o700 because these are the
+   * user's documents and the root may well be under a shared temp dir.
+   */
+  async function ensureRoot(): Promise<void> {
+    if (ensured === undefined) {
+      ensured = fs.mkdir(root, { recursive: true, mode: 0o700 }).then(
+        () => undefined,
+        (error: unknown) => {
+          ensured = undefined;
+          throw error;
+        }
+      );
+    }
+    return ensured;
+  }
+
+  function dirFor(handle: string): string {
+    return path.join(root, handle);
+  }
+
+  /**
+   * Write bytes so that a reader sees either the old file or the new one.
+   *
+   * `rename` within a directory is atomic on every platform this runs on, so
+   * the temp name is what absorbs an interrupted write. The suffix is random
+   * because two connections may share a configured root.
+   */
+  async function writeAtomic(target: string, contents: string): Promise<void> {
+    const temp = `${target}.${randomBytes(6).toString('hex')}.tmp`;
+    try {
+      await fs.writeFile(temp, contents, { encoding: 'utf8', mode: 0o600 });
+      await fs.rename(temp, target);
+    } catch (error) {
+      await fs.rm(temp, { force: true }).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  function revisionFile(handle: string, revision: number): string {
+    return path.join(
+      dirFor(handle),
+      `${REVISION_PREFIX}${revision}${REVISION_SUFFIX}`
+    );
+  }
+
+  async function readMeta(handle: string): Promise<PersistedMeta | undefined> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(path.join(dirFor(handle), META_FILE), 'utf8');
+    } catch {
+      return undefined;
+    }
+    return parseMeta(raw, handle);
+  }
+
+  async function readRevision(
+    handle: string,
+    revision: number
+  ): Promise<PersistedDocument | undefined> {
+    let text: string;
+    try {
+      text = await fs.readFile(revisionFile(handle, revision), 'utf8');
+    } catch {
+      return undefined;
+    }
+    // Parsed only to prove it is a document; the store wants the TEXT, which
+    // is its authoritative form, so the parse result is deliberately dropped.
+    try {
+      const parsed: unknown = JSON.parse(text);
+      if (
+        parsed === null ||
+        typeof parsed !== 'object' ||
+        Array.isArray(parsed)
+      )
+        return undefined;
+    } catch {
+      return undefined;
+    }
+    return { revision, text, bytes: Buffer.byteLength(text, 'utf8') };
+  }
+
+  /** Handles with a directory in the root, whatever state it is in. */
+  async function handleDirs(): Promise<string[]> {
+    try {
+      const entries = await fs.readdir(root, { withFileTypes: true });
+      return entries
+        .filter(
+          (entry) => entry.isDirectory() && isPersistableHandle(entry.name)
+        )
+        .map((entry) => entry.name);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Keep the root under `maxWorkspaces`, dropping the stalest first.
+   *
+   * Run before a new workspace's first write rather than on a timer, and
+   * `incoming` is both exempt and counted — it is about to exist, so making
+   * room for it is the whole point, and it can never evict itself.
+   */
+  async function pruneWorkspaces(incoming: string): Promise<void> {
+    const handles = (await handleDirs()).filter(
+      (handle) => handle !== incoming
+    );
+    const excess = handles.length + 1 - bounds.maxWorkspaces;
+    if (excess <= 0) return;
+
+    const metas = await Promise.all(
+      handles.map(async (handle) => ({
+        handle,
+        // An unreadable entry sorts first: it is the one worth losing.
+        updatedAt: (await readMeta(handle))?.updatedAt ?? 0,
+      }))
+    );
+    metas.sort((a, b) => a.updatedAt - b.updatedAt);
+
+    for (const victim of metas.slice(0, excess)) {
+      await fs
+        .rm(dirFor(victim.handle), { recursive: true, force: true })
+        .catch(() => undefined);
+    }
+  }
+
+  /**
+   * Delete revision files the metadata no longer names.
+   *
+   * Half-written `.tmp` files are deliberately left: `revisionOf` does not
+   * match them, and one could belong to a write another connection sharing
+   * this root is in the middle of. A leaked one is reaped with its workspace,
+   * by `remove` or by the workspace ceiling, so it cannot accumulate without
+   * bound.
+   */
+  async function pruneRevisions(
+    handle: string,
+    retained: ReadonlySet<number>
+  ): Promise<void> {
+    let names: string[];
+    try {
+      names = await fs.readdir(dirFor(handle));
+    } catch {
+      return;
+    }
+    for (const name of names) {
+      const revision = revisionOf(name);
+      if (revision === undefined || retained.has(revision)) continue;
+      await fs
+        .rm(path.join(dirFor(handle), name), { force: true })
+        .catch(() => undefined);
+    }
+  }
+
+  return {
+    root,
+    limits: bounds,
+
+    async save(snapshot) {
+      if (!isPersistableHandle(snapshot.handle)) {
+        throw new Error(
+          `Workspace handle ${JSON.stringify(
+            snapshot.handle
+          )} cannot be used as a directory name.`
+        );
+      }
+      if (snapshot.head.bytes > bounds.maxEntryBytes) {
+        throw new Error(
+          `Revision ${snapshot.head.revision} is ${snapshot.head.bytes} bytes, over the ${bounds.maxEntryBytes}-byte persistence limit.`
+        );
+      }
+
+      await ensureRoot();
+      const dir = dirFor(snapshot.handle);
+      const fresh = !(await exists(dir));
+      if (fresh) await pruneWorkspaces(snapshot.handle);
+      await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+
+      // Head first, then the pins newest-first, so a revision cap that bites
+      // discards the oldest pin rather than the document itself. A pin taken
+      // at the current head shares its file and costs nothing to keep — it is
+      // still listed, because the memory store lists it and a record that
+      // changed shape on recovery would be its own bug.
+      const files: PersistedDocument[] = [snapshot.head];
+      const retained = new Set([snapshot.head.revision]);
+      const pinned: number[] = [];
+      for (const pin of [...snapshot.pins].sort(
+        (a, b) => b.revision - a.revision
+      )) {
+        if (!retained.has(pin.revision)) {
+          if (files.length >= bounds.maxRevisionsPerWorkspace) continue;
+          files.push(pin);
+          retained.add(pin.revision);
+        }
+        pinned.push(pin.revision);
+      }
+
+      for (const document of files) {
+        const target = revisionFile(snapshot.handle, document.revision);
+        // Revisions are immutable, so an existing file is already the right
+        // bytes: only the head is ever new, and re-pinning is metadata.
+        if (await exists(target)) continue;
+        await writeAtomic(target, document.text);
+      }
+
+      const meta: PersistedMeta & { schema: number } = {
+        schema: SCHEMA_VERSION,
+        handle: snapshot.handle,
+        format: snapshot.format,
+        revision: snapshot.head.revision,
+        bytes: snapshot.head.bytes,
+        createdAt: snapshot.createdAt,
+        updatedAt: snapshot.updatedAt,
+        ...(snapshot.title !== undefined && { title: snapshot.title }),
+        pinnedRevisions: pinned.sort((a, b) => a - b),
+      };
+      await writeAtomic(path.join(dir, META_FILE), JSON.stringify(meta));
+
+      // Only now, with the metadata committed, is an older revision file
+      // unreferenced and safe to delete.
+      await pruneRevisions(snapshot.handle, retained);
+    },
+
+    async list() {
+      const handles = await handleDirs();
+      const metas = await Promise.all(
+        handles.map((handle) => readMeta(handle))
+      );
+      return metas
+        .filter((meta): meta is PersistedMeta => meta !== undefined)
+        .sort((a, b) => b.updatedAt - a.updatedAt);
+    },
+
+    async load(handle) {
+      if (!isPersistableHandle(handle)) return undefined;
+      const meta = await readMeta(handle);
+      if (!meta) return undefined;
+
+      const head = await readRevision(handle, meta.revision);
+      // Metadata without its document is a torn or hand-edited directory. It
+      // is not recoverable, and leaving it would keep answering `list` with a
+      // handle that fails on use, so it goes.
+      if (!head) {
+        await fs
+          .rm(dirFor(handle), { recursive: true, force: true })
+          .catch(() => undefined);
+        return undefined;
+      }
+
+      const pins: PersistedDocument[] = [];
+      for (const revision of meta.pinnedRevisions) {
+        const pin = await readRevision(handle, revision);
+        if (pin) pins.push(pin);
+      }
+
+      return {
+        ...meta,
+        // A pin whose file went missing is dropped rather than advertised: the
+        // record has to describe what can actually be read back.
+        pinnedRevisions: pins.map((pin) => pin.revision).sort((a, b) => a - b),
+        head,
+        pins,
+      };
+    },
+
+    async remove(handle) {
+      if (!isPersistableHandle(handle)) return false;
+      const dir = dirFor(handle);
+      if (!(await exists(dir))) return false;
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+      return true;
+    },
+  };
+}
+
+async function exists(target: string): Promise<boolean> {
+  try {
+    await fs.stat(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Revision number encoded in a file name, or undefined for anything else. */
+function revisionOf(name: string): number | undefined {
+  if (!name.startsWith(REVISION_PREFIX) || !name.endsWith(REVISION_SUFFIX)) {
+    return undefined;
+  }
+  const digits = name.slice(
+    REVISION_PREFIX.length,
+    name.length - REVISION_SUFFIX.length
+  );
+  if (!/^[0-9]+$/.test(digits)) return undefined;
+  return Number(digits);
+}
+
+/**
+ * Read metadata defensively.
+ *
+ * This directory outlives the process that wrote it and is a plain path a user
+ * can edit, back up or half-restore, so every field is checked before it is
+ * trusted — a corrupt entry is skipped, never allowed to become a live
+ * workspace whose record lies about what it holds.
+ */
+function parseMeta(raw: string, handle: string): PersistedMeta | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const meta = parsed as Record<string, unknown>;
+  if (meta.schema !== SCHEMA_VERSION) return undefined;
+  if (meta.handle !== handle) return undefined;
+  if (!FORMAT_NAMES.includes(meta.format as FormatName)) return undefined;
+  if (!isPositiveInteger(meta.revision)) return undefined;
+  if (!isNonNegativeInteger(meta.bytes)) return undefined;
+  if (!isNonNegativeInteger(meta.createdAt)) return undefined;
+  if (!isNonNegativeInteger(meta.updatedAt)) return undefined;
+  if (meta.title !== undefined && typeof meta.title !== 'string')
+    return undefined;
+
+  const pinnedRevisions = Array.isArray(meta.pinnedRevisions)
+    ? meta.pinnedRevisions.filter(isPositiveInteger)
+    : [];
+
+  return {
+    handle,
+    format: meta.format as FormatName,
+    revision: meta.revision,
+    bytes: meta.bytes,
+    createdAt: meta.createdAt,
+    updatedAt: meta.updatedAt,
+    ...(typeof meta.title === 'string' && { title: meta.title }),
+    pinnedRevisions: [...pinnedRevisions].sort((a, b) => a - b),
+  };
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}

--- a/packages/mcp-server/src/workspace/store.ts
+++ b/packages/mcp-server/src/workspace/store.ts
@@ -71,6 +71,12 @@ export const WORKSPACE_ERROR_CODES = {
    * has stopped being survivable and saying so is the whole point.
    */
   NOT_PERSISTED: 'W_WORKSPACE_NOT_PERSISTED',
+  /**
+   * A close could not delete the durable copy, so nothing was released (#290).
+   * An error rather than a warning: the agent asked for the document to be
+   * destroyed, and it is still there to be read by the next connection.
+   */
+  NOT_CLOSED: 'E_WORKSPACE_NOT_CLOSED',
 } as const;
 
 export type EvictionReason = 'ttl' | 'closed';
@@ -727,24 +733,40 @@ export function createMemoryWorkspaceStore(
     async close(handle) {
       sweep();
       const entry = entries.get(handle);
-      if (entry) evict(entry, 'closed');
 
       // Deliberately destructive on disk as well. `jto_workspace_close` is
       // documented as unrecoverable, and a durable copy that outlived it would
       // reappear on the next use of the handle — the opposite of what the
       // agent asked for. Note this reads no document: closing has to work when
       // the byte budget is too full to restore one.
+      //
+      // Disk goes FIRST, and nothing is released unless it succeeds. Reporting
+      // a close that left the JSON readable would be answering a request to
+      // destroy data with a claim the next connection disproves, so a failure
+      // here leaves the workspace exactly as it was — open, and retryable.
       let durable = false;
       if (persistence) {
         try {
           durable = await persistence.remove(handle);
-        } catch {
-          /* reported below as "nothing to close", never as a failure */
+        } catch (error) {
+          return failure(
+            WORKSPACE_ERROR_CODES.NOT_CLOSED,
+            `Workspace ${handle} could not be removed from ${persistence.root}: ${
+              error instanceof Error ? error.message : String(error)
+            }. It is still open and still on disk.`,
+            {
+              suggestion:
+                'Check the workspace directory is writable, then close again.',
+              context: { handle, workspaceRoot: persistence.root },
+            }
+          );
         }
-        // The revision is unknown here and unread: `missing` only surfaces one
-        // for a TTL eviction, which this is not.
-        if (durable && !entry) tombstone(handle, 'closed', 0);
       }
+
+      if (entry) evict(entry, 'closed');
+      // The revision is unknown for a handle this connection only ever saw on
+      // disk, and unread: `missing` only surfaces one for a TTL eviction.
+      else if (durable) tombstone(handle, 'closed', 0);
 
       return { ok: true, handle, closed: entry !== undefined || durable };
     },
@@ -758,7 +780,18 @@ export function createMemoryWorkspaceStore(
      * revisions. The handles come back from disk on next use.
      */
     async closeAll() {
-      for (const entry of [...entries.values()]) evict(entry, 'closed');
+      for (const entry of [...entries.values()]) {
+        if (!persistence) {
+          evict(entry, 'closed');
+          continue;
+        }
+        // No closed tombstone when there is a durable copy to come back to.
+        // `list` hides handles that were closed on purpose, and this is not
+        // that: the host wanted its memory back, and the root is still the way
+        // back to the work — which is the whole promise being kept here.
+        entries.delete(entry.handle);
+        tombstones.delete(entry.handle);
+      }
     },
   };
 

--- a/packages/mcp-server/src/workspace/store.ts
+++ b/packages/mcp-server/src/workspace/store.ts
@@ -23,7 +23,13 @@
 
 import { randomBytes } from 'crypto';
 
-import { ERROR_CODES, failure, type Failure } from '../lib/errors.js';
+import {
+  ERROR_CODES,
+  diagnostic,
+  failure,
+  type Diagnostic,
+  type Failure,
+} from '../lib/errors.js';
 import type {
   JsonPatchOperation,
   WorkspaceRecord,
@@ -37,6 +43,14 @@ import {
   parsePointer,
   resolvePointer,
 } from './json-pointer.js';
+import {
+  isPersistableHandle,
+  type PersistedDocument,
+  type PersistedMeta,
+  type PersistenceLimits,
+  type RestoredWorkspace,
+  type WorkspacePersistence,
+} from './persistence.js';
 
 /**
  * Workspace-lifecycle codes.
@@ -51,6 +65,12 @@ export const WORKSPACE_ERROR_CODES = {
   LIMIT: 'E_WORKSPACE_LIMIT',
   DOCUMENT_TOO_LARGE: 'E_DOCUMENT_TOO_LARGE',
   INVALID_ROOT: 'E_INVALID_DOCUMENT_ROOT',
+  /**
+   * A revision could not be mirrored to disk (#290). A warning, never a
+   * failure: the edit landed and the workspace is usable, but this connection
+   * has stopped being survivable and saying so is the whole point.
+   */
+  NOT_PERSISTED: 'W_WORKSPACE_NOT_PERSISTED',
 } as const;
 
 export type EvictionReason = 'ttl' | 'closed';
@@ -95,12 +115,22 @@ export interface MemoryWorkspaceStoreOptions extends Partial<WorkspaceLimits> {
   now?: () => number;
   /** Injectable handle source, for tests that need predictable handles. */
   newHandle?: () => string;
+  /**
+   * Disk backing (#290). Absent is the historical behaviour: memory only, and
+   * everything goes when the connection does.
+   */
+  persistence?: WorkspacePersistence;
 }
 
 export interface MemoryWorkspaceStore extends WorkspaceStore {
   readonly limits: WorkspaceLimits;
   /** Live totals, for `jto_workspace_list` to show the agent its budget. */
   usage(): { workspaces: number; bytes: number };
+  /**
+   * Where revisions survive the connection, when a root was configured.
+   * Absent means handles are memory-only and end with this process (#290).
+   */
+  readonly persistence?: { root: string; limits: PersistenceLimits };
 }
 
 interface Pin {
@@ -120,6 +150,8 @@ interface Entry {
   touchedAt: number;
   title?: string;
   pins: Map<number, Pin>;
+  /** Whether the last write to this entry reached disk (#290). */
+  persisted: boolean;
 }
 
 interface Tombstone {
@@ -144,6 +176,7 @@ export function createMemoryWorkspaceStore(
   };
   const now = options.now ?? Date.now;
   const newHandle = options.newHandle ?? defaultHandle;
+  const persistence = options.persistence;
 
   /** Insertion-ordered, which is also the order `list` reports. */
   const entries = new Map<string, Entry>();
@@ -161,12 +194,12 @@ export function createMemoryWorkspaceStore(
     return total;
   }
 
-  function tombstone(entry: Entry, reason: EvictionReason): void {
-    tombstones.set(entry.handle, {
-      reason,
-      at: now(),
-      revision: entry.revision,
-    });
+  function tombstone(
+    handle: string,
+    reason: EvictionReason,
+    revision: number
+  ): void {
+    tombstones.set(handle, { reason, at: now(), revision });
     // Oldest first: `Map` preserves insertion order, and a re-set handle is
     // deleted before it is written, so the order stays honest.
     while (tombstones.size > MAX_TOMBSTONES) {
@@ -179,7 +212,7 @@ export function createMemoryWorkspaceStore(
   function evict(entry: Entry, reason: EvictionReason): void {
     entries.delete(entry.handle);
     tombstones.delete(entry.handle);
-    tombstone(entry, reason);
+    tombstone(entry.handle, reason, entry.revision);
   }
 
   /**
@@ -195,6 +228,163 @@ export function createMemoryWorkspaceStore(
     for (const entry of [...entries.values()]) {
       if (at - entry.touchedAt > limits.idleTtlMs) evict(entry, 'ttl');
     }
+  }
+
+  /**
+   * Mirror an entry to disk, and say so when that did not take.
+   *
+   * Durability is best-effort by construction. The edit is already committed
+   * in memory when this runs, and refusing an otherwise good patch because a
+   * directory turned read-only would trade a working authoring loop for a
+   * guarantee the agent never asked for. What is NOT optional is reporting
+   * it: a workspace the agent believes will survive a lost connection and
+   * will not is the exact failure this feature exists to remove, so the
+   * warning rides back on the same result as the edit.
+   */
+  async function persist(entry: Entry): Promise<Diagnostic | undefined> {
+    if (!persistence) return undefined;
+    try {
+      await persistence.save({
+        handle: entry.handle,
+        format: entry.format,
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt,
+        ...(entry.title !== undefined && { title: entry.title }),
+        head: {
+          revision: entry.revision,
+          text: entry.text,
+          bytes: entry.bytes,
+        },
+        pins: [...entry.pins.entries()].map(([revision, pin]) => ({
+          revision,
+          text: pin.text,
+          bytes: pin.bytes,
+        })),
+      });
+      entry.persisted = true;
+      return undefined;
+    } catch (error) {
+      entry.persisted = false;
+      return diagnostic(
+        WORKSPACE_ERROR_CODES.NOT_PERSISTED,
+        `Revision ${entry.revision} of ${entry.handle} is held in memory but was not written to ${persistence.root}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        {
+          severity: 'warning',
+          suggestion:
+            'Export the JSON with jto_workspace_snapshot and keep it yourself; this handle will not survive a lost connection.',
+          context: {
+            handle: entry.handle,
+            revision: entry.revision,
+            workspaceRoot: persistence.root,
+          },
+        }
+      );
+    }
+  }
+
+  /** Wrap a record with whatever the write had to say. */
+  function committed(
+    record: WorkspaceRecord,
+    warning: Diagnostic | undefined
+  ): { ok: true; record: WorkspaceRecord; warnings?: Diagnostic[] } {
+    return { ok: true, record, ...(warning && { warnings: [warning] }) };
+  }
+
+  /**
+   * Bring a handle back from disk.
+   *
+   * This is the half of #290 an agent actually notices. After a host session
+   * reset the memory map is empty and the handle it is holding looks unknown,
+   * so every entry point that misses looks here before reporting it gone —
+   * the client resumes at the revision it left off at instead of re-authoring.
+   * The same path covers a handle the idle TTL swept, which is why eviction no
+   * longer has to mean loss.
+   *
+   * The memory budget applies exactly as it does to a create: a restore that
+   * does not fit is refused rather than allowed to push the connection past a
+   * limit it publishes. The document stays on disk, so freeing a workspace and
+   * asking again works.
+   */
+  async function rehydrate(
+    handle: string
+  ): Promise<{ ok: true; entry: Entry } | Failure | undefined> {
+    if (!persistence || !isPersistableHandle(handle)) return undefined;
+
+    let loaded: RestoredWorkspace | undefined;
+    try {
+      loaded = await persistence.load(handle);
+    } catch {
+      // An unreadable directory is indistinguishable from an absent one to the
+      // agent, and `missing` already says the useful thing about both.
+      return undefined;
+    }
+    if (!loaded) return undefined;
+    const restored = loaded;
+
+    // Disk may have been written by a connection with a roomier pin budget.
+    const pins: PersistedDocument[] = [...restored.pins]
+      .sort((a, b) => b.revision - a.revision)
+      .slice(0, limits.maxPinnedRevisions);
+
+    const needed = pins.reduce(
+      (total, pin) => total + pin.bytes,
+      restored.head.bytes
+    );
+    if (restored.head.bytes > limits.maxDocumentBytes) {
+      return tooLarge(restored.head.bytes, limits.maxDocumentBytes);
+    }
+    if (!hasRoom(needed, true)) {
+      return failure(
+        WORKSPACE_ERROR_CODES.LIMIT,
+        `Workspace ${handle} is on disk at revision ${restored.revision} but does not fit in this connection's ${limits.maxTotalBytes}-byte budget.`,
+        {
+          suggestion:
+            'Close a workspace you have finished with, then use this handle again.',
+          context: {
+            handle,
+            bytes: needed,
+            maxTotalBytes: limits.maxTotalBytes,
+            maxWorkspaces: limits.maxWorkspaces,
+          },
+        }
+      );
+    }
+
+    const entry: Entry = {
+      handle,
+      format: restored.format,
+      revision: restored.head.revision,
+      text: restored.head.text,
+      bytes: restored.head.bytes,
+      createdAt: restored.createdAt,
+      updatedAt: restored.updatedAt,
+      touchedAt: now(),
+      ...(restored.title !== undefined && { title: restored.title }),
+      pins: new Map(
+        pins.map((pin) => [pin.revision, { text: pin.text, bytes: pin.bytes }])
+      ),
+      persisted: true,
+    };
+    entries.set(handle, entry);
+    // The handle is live again, so whatever the tombstone said about it is
+    // no longer true.
+    tombstones.delete(handle);
+    return { ok: true, entry };
+  }
+
+  /**
+   * The entry behind a handle: resident, restored from disk, or a failure
+   * explaining which kind of gone it is.
+   */
+  async function resolve(handle: string): Promise<{ entry: Entry } | Failure> {
+    const entry = entries.get(handle);
+    if (entry) return { entry };
+    const restored = await rehydrate(handle);
+    if (restored === undefined) return missing(handle);
+    if (!restored.ok) return restored;
+    return { entry: restored.entry };
   }
 
   function missing(handle: string): Failure {
@@ -246,12 +436,38 @@ export function createMemoryWorkspaceStore(
       updatedAt: new Date(entry.updatedAt).toISOString(),
       ...(entry.title !== undefined && { title: entry.title }),
       pinnedRevisions: [...entry.pins.keys()].sort((a, b) => a - b),
+      ...(persistence && { persisted: entry.persisted }),
+    };
+  }
+
+  /**
+   * A record for a workspace that is on disk but not in memory (#290).
+   *
+   * Built from the metadata alone: `jto_workspace_list` after a reconnect is
+   * how an agent finds the handles it lost, and making it read every document
+   * back would charge that recovery the full price of the connection it is
+   * recovering from. The documents load when a handle is used.
+   */
+  function fromMeta(meta: PersistedMeta): WorkspaceRecord {
+    return {
+      handle: meta.handle,
+      format: meta.format,
+      revision: meta.revision,
+      bytes: meta.bytes,
+      createdAt: new Date(meta.createdAt).toISOString(),
+      updatedAt: new Date(meta.updatedAt).toISOString(),
+      ...(meta.title !== undefined && { title: meta.title }),
+      pinnedRevisions: [...meta.pinnedRevisions],
+      persisted: true,
     };
   }
 
   return {
     available: true,
     limits,
+    ...(persistence && {
+      persistence: { root: persistence.root, limits: persistence.limits },
+    }),
 
     usage() {
       sweep();
@@ -299,15 +515,20 @@ export function createMemoryWorkspaceStore(
         touchedAt: at,
         ...(input.title !== undefined && { title: input.title }),
         pins: new Map(),
+        persisted: false,
       };
       entries.set(entry.handle, entry);
-      return { ok: true, record: toRecord(entry) };
+      // Ordered: `toRecord` reports `persisted`, so the write has to have been
+      // attempted before the record describing it is built.
+      const warning = await persist(entry);
+      return committed(toRecord(entry), warning);
     },
 
     async get(handle, readOptions) {
       sweep();
-      const entry = entries.get(handle);
-      if (!entry) return missing(handle);
+      const found = await resolve(handle);
+      if (!('entry' in found)) return found;
+      const entry = found.entry;
       entry.touchedAt = now();
 
       let text = entry.text;
@@ -354,8 +575,9 @@ export function createMemoryWorkspaceStore(
 
     async patch(input) {
       sweep();
-      const entry = entries.get(input.handle);
-      if (!entry) return missing(input.handle);
+      const found = await resolve(input.handle);
+      if (!('entry' in found)) return found;
+      const entry = found.entry;
       entry.touchedAt = now();
 
       if (
@@ -436,13 +658,15 @@ export function createMemoryWorkspaceStore(
       entry.revision += 1;
       entry.updatedAt = now();
       entry.touchedAt = entry.updatedAt;
-      return { ok: true, record: toRecord(entry) };
+      const warning = await persist(entry);
+      return committed(toRecord(entry), warning);
     },
 
     async snapshot(handle) {
       sweep();
-      const entry = entries.get(handle);
-      if (!entry) return missing(handle);
+      const found = await resolve(handle);
+      if (!('entry' in found)) return found;
+      const entry = found.entry;
       entry.touchedAt = now();
 
       const revision = entry.revision;
@@ -461,25 +685,78 @@ export function createMemoryWorkspaceStore(
         }
       }
 
-      return { ok: true, record: toRecord(entry), document };
+      // The pin is part of what survives, so it is written before the agent
+      // is told it exists — and before `toRecord` reports `persisted`.
+      const warning = entry.pins.has(revision)
+        ? await persist(entry)
+        : undefined;
+
+      return {
+        ok: true,
+        record: toRecord(entry),
+        document,
+        ...(warning && { warnings: [warning] }),
+      };
     },
 
     async list() {
       sweep();
-      return {
-        ok: true,
-        records: [...entries.values()].map((entry) => toRecord(entry)),
-      };
+      const records = [...entries.values()].map((entry) => toRecord(entry));
+      if (!persistence) return { ok: true, records };
+
+      // Resident first, in the order they were opened, then whatever else the
+      // root still holds — which after a reconnect is everything, and is the
+      // only way back to a handle the client no longer has.
+      const resident = new Set(records.map((record) => record.handle));
+      let stored: PersistedMeta[] = [];
+      try {
+        stored = await persistence.list();
+      } catch {
+        /* an unreadable root simply contributes nothing */
+      }
+      for (const meta of stored) {
+        if (resident.has(meta.handle)) continue;
+        // A close is a decision, not a cache miss: a durable copy that
+        // outlived one is not offered back.
+        if (tombstones.get(meta.handle)?.reason === 'closed') continue;
+        records.push(fromMeta(meta));
+      }
+      return { ok: true, records };
     },
 
     async close(handle) {
       sweep();
       const entry = entries.get(handle);
-      if (!entry) return { ok: true, handle, closed: false };
-      evict(entry, 'closed');
-      return { ok: true, handle, closed: true };
+      if (entry) evict(entry, 'closed');
+
+      // Deliberately destructive on disk as well. `jto_workspace_close` is
+      // documented as unrecoverable, and a durable copy that outlived it would
+      // reappear on the next use of the handle — the opposite of what the
+      // agent asked for. Note this reads no document: closing has to work when
+      // the byte budget is too full to restore one.
+      let durable = false;
+      if (persistence) {
+        try {
+          durable = await persistence.remove(handle);
+        } catch {
+          /* reported below as "nothing to close", never as a failure */
+        }
+        // The revision is unknown here and unread: `missing` only surfaces one
+        // for a TTL eviction, which this is not.
+        if (durable && !entry) tombstone(handle, 'closed', 0);
+      }
+
+      return { ok: true, handle, closed: entry !== undefined || durable };
     },
 
+    /**
+     * Release memory, keep the disk.
+     *
+     * The asymmetry with `close` is the point: this exists for a host
+     * reclaiming memory at a moment of its own choosing, and #290 is precisely
+     * about an event that ends a connection not being allowed to destroy
+     * revisions. The handles come back from disk on next use.
+     */
     async closeAll() {
       for (const entry of [...entries.values()]) evict(entry, 'closed');
     },


### PR DESCRIPTION
Closes #290.

## Problem

Workspaces were memory-only. `entries`, `tombstones` and per-revision `pins` all lived in `Map`s built per connection, with no disk backing and no export path — so the authoritative artifact, the document JSON, existed in exactly one place: server memory. Any event that ended the connection discarded every revision. `jto_workspace_snapshot` did not help, because the pins were in the same memory.

## What this adds

`--workspace-dir <path>` / `JTO_MCP_WORKSPACE_DIR` makes the connection's store disk-backed. **Off by default** — without it, handles stay memory-only and end with the connection, exactly as before.

With a root configured:

- `jto_workspace_create`, `_patch` and `_snapshot` mirror the revision before they answer; the `workspace` record carries `persisted`.
- `jto_workspace_list` merges in every workspace under the root, including ones this connection never opened — that is how a reconnecting agent gets its handles back. `jto_workspace_inspect` (and any other handle-taking tool) loads the document on demand.
- The idle TTL still releases memory but no longer loses anything: the handle comes back from disk on next use.
- `jto_workspace_close` deletes the durable copy too — it is the one operation meant to destroy work. `closeAll` (a host reclaiming memory) does not.
- `jto_info.workspaces` gains `persistent` / `root`; `jto_workspace_list` gains `persistence`.

## Layout and durability

One directory per handle: `meta.json` plus `rev-<n>.json` for the head and its pins. The revision file is renamed into place **before** the metadata that names it, so `meta.json` never points at bytes that are not there — interrupt a write at any point and what is on disk is either the old revision or the new one. Listing after a reconnect reads one small `meta.json` per workspace; documents are only paid for when a handle is used. A handle is the only thing that reaches the filesystem and is whitelisted before it becomes a path segment; corrupt or half-restored directories are skipped rather than made live.

Bounded as the issue asked: 32 workspaces (least-recently-updated evicted first), 9 revision files per handle (head + its pins), 16 MiB per revision.

**Durability degrades loudly.** A revision that cannot be written comes back as a `W_WORKSPACE_NOT_PERSISTED` warning with the edit applied — never as a failed edit. A workspace the agent believes is survivable and is not is the exact failure this feature exists to remove.

## Tests

- `workspace-persistence.test.ts` — 27 cases, most of them built around a *second* store on the same root, which is what a reconnecting client gets: revisions and pins read back, conditional writes honoured on a resumed handle, TTL recovery, close-destroys / closeAll-keeps, all three bounds, corrupt metadata, a missing revision file, handle traversal, a disk that refuses, and the config precedence.
- `stdio-workspace-recovery.test.ts` — the reported failure end to end: one child process authors five revisions, is killed with nothing exported, and a second child given only the same `--workspace-dir` finds the handle through `jto_workspace_list`, reads it, validates by handle and keeps patching.

Full repo suite green (serial). The `persisted` flag being reported before the write had actually happened was a real bug the stdio suite caught and the in-process one could not — pinned by a test now.

## Note

Handles become cross-connection when this is on. Individual writes are atomic, but two connections sharing a root each keep their own memory copy, and `baseRevision` guards a write against the connection that made it. One root per client is the arrangement this is built for; both READMEs say so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspaces can survive lost connections when disk persistence is enabled with `--workspace-dir` or `JTO_MCP_WORKSPACE_DIR`.
  * Workspaces restore across sessions, while memory is released after idle expiration.
  * Workspace information and listings show persistence status and location.
  * Closing a workspace removes its durable copy.

* **Bug Fixes**
  * Persistence failures no longer prevent edits from being applied; a warning is reported instead.
  * Invalid directory options now produce clear startup errors.

* **Documentation**
  * Added guidance for configuring and using disk-backed workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->