### PR TITLE
fix(mcp): serialize durable workspace operations (#290 follow-up)

### DIFF
--- a/.changeset/mcp-serialize-durable-workspace-ops.md
+++ b/.changeset/mcp-serialize-durable-workspace-ops.md
@@ -1,0 +1,29 @@
+---
+'@json-to-office/mcp-server': patch
+---
+
+Serialize the durable side of MCP workspaces, so concurrent tool calls cannot
+undo each other (follow-up to #290, shipped in 1.8.0).
+
+Tool calls are independent async tasks and agents pipeline them, which left two
+orderings broken. A `jto_workspace_close` that deleted the directory while a
+`jto_workspace_patch` was still writing could have the write recreate it, so a
+workspace the agent had been told was destroyed came back on the next use of
+the handle. And two workspaces opened at once each counted the root before
+either had created its directory, so both saw room under `maxWorkspaces` — and
+one could delete the other's half-written directory, which sorts stalest
+precisely because its metadata is not there yet.
+
+Every durable operation for a connection now runs through one queue, and a
+close performs its delete and its eviction in a single critical section. A
+write that reaches the front of the queue after its workspace is gone declines
+to recreate it and reports `persisted: false`, rather than claiming durability
+for a revision that was never written. The queue is root-scoped rather than
+per-handle on purpose: the count-then-prune sequence is about the root, so a
+per-handle lock would not have covered it.
+
+Also fixes a hazard found while tracing those: rehydrating a workspace deleted
+the whole directory whenever the head revision file was missing, which a
+concurrent prune causes benignly — a read that picked up revision N's metadata
+a moment before a save committed N+1 and pruned N. It now re-reads the metadata
+before treating a directory as torn.

--- a/packages/mcp-server/src/__tests__/workspace-persistence.test.ts
+++ b/packages/mcp-server/src/__tests__/workspace-persistence.test.ts
@@ -321,28 +321,130 @@ describe('closing', () => {
   });
 
   it('reports nothing closed, and keeps the workspace, when the disk refuses', async () => {
-    const store = build();
+    // The store under test has to be the one whose close fails, or "the entry
+    // survived" is a claim about some other store's memory.
+    const persistence = createWorkspacePersistenceAt(root);
+    const store = createMemoryWorkspaceStore({ now: () => clock, persistence });
     const { handle } = await open(store);
 
     // A directory that cannot be removed, which is what a permission problem
     // or a Windows file lock looks like from here.
-    const persistence = createWorkspacePersistenceAt(root);
     const removal = vi
       .spyOn(persistence, 'remove')
       .mockRejectedValue(new Error('EPERM: operation not permitted'));
-    const guarded = createMemoryWorkspaceStore({
-      now: () => clock,
-      persistence,
-    });
 
-    const problem = failed(await guarded.close(handle));
+    const problem = failed(await store.close(handle));
     expect(problem.code).toBe(WORKSPACE_ERROR_CODES.NOT_CLOSED);
     expect(problem.message).toMatch(/still open and still on disk/);
-    removal.mockRestore();
 
-    // Nothing was released on the strength of a delete that did not happen.
-    expect(unwrap(await store.get(handle)).record.handle).toBe(handle);
+    // Still resident, not merely still on disk: a read that had to go to the
+    // disk would mean the entry was released on the strength of a delete that
+    // never happened.
+    const load = vi.spyOn(persistence, 'load');
+    expect(unwrap(await store.get(handle)).record.revision).toBe(1);
+    expect(load).not.toHaveBeenCalled();
+    load.mockRestore();
     expect(await handles()).toEqual([handle]);
+
+    // And the failure is what it says it is: retryable.
+    removal.mockRestore();
+    expect(unwrap(await store.close(handle)).closed).toBe(true);
+    expect(await handles()).toEqual([]);
+  });
+});
+
+describe('overlapping calls', () => {
+  it('does not let a patch in flight resurrect a closed workspace', async () => {
+    const persistence = createWorkspacePersistenceAt(root);
+    const store = createMemoryWorkspaceStore({ now: () => clock, persistence });
+    const { handle } = await open(store);
+
+    // The interleaving is forced rather than hoped for: the patch's write is
+    // held open, so the close is guaranteed to arrive while it is in flight —
+    // the arrangement in which an unserialized save recreates the directory
+    // the close just deleted.
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const write = persistence.save.bind(persistence);
+    vi.spyOn(persistence, 'save').mockImplementationOnce(async (snapshot) => {
+      await held;
+      return write(snapshot);
+    });
+
+    const patching = store.patch({
+      handle,
+      operations: [{ op: 'add', path: '/props/title', value: 'racing' }],
+    });
+    const closing = store.close(handle);
+    release();
+    const [patched, closed] = await Promise.all([patching, closing]);
+
+    expect(unwrap(closed).closed).toBe(true);
+    // Whichever order they landed in, the close is the last word on disk.
+    expect(await handles()).toEqual([]);
+    expect(unwrap(await store.list()).records).toEqual([]);
+    expect(failed(await build().get(handle)).code).toBe(
+      ERROR_CODES.UNKNOWN_HANDLE
+    );
+    // The patch either committed before the close or reported the handle
+    // gone; what it may not do is leave the document behind.
+    if (patched.ok) expect(patched.record.revision).toBe(2);
+  });
+
+  it('drops a write that was queued behind the close of its own workspace', async () => {
+    // The other ordering. Here the close reaches the disk first, so the
+    // queue alone cannot help: the write that comes after has to notice the
+    // workspace it belongs to is gone and decline to recreate it.
+    const persistence = createWorkspacePersistenceAt(root);
+    const store = createMemoryWorkspaceStore({ now: () => clock, persistence });
+    const { handle } = await open(store);
+
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const erase = persistence.remove.bind(persistence);
+    vi.spyOn(persistence, 'remove').mockImplementationOnce(async (target) => {
+      await held;
+      return erase(target);
+    });
+
+    const closing = store.close(handle);
+    const patching = store.patch({
+      handle,
+      operations: [{ op: 'add', path: '/props/title', value: 'too late' }],
+    });
+    release();
+    const [closed, patched] = await Promise.all([closing, patching]);
+
+    expect(unwrap(closed).closed).toBe(true);
+    expect(await handles()).toEqual([]);
+    // The patch may well have committed in memory — it was applied before the
+    // close landed — but it must not have put the workspace back on disk.
+    if (patched.ok) expect(patched.record.persisted).toBe(false);
+  });
+
+  it('holds the workspace ceiling when several are opened at once', async () => {
+    const store = build({ limits: { maxWorkspaces: 2 } });
+
+    // Concurrent first saves each count the root before any of them has
+    // created its directory, so unserialized they all see room.
+    const created = await Promise.all([
+      store.create({ format: 'docx', document: document() }),
+      store.create({ format: 'docx', document: document() }),
+      store.create({ format: 'docx', document: document() }),
+    ]);
+    for (const result of created) expect(result.ok).toBe(true);
+
+    expect(await handles()).toHaveLength(2);
+    // Every surviving directory is whole — none was deleted mid-write by a
+    // sibling that thought it was pruning something stale.
+    for (const handle of await handles()) {
+      const restored = await createWorkspacePersistenceAt(root).load(handle);
+      expect(restored?.head.revision).toBe(1);
+    }
   });
 });
 

--- a/packages/mcp-server/src/workspace/persistence.ts
+++ b/packages/mcp-server/src/workspace/persistence.ts
@@ -143,6 +143,19 @@ export interface RestoredWorkspace extends PersistedMeta {
   pins: PersistedDocument[];
 }
 
+/**
+ * The durable half of a workspace store.
+ *
+ * Not internally synchronized: `save` and `remove` each read the root, decide
+ * what to prune and then act, so two of them running at once can both decide
+ * there is room, or one can delete a directory the other is half way through
+ * writing. Callers serialize — `createMemoryWorkspaceStore` runs every durable
+ * operation through one queue, which is also where the ordering against a
+ * close is settled. Reads (`list`, `load`) need no such treatment: metadata is
+ * renamed into place after the revision it names, so a concurrent read sees
+ * one committed state or the other, and `load` re-reads before it treats a
+ * missing document as a torn directory.
+ */
 export interface WorkspacePersistence {
   /** Absolute path of the root. May not exist on disk until first write. */
   readonly root: string;
@@ -488,10 +501,24 @@ export function createWorkspacePersistenceAt(
 
     async load(handle) {
       if (!isPersistableHandle(handle)) return undefined;
-      const meta = await readMeta(handle);
-      if (!meta) return undefined;
 
-      const head = await readRevision(handle, meta.revision);
+      // Read twice before condemning anything. A read is not serialized
+      // against a write, so a `load` that picked up revision N's metadata a
+      // moment before a save committed N+1 and pruned N finds the document it
+      // was promised gone — through no fault of the directory. The retry sees
+      // the newer metadata and succeeds; only a directory that is still
+      // missing its own head on the second look is genuinely torn.
+      let meta = await readMeta(handle);
+      if (!meta) return undefined;
+      let head = await readRevision(handle, meta.revision);
+      if (!head) {
+        const second = await readMeta(handle);
+        if (second) {
+          meta = second;
+          head = await readRevision(handle, second.revision);
+        }
+      }
+
       // Metadata without its document is a torn or hand-edited directory. It
       // is not recoverable, and leaving it would keep answering `list` with a
       // handle that fails on use, so it goes.

--- a/packages/mcp-server/src/workspace/store.ts
+++ b/packages/mcp-server/src/workspace/store.ts
@@ -237,6 +237,34 @@ export function createMemoryWorkspaceStore(
   }
 
   /**
+   * One durable operation at a time.
+   *
+   * Every tool call is its own async task, so a client that pipelines — and
+   * agents do, they fan tool calls out — can have `jto_workspace_patch`
+   * awaiting a write while `jto_workspace_close` starts deleting the same
+   * directory. Two orderings go wrong without this: a save can recreate a
+   * directory a close has already removed, resurrecting a workspace the agent
+   * was told was destroyed; and two first saves can each read the workspace
+   * count, both decide there is room, and one can then delete the other's
+   * half-written directory. Both are the same defect as the swallowed `rm`
+   * error — a promise about durability that the next call disproves.
+   *
+   * A single chain rather than one per handle: the operations being ordered
+   * are a few milliseconds of filesystem work, they contend on one disk
+   * anyway, and the count-then-prune sequence is about the ROOT, so a
+   * per-handle lock would not have covered it.
+   */
+  let durable: Promise<unknown> = Promise.resolve();
+
+  function queued<T>(work: () => Promise<T>): Promise<T> {
+    const running = durable.then(work);
+    // The chain must survive a failed operation, so what the next one waits on
+    // is the settled shape of this one, not its rejection.
+    durable = running.catch(() => undefined);
+    return running;
+  }
+
+  /**
    * Mirror an entry to disk, and say so when that did not take.
    *
    * Durability is best-effort by construction. The edit is already committed
@@ -250,44 +278,70 @@ export function createMemoryWorkspaceStore(
   async function persist(entry: Entry): Promise<Diagnostic | undefined> {
     if (!persistence) return undefined;
     try {
-      await persistence.save({
-        handle: entry.handle,
-        format: entry.format,
-        createdAt: entry.createdAt,
-        updatedAt: entry.updatedAt,
-        ...(entry.title !== undefined && { title: entry.title }),
-        head: {
-          revision: entry.revision,
-          text: entry.text,
-          bytes: entry.bytes,
-        },
-        pins: [...entry.pins.entries()].map(([revision, pin]) => ({
-          revision,
-          text: pin.text,
-          bytes: pin.bytes,
-        })),
+      const written = await queued(async () => {
+        // Checked here, inside the queue, rather than before joining it: a
+        // close that ran while this was waiting has already taken the
+        // directory away, and writing now would put it back.
+        if (entries.get(entry.handle) !== entry) return false;
+        await saveEntry(entry);
+        return true;
       });
+      if (!written) {
+        // Skipped because the workspace was closed while this waited. No
+        // warning — the agent asked for that close and was told it happened —
+        // but the record must not claim durability for a revision that was
+        // never written.
+        entry.persisted = false;
+        return undefined;
+      }
       entry.persisted = true;
       return undefined;
     } catch (error) {
       entry.persisted = false;
-      return diagnostic(
-        WORKSPACE_ERROR_CODES.NOT_PERSISTED,
-        `Revision ${entry.revision} of ${entry.handle} is held in memory but was not written to ${persistence.root}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-        {
-          severity: 'warning',
-          suggestion:
-            'Export the JSON with jto_workspace_snapshot and keep it yourself; this handle will not survive a lost connection.',
-          context: {
-            handle: entry.handle,
-            revision: entry.revision,
-            workspaceRoot: persistence.root,
-          },
-        }
-      );
+      return notPersisted(entry, error);
     }
+  }
+
+  /** The write itself, always called from inside the queue. */
+  async function saveEntry(entry: Entry): Promise<void> {
+    if (!persistence) return;
+    await persistence.save({
+      handle: entry.handle,
+      format: entry.format,
+      createdAt: entry.createdAt,
+      updatedAt: entry.updatedAt,
+      ...(entry.title !== undefined && { title: entry.title }),
+      head: {
+        revision: entry.revision,
+        text: entry.text,
+        bytes: entry.bytes,
+      },
+      pins: [...entry.pins.entries()].map(([revision, pin]) => ({
+        revision,
+        text: pin.text,
+        bytes: pin.bytes,
+      })),
+    });
+  }
+
+  function notPersisted(entry: Entry, error: unknown): Diagnostic {
+    const root = persistence?.root ?? '';
+    return diagnostic(
+      WORKSPACE_ERROR_CODES.NOT_PERSISTED,
+      `Revision ${entry.revision} of ${entry.handle} is held in memory but was not written to ${root}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      {
+        severity: 'warning',
+        suggestion:
+          'Export the JSON with jto_workspace_snapshot and keep it yourself; this handle will not survive a lost connection.',
+        context: {
+          handle: entry.handle,
+          revision: entry.revision,
+          workspaceRoot: root,
+        },
+      }
+    );
   }
 
   /** Wrap a record with whatever the write had to say. */
@@ -744,31 +798,45 @@ export function createMemoryWorkspaceStore(
       // a close that left the JSON readable would be answering a request to
       // destroy data with a claim the next connection disproves, so a failure
       // here leaves the workspace exactly as it was — open, and retryable.
-      let durable = false;
-      if (persistence) {
-        try {
-          durable = await persistence.remove(handle);
-        } catch (error) {
-          return failure(
-            WORKSPACE_ERROR_CODES.NOT_CLOSED,
-            `Workspace ${handle} could not be removed from ${persistence.root}: ${
-              error instanceof Error ? error.message : String(error)
-            }. It is still open and still on disk.`,
-            {
-              suggestion:
-                'Check the workspace directory is writable, then close again.',
-              context: { handle, workspaceRoot: persistence.root },
-            }
-          );
-        }
+      if (!persistence) {
+        if (entry) evict(entry, 'closed');
+        return { ok: true, handle, closed: entry !== undefined };
       }
 
-      if (entry) evict(entry, 'closed');
-      // The revision is unknown for a handle this connection only ever saw on
-      // disk, and unread: `missing` only surfaces one for a TTL eviction.
-      else if (durable) tombstone(handle, 'closed', 0);
-
-      return { ok: true, handle, closed: entry !== undefined || durable };
+      // The delete and the eviction share one critical section. Splitting them
+      // would let a patch's write, queued behind the delete, run in the gap
+      // and recreate the directory — the entry would still be in the map, so
+      // its own liveness check would wave it through, and a workspace the
+      // agent was told was destroyed would be back.
+      const root = persistence.root;
+      try {
+        return await queued(async () => {
+          const removed = await persistence.remove(handle);
+          const resident = entries.get(handle);
+          if (resident) evict(resident, 'closed');
+          // The revision is unknown for a handle this connection only ever saw
+          // on disk, and unread: `missing` only surfaces one for a TTL
+          // eviction.
+          else if (removed) tombstone(handle, 'closed', 0);
+          return {
+            ok: true as const,
+            handle,
+            closed: resident !== undefined || removed,
+          };
+        });
+      } catch (error) {
+        return failure(
+          WORKSPACE_ERROR_CODES.NOT_CLOSED,
+          `Workspace ${handle} could not be removed from ${root}: ${
+            error instanceof Error ? error.message : String(error)
+          }. It is still open and still on disk.`,
+          {
+            suggestion:
+              'Check the workspace directory is writable, then close again.',
+            context: { handle, workspaceRoot: root },
+          }
+        );
+      }
     },
 
     /**


### PR DESCRIPTION
Follow-up to #297, which merged at `06660a1` while this work was in flight. These are the fixes for the second round of review comments on that PR — they were pushed after the merge, so they never landed. Cherry-picked onto `main` unchanged and re-verified there.

## Two concurrency bugs

Tool calls are independent async tasks and agents pipeline them, so two orderings went wrong:

**`close` racing an in-flight `patch`.** `close` awaits `persistence.remove` while a patch is inside `persistence.save`. If the `rm` lands before the save reaches its `mkdir`, the save recreates the directory *after* `close` returned `closed: true` — a workspace the agent was told was destroyed comes back on the next use of the handle.

**Concurrent first saves.** Two `save` calls each read the workspace count before either has created its directory, so both decide there is room under `maxWorkspaces`. One can then delete the other's half-written directory, which sorts stalest precisely because its `meta.json` is not there yet.

Both are the same defect as the swallowed `rm` error fixed in #297: a durability promise the next call disproves.

## Fix

Every durable operation for a connection runs through one queue, and `close` performs its delete and its eviction in a single critical section — splitting them left a gap where a write queued behind the delete would still see its entry in the map and be waved through by its own liveness check. A write that reaches the front of the queue after its workspace is gone declines to recreate it, and reports `persisted: false` rather than claiming durability for a revision that was never written.

The queue is deliberately **not** per-handle. The count-then-prune sequence is about the root, not one handle, so a per-handle lock would not have covered the second race — and these are a few milliseconds of filesystem work contending on one disk anyway.

## A third hazard, found while tracing

`load` deleted the entire workspace directory whenever the head revision file was missing. A concurrent prune causes exactly that, benignly: a read that picks up revision N's metadata a moment before a save commits N+1 and prunes N. A well-timed read could therefore destroy a healthy workspace. It now re-reads the metadata before condemning anything.

## Tests

Four new cases, each confirmed to fail against the specific code it guards by reverting that code and watching it go red. The two orderings need separate tests because patch-then-close is caught by the queue and close-then-patch only by the liveness check; both force the interleaving with a held promise rather than hoping for it.

The failed-close test from #297 is also repaired: it asserted against a different store than the one whose close failed, so it would have passed with the fix reverted. It now uses the store under test, spies on `persistence.load` to prove the entry stayed resident rather than being rehydrated, and checks the retry succeeds.

547 passing, up from 544.
