### PR TITLE
fix(fonts): stage faces the document can actually reference

### DIFF
--- a/.changeset/fonts-resolved-family-stamp.md
+++ b/.changeset/fonts-resolved-family-stamp.md
@@ -1,0 +1,35 @@
+---
+'@json-to-office/shared': patch
+---
+
+Resolved font bytes now declare the family they were resolved as.
+
+`ResolvedFont.family` was a claim about the bytes that nothing enforced. A host
+— Core Text, fontconfig, GDI — finds a face by the family in its `name` table,
+never by the registry entry or the filename, so a source whose name table says
+something else is unreachable from every run that references it. It fails
+silently: on a machine that has the real family installed the reference lands
+there instead, and only a host without it shows the fallback.
+
+Inter is the case that surfaced it. It resolves through an upstream override
+that instances `InterVariable.ttf` per weight, and harfbuzz keeps the master's
+name table — so every instance called itself "Inter Variable". The preview
+stager renames a face only when the weight synthesizes a family of its own, so
+"Inter Medium" and "Inter SemiBold" were saved on the way out while weights 400
+and 700 — which ride the run's bold/italic toggles on the base family — were
+staged under a name nothing asks for. In the preview container, which ships no
+Inter, every paragraph without an explicit `fontWeight` rendered in a fallback
+while the weighted ones came out correct.
+
+`FontRegistry` now stamps each materialized source with the entry's family,
+before validation and after the cache, so instanced bytes stay shareable across
+families and no cached font is invalidated. Bytes that already answer to the
+family — on either nameID 1 or nameID 16 — are passed through untouched.
+Full and PostScript names take the face's RIBBI style as a suffix, so the four
+faces of one family stay individually addressable rather than colliding on
+"Inter" (two fonts sharing a PostScript name is malformed, and Core Text may
+refuse the second registration).
+
+`validateFontMetadata` gained a `FAMILY_MISMATCH` diagnostic for the same
+mismatch, which now fires only when the repair could not run — a font with no
+name table, a format-1 one, or non-sfnt bytes.

--- a/.changeset/preview-bold-weight-fetch.md
+++ b/.changeset/preview-bold-weight-fetch.md
@@ -1,0 +1,22 @@
+---
+'@json-to-office/jto': patch
+---
+
+The preview now fetches a bold face for documents that ask for bold with
+`bold: true`.
+
+`collectReferencedWeights` narrows what the LibreOffice preview fetches to the
+weights a document actually uses, but it only counted numeric `fontWeight`
+values. `bold: true` is shorthand for `fontWeight: 700` — the schema says so and
+the compiler resolves it that way — so a document that mixes the two lost its
+bold face: referencing any numeric weight took it off the "no explicit weights"
+fallback of {400, 700}, and nothing put 700 back. The bold runs then asked the
+host for a face that was never staged, which renders as Inter on a machine with
+Inter installed and as a fallback anywhere else — the preview container ships
+only Liberation/Carlito/Caladea/DejaVu.
+
+`bold: true` now counts as a reference to 700, with the compiler's own
+precedence: a font that sets both takes the numeric weight, and its `bold` says
+nothing about which face is wanted. `modern-annual-report-1` goes from fetching
+Inter {400, 500, 600} to {400, 500, 600, 700}; that extra face per bold-using
+family and cold cache is the cost of the bold text rendering at all.

--- a/packages/jto-ops/src/font-staging/fontconfig-stager.ts
+++ b/packages/jto-ops/src/font-staging/fontconfig-stager.ts
@@ -47,6 +47,11 @@ export class FontconfigStager implements FontStager {
         // Rewrite `name` table so fontconfig indexes the file under the
         // synthetic sub-family ("Inter Light"), matching the doc's
         // `rFonts`/`fontFace` references after synthesizeFamilyName.
+        //
+        // The unrewritten branch (RIBBI: the run rides bold/italic toggles
+        // on the base family) leans on the bytes already declaring
+        // `r.family`. That is FontRegistry's `stampResolvedFamily` — do not
+        // read the skip as "this file is fine by construction".
         const synth = synthesizeFamilyName(r.family, s.weight, s.italic);
         const data =
           synth.family === r.family

--- a/packages/jto-ops/src/font-staging/macos-stager.ts
+++ b/packages/jto-ops/src/font-staging/macos-stager.ts
@@ -217,6 +217,11 @@ export class MacOSCoreTextStager implements FontStager {
         // sub-family the doc references (e.g. "Inter Light"). Without
         // this, Core Text indexes the staged file as "Inter" and
         // LibreOffice can't resolve `rFonts w:ascii="Inter Light"`.
+        //
+        // The unrewritten branch (RIBBI: the run rides bold/italic toggles
+        // on the base family) leans on the bytes already declaring
+        // `r.family`. That is FontRegistry's `stampResolvedFamily` — do not
+        // read the skip as "this file is fine by construction".
         const synth = synthesizeFamilyName(r.family, s.weight, s.italic);
         const data =
           synth.family === r.family

--- a/packages/jto-ops/src/font-staging/windows-stager.ts
+++ b/packages/jto-ops/src/font-staging/windows-stager.ts
@@ -90,6 +90,11 @@ export class WindowsFontStager implements FontStager {
         const suffix = s.italic ? 'i' : 'r';
         // Rewrite the TTF's internal family name so GDI registers the
         // file under the synthetic sub-family the doc references.
+        //
+        // The unrewritten branch (RIBBI: the run rides bold/italic toggles
+        // on the base family) leans on the bytes already declaring
+        // `r.family`. That is FontRegistry's `stampResolvedFamily` — do not
+        // read the skip as "this file is fine by construction".
         const synth = synthesizeFamilyName(r.family, s.weight, s.italic);
         const data =
           synth.family === r.family

--- a/packages/jto/src/server/services/__tests__/collect-referenced-weights.test.ts
+++ b/packages/jto/src/server/services/__tests__/collect-referenced-weights.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { autoGoogleFontEntries, collectReferencedWeights } from '../generator';
+
+/**
+ * The narrowing this feeds decides which faces the LibreOffice preview gets
+ * to stage. A weight the walk misses is a weight the host has to find on its
+ * own — which works on a machine with the family installed and renders a
+ * fallback everywhere else.
+ */
+describe('collectReferencedWeights', () => {
+  it('collects numeric fontWeight values', () => {
+    const doc = {
+      children: [
+        { name: 'paragraph', props: { font: { fontWeight: 500 } } },
+        { name: 'paragraph', props: { font: { fontWeight: 600 } } },
+      ],
+    };
+    expect(collectReferencedWeights(doc, undefined)).toEqual(
+      new Set([500, 600])
+    );
+  });
+
+  it('counts bold: true as a reference to 700', () => {
+    // `bold: true` is shorthand for `fontWeight: 700` (font.ts's schema says
+    // so) and the compiler resolves it to exactly that, so it names a face
+    // the document will ask a host for.
+    const doc = {
+      children: [{ name: 'paragraph', props: { font: { bold: true } } }],
+    };
+    expect(collectReferencedWeights(doc, undefined)).toEqual(new Set([700]));
+  });
+
+  it('covers a document that mixes numeric weights with bold: true', () => {
+    // The regression: referencing 500 took this doc off the "no explicit
+    // weights" fallback of {400, 700}, and nothing put 700 back — so the
+    // bold runs were never staged.
+    const doc = {
+      props: {
+        componentDefaults: { paragraph: { font: { family: 'Inter' } } },
+      },
+      children: [
+        { name: 'paragraph', props: { font: { fontWeight: 500 } } },
+        { name: 'paragraph', props: { font: { bold: true } } },
+      ],
+    };
+    expect(collectReferencedWeights(doc, undefined)).toEqual(
+      new Set([500, 700])
+    );
+  });
+
+  it('lets an explicit fontWeight on the same font win over its bold flag', () => {
+    // Compiler precedence: `fontWeight ?? (bold ? 700 : undefined)`. The run
+    // renders as Medium, so 700 is not a face this font needs.
+    const doc = {
+      children: [
+        {
+          name: 'paragraph',
+          props: { font: { fontWeight: 500, bold: true } },
+        },
+      ],
+    };
+    expect(collectReferencedWeights(doc, undefined)).toEqual(new Set([500]));
+  });
+
+  it('reads bold off every text-bearing shape, not just paragraph fonts', () => {
+    // `bold` lives on table cells and list markers too, and each renders in
+    // the document's family.
+    const doc = {
+      children: [
+        {
+          name: 'table',
+          props: { rows: [{ cells: [{ font: { bold: true } }] }] },
+        },
+      ],
+    };
+    expect(collectReferencedWeights(doc, undefined)).toEqual(new Set([700]));
+  });
+
+  it('walks custom themes as well as the document', () => {
+    const themes = { mine: { styles: { heading1: { bold: true } } } };
+    expect(collectReferencedWeights({ children: [] }, themes)).toEqual(
+      new Set([700])
+    );
+  });
+
+  it('ignores out-of-range and non-numeric fontWeight values', () => {
+    const doc = {
+      children: [
+        { name: 'paragraph', props: { font: { fontWeight: 1000 } } },
+        { name: 'paragraph', props: { font: { fontWeight: 'bold' } } },
+      ],
+    };
+    expect(collectReferencedWeights(doc, undefined)).toEqual(new Set());
+  });
+
+  it('stays empty for a document that references no weight at all', () => {
+    // Still the signal `autoGoogleFontEntries` reads to fall back to
+    // {400, 700} — a bundled theme's own bold styles are out of this walk's
+    // sight, so "nothing referenced" must not mean "fetch Regular only".
+    const doc = {
+      children: [{ name: 'paragraph', props: { text: 'plain' } }],
+    };
+    expect(collectReferencedWeights(doc, undefined)).toEqual(new Set());
+  });
+});
+
+describe('autoGoogleFontEntries — weights reaching the fetcher', () => {
+  it('keeps the bold variant for a doc that mixes fontWeight 500 with bold: true', () => {
+    // End of the chain: Inter resolves through the upstream override, and
+    // the variant filter is what decides whether a bold face is instanced
+    // at all. This is the shape modern-annual-report-1 has.
+    const entries = autoGoogleFontEntries(
+      new Set(['Inter']),
+      new Set(),
+      collectReferencedWeights(
+        {
+          children: [
+            { name: 'paragraph', props: { font: { fontWeight: 500 } } },
+            { name: 'paragraph', props: { font: { bold: true } } },
+          ],
+        },
+        undefined
+      ),
+      false
+    );
+
+    expect(entries).toHaveLength(1);
+    const weights = entries[0].sources.map(
+      (s) => (s as { weight: number }).weight
+    );
+    expect(new Set(weights)).toEqual(new Set([400, 500, 700]));
+  });
+
+  it('narrows to Regular when the doc asks for no bold anywhere', () => {
+    // The saving this narrowing exists for still holds — bold is fetched
+    // because it is referenced, not unconditionally.
+    const entries = autoGoogleFontEntries(
+      new Set(['Inter']),
+      new Set(),
+      collectReferencedWeights(
+        {
+          children: [
+            { name: 'paragraph', props: { font: { fontWeight: 500 } } },
+          ],
+        },
+        undefined
+      ),
+      false
+    );
+
+    const weights = entries[0].sources.map(
+      (s) => (s as { weight: number }).weight
+    );
+    expect(new Set(weights)).toEqual(new Set([400, 500]));
+  });
+});

--- a/packages/jto/src/server/services/generator.ts
+++ b/packages/jto/src/server/services/generator.ts
@@ -118,10 +118,28 @@ export function collectReferencedNames(
   return names;
 }
 
+/** A weight the walker will honour: canonical range, numeric. */
+function isReferenceableWeight(v: unknown): v is number {
+  return typeof v === 'number' && v >= 100 && v <= 900;
+}
+
 /**
- * Walk the doc tree + custom themes for `fontWeight` numeric values. Used
+ * Walk the doc tree + custom themes for the weights it references. Used
  * to narrow `autoGoogleFontEntries` so cold-cache runs fetch only the
  * weights the doc actually needs instead of 18 faces per Google family.
+ *
+ * `bold: true` counts as a reference to 700. It is shorthand for exactly
+ * that (see the `fontWeight` schema description), and the compiler resolves
+ * it that way — `applyFontWeightAlias` takes `fontWeight ?? (bold ? 700 :
+ * undefined)`. Collecting only the numeric form made the narrowing lie about
+ * a document that mixes the two: it referenced 500, so the "no explicit
+ * weights" fallback of {400, 700} no longer applied, and the bold runs asked
+ * a host for a face nothing had fetched. Only visible where the family isn't
+ * installed — a container, a colleague's laptop.
+ *
+ * Precedence is per-object, mirroring the compiler: a font that sets both
+ * takes the numeric weight and its `bold` says nothing about which face is
+ * wanted.
  */
 export function collectReferencedWeights(
   config: unknown,
@@ -135,13 +153,12 @@ export function collectReferencedWeights(
       return;
     }
     if (typeof node === 'object') {
-      for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
-        if (
-          k === 'fontWeight' &&
-          typeof v === 'number' &&
-          v >= 100 &&
-          v <= 900
-        ) {
+      const obj = node as Record<string, unknown>;
+      if (obj.bold === true && !isReferenceableWeight(obj.fontWeight)) {
+        weights.add(700);
+      }
+      for (const [k, v] of Object.entries(obj)) {
+        if (k === 'fontWeight' && isReferenceableWeight(v)) {
           weights.add(v);
         } else {
           visit(v);
@@ -241,9 +258,12 @@ export function autoGoogleFontEntries(
     // Narrow the fetched weight set to what the doc actually references.
     // Cold-cache fetches 1 file per (weight × italic) serially — Inter has
     // 18 faces advertised — so docs that only use 400/700 shouldn't pay
-    // for all nine. When the doc references no explicit weights, fall
-    // back to 400/700 (Regular + Bold). When it does, fetch those
-    // weights (intersected with what the family advertises).
+    // for all nine. When the doc references no weight at all — neither a
+    // numeric `fontWeight` nor a `bold: true`, both of which
+    // `collectReferencedWeights` reports — fall back to 400/700 (Regular +
+    // Bold), which also covers weights a bundled theme asks for out of this
+    // walk's sight. When it does, fetch those weights (intersected with
+    // what the family advertises).
     const wanted = (() => {
       if (!referencedWeights || referencedWeights.size === 0) {
         const filtered = match.weights.filter((w) => w === 400 || w === 700);

--- a/packages/shared/src/fonts/__tests__/registry.test.ts
+++ b/packages/shared/src/fonts/__tests__/registry.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { FontRegistry } from '../registry';
 import type { FontRegistryEntry } from '../../schemas/font-catalog';
 import { detectFontFormat } from '../sources/format';
+import {
+  readFontFamilyNames,
+  readNameRecords,
+  rewriteFontFamilyName,
+} from '../sources/ttf-name';
 
 // A small valid TTF header (0x00010000) padded — enough for format detection.
 const MINIMAL_TTF_BUF = Buffer.concat([
@@ -239,5 +246,121 @@ describe('detectFontFormat', () => {
     expect(detectFontFormat(Buffer.from([0xde, 0xad, 0xbe, 0xef]))).toBe(
       'unknown'
     );
+  });
+});
+
+/**
+ * Resolved bytes must declare the family they were resolved as — nothing
+ * downstream can find them otherwise. A host matches a run's `rFonts
+ * w:ascii="Inter"` against the font's own name table, never against the
+ * registry entry, so bytes calling themselves something else are invisible
+ * to every reference — silently, on any machine that happens to have the
+ * real family installed.
+ */
+describe('FontRegistry family stamping', () => {
+  const REAL_TTF = readFileSync(
+    path.resolve(
+      __dirname,
+      '../../../../core-docx/src/styles/fonts/life-sans/LifeSans-Medium.ttf'
+    )
+  );
+
+  /** A font that calls itself `declared`, registered under `family`. */
+  const registerAs = (
+    family: string,
+    declared: string,
+    sources: Array<{ weight: number; italic: boolean }>
+  ): FontRegistry => {
+    const entry: FontRegistryEntry = {
+      id: family,
+      family,
+      sources: sources.map((s) => ({
+        kind: 'data' as const,
+        data: rewriteFontFamilyName(REAL_TTF, declared).toString('base64'),
+        weight: s.weight,
+        italic: s.italic,
+      })),
+    };
+    return new FontRegistry({ opts: { extraEntries: [entry] } });
+  };
+
+  it('rewrites bytes that declare a different family (the InterVariable case)', async () => {
+    // Weight 400 is the case that broke: the preview stager only renames a
+    // face when the weight synthesizes a distinct family ("Inter Medium"),
+    // so Regular and Bold reach the host under whatever the file says.
+    const out = await registerAs('Inter', 'Inter Variable', [
+      { weight: 400, italic: false },
+    ]).resolve('Inter');
+
+    expect(readFontFamilyNames(out.sources[0].data)).toEqual(['Inter']);
+    // Repaired before validation runs, so it must not also warn. Matched on
+    // the bracketed code — "FAMILY_MISMATCH" is a substring of
+    // "SUBFAMILY_MISMATCH", which the fixture legitimately trips.
+    expect(
+      out.warnings.some((w) =>
+        w.includes('[FONT_METADATA_DEFECT:FAMILY_MISMATCH]')
+      )
+    ).toBe(false);
+  });
+
+  it('keeps the faces of one family individually addressable', async () => {
+    // All four RIBBI faces share the family name, so PostScript names have
+    // to differ — two fonts with the same PostScript name is malformed, and
+    // Core Text may refuse to register the second one.
+    const out = await registerAs('Inter', 'Inter Variable', [
+      { weight: 400, italic: false },
+      { weight: 400, italic: true },
+      { weight: 700, italic: false },
+      { weight: 700, italic: true },
+    ]).resolve('Inter');
+
+    const psNames = out.sources.map(
+      (s) => readNameRecords(s.data, new Set([6]))[0]?.value
+    );
+    expect(psNames).toEqual([
+      'Inter',
+      'Inter-Italic',
+      'Inter-Bold',
+      'Inter-BoldItalic',
+    ]);
+    expect(new Set(psNames).size).toBe(psNames.length);
+  });
+
+  it('leaves bytes that already answer to the family untouched', async () => {
+    // Costs a name-table rebuild, and a legitimately-named static has
+    // nothing to gain from one.
+    const out = await registerAs('Life Sans', 'Life Sans', [
+      { weight: 500, italic: false },
+    ]).resolve('Life Sans');
+
+    expect(
+      out.sources[0].data.equals(rewriteFontFamilyName(REAL_TTF, 'Life Sans'))
+    ).toBe(true);
+  });
+
+  it('accepts a match on the typographic family without rewriting', async () => {
+    // The fixture ships nameID 1 "Life Sans Medium" / nameID 16 "Life Sans".
+    // Registered as "Life Sans" it already resolves — rewriting would clobber
+    // a legitimate nameID 1.
+    const entry: FontRegistryEntry = {
+      id: 'Life Sans',
+      family: 'Life Sans',
+      sources: [
+        {
+          kind: 'data',
+          data: REAL_TTF.toString('base64'),
+          weight: 500,
+          italic: false,
+        },
+      ],
+    };
+    const out = await new FontRegistry({
+      opts: { extraEntries: [entry] },
+    }).resolve('Life Sans');
+
+    expect(readFontFamilyNames(out.sources[0].data)).toContain(
+      'Life Sans Medium'
+    );
+    expect(out.sources[0].data.equals(REAL_TTF)).toBe(true);
   });
 });

--- a/packages/shared/src/fonts/index.ts
+++ b/packages/shared/src/fonts/index.ts
@@ -33,7 +33,11 @@ export {
   type SynthesizedFamily,
 } from './synthesize';
 
-export { rewriteFontFamilyName } from './sources/ttf-name';
+export {
+  rewriteFontFamilyName,
+  readFontFamilyNames,
+  legacySubfamilyName,
+} from './sources/ttf-name';
 
 // Pure (URL + array membership) and browser-safe, so the playground preview
 // can apply the same host policy as the Node fetchers.

--- a/packages/shared/src/fonts/registry.ts
+++ b/packages/shared/src/fonts/registry.ts
@@ -20,6 +20,11 @@ import { loadDataFontSource } from './sources/data-loader';
 import { fetchGoogleFontSources } from './sources/google-fetcher';
 import { fetchUrlFontSource } from './sources/url-fetcher';
 import { validateFontMetadata } from './sources/ttf-validate';
+import {
+  readFontFamilyNames,
+  rewriteFontFamilyName,
+  standardSubfamilyNames,
+} from './sources/ttf-name';
 import { FontMemoryCache } from './cache/memory-cache';
 
 /**
@@ -86,6 +91,52 @@ export interface FontRegistryInput {
    * its `fs.promises.readFile` bootstrap) into client bundles.
    */
   variableLoader?: FontVariableLoader;
+}
+
+/**
+ * Make the bytes declare the family they were resolved as.
+ *
+ * `ResolvedFont.family` is a claim about the bytes that every consumer
+ * relies on and that nothing used to enforce. A host — Core Text,
+ * fontconfig, GDI — finds a face by the family in its `name` table, never
+ * by the registry entry or the filename, so a source whose name table says
+ * something else is unreachable from the runs that reference it. It fails
+ * silently: on a machine that happens to have the real family installed the
+ * reference lands there instead, and only a host without it (a container,
+ * a colleague's laptop) shows the fallback.
+ *
+ * The case that forced this: Inter resolves through an upstream override
+ * that instances `InterVariable.ttf` per weight, and harfbuzz keeps the
+ * master's name table — so every instance called itself "Inter Variable".
+ * The weighted faces were saved by the preview stager renaming them to
+ * "Inter Medium" / "Inter SemiBold" on the way out; weights 400 and 700
+ * kept the family name unchanged (they ride the run's bold/italic toggles
+ * instead), so those alone were staged under a name no run asks for.
+ *
+ * Matching on ANY declared name (family or typographic family) keeps a
+ * legitimately-named static untouched: LifeSans-Medium.ttf registered as
+ * "Life Sans" already answers to it via nameID 16, even though nameID 1
+ * says "Life Sans Medium". Only bytes that answer to nothing get rewritten.
+ */
+function stampResolvedFamily(
+  source: ResolvedFontSource,
+  family: string
+): ResolvedFontSource {
+  if (source.format !== 'ttf' && source.format !== 'otf') return source;
+  const declared = readFontFamilyNames(source.data);
+  // Nothing declared: no claim to contradict, and nothing to repair against.
+  if (declared.length === 0 || declared.includes(family)) return source;
+  // The style this face occupies within `family`. The family IDs become
+  // `family` for all four RIBBI faces, so full/PostScript names have to
+  // carry the style or roman and italic collide on both.
+  const subfamily = standardSubfamilyNames(
+    source.weight,
+    source.italic
+  )?.legacy;
+  return {
+    ...source,
+    data: rewriteFontFamilyName(source.data, family, subfamily),
+  };
 }
 
 export class FontRegistry {
@@ -155,7 +206,8 @@ export class FontRegistry {
     for (const source of entry.sources) {
       try {
         const materialized = await this.materializeSource(source, warnings);
-        for (const s of materialized) {
+        for (const raw of materialized) {
+          const s = stampResolvedFamily(raw, entry.family);
           if (s.format === 'ttf' || s.format === 'otf') {
             for (const d of validateFontMetadata(
               s.data,

--- a/packages/shared/src/fonts/sources/__tests__/ttf-name.test.ts
+++ b/packages/shared/src/fonts/sources/__tests__/ttf-name.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import {
   legacySubfamilyName,
   readFontFamilyNames,
+  readNameRecords,
   rewriteFontFamilyName,
   rewriteFontSubfamilyNames,
   standardSubfamilyNames,
@@ -330,5 +331,51 @@ describe('legacySubfamilyName', () => {
     expect(legacySubfamilyName(false, true)).toBe('Italic');
     expect(legacySubfamilyName(true, false)).toBe('Bold');
     expect(legacySubfamilyName(true, true)).toBe('Bold Italic');
+  });
+});
+
+describe('readNameRecords bounds', () => {
+  const original = readFileSync(FIXTURE);
+
+  it('does not decode records past the end of the name table', () => {
+    // `Buffer.slice` clamps instead of throwing, so a count larger than the
+    // table holds used to walk into whatever table follows and decode its
+    // bytes as name records.
+    const buf = Buffer.from(original);
+    const { offset } = nameTableSpan(buf);
+    const realCount = buf.readUInt16BE(offset + 2);
+    buf.writeUInt16BE(realCount + 40, offset + 2);
+
+    expect(readNameRecords(buf)).toHaveLength(readNameRecords(original).length);
+    expect(readFontFamilyNames(buf)).toEqual(readFontFamilyNames(original));
+  });
+
+  it('skips a record whose string runs past the table, keeping the rest', () => {
+    // One bad record shouldn't cost the font every other name it declares.
+    const buf = Buffer.from(original);
+    const { offset, length } = nameTableSpan(buf);
+    // First record: point its string at the table's last byte and claim the
+    // string is longer than the table.
+    buf.writeUInt16BE(length, offset + 6 + 8);
+    buf.writeUInt16BE(0xfff0, offset + 6 + 10);
+
+    const records = readNameRecords(buf);
+    expect(records).toHaveLength(readNameRecords(original).length - 1);
+    // Nothing decoded from beyond the table — the skipped record's id is
+    // simply absent rather than carrying foreign bytes.
+    const firstId = original.readUInt16BE(offset + 6 + 6);
+    const before = readNameRecords(original).filter(
+      (r) => r.nameID === firstId
+    );
+    const after = records.filter((r) => r.nameID === firstId);
+    expect(after).toHaveLength(before.length - 1);
+  });
+
+  it('reports nothing for a table whose string offset is out of range', () => {
+    const buf = Buffer.from(original);
+    const { offset } = nameTableSpan(buf);
+    buf.writeUInt16BE(0xfff0, offset + 4); // storage offset past the table
+    expect(readNameRecords(buf)).toEqual([]);
+    expect(readFontFamilyNames(buf)).toEqual([]);
   });
 });

--- a/packages/shared/src/fonts/sources/__tests__/ttf-name.test.ts
+++ b/packages/shared/src/fonts/sources/__tests__/ttf-name.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import {
+  legacySubfamilyName,
+  readFontFamilyNames,
   rewriteFontFamilyName,
   rewriteFontSubfamilyNames,
   standardSubfamilyNames,
@@ -85,6 +87,46 @@ describe('rewriteFontFamilyName', () => {
     for (const s of psNames) expect(s).toBe('SynthLight');
   });
 
+  it('keeps full + PostScript names distinct across a family when given a subfamily', () => {
+    // The four RIBBI faces share one family name and are told apart by the
+    // style bits, so nameID 4/6 have to carry the style or roman and italic
+    // become indistinguishable — Core Text may then refuse to register the
+    // second of the pair at all.
+    const roman = readNameStrings(rewriteFontFamilyName(original, 'Inter'));
+    const italic = readNameStrings(
+      rewriteFontFamilyName(original, 'Inter', 'Italic')
+    );
+    const boldItalic = readNameStrings(
+      rewriteFontFamilyName(original, 'Inter', 'Bold Italic')
+    );
+
+    // Family IDs are the family alone, in every face.
+    for (const names of [roman, italic, boldItalic]) {
+      for (const id of [1, 16]) {
+        for (const s of names.get(id) ?? []) expect(s).toBe('Inter');
+      }
+    }
+    for (const s of roman.get(4) ?? []) expect(s).toBe('Inter');
+    for (const s of italic.get(4) ?? []) expect(s).toBe('Inter Italic');
+    for (const s of boldItalic.get(4) ?? [])
+      expect(s).toBe('Inter Bold Italic');
+    for (const s of roman.get(6) ?? []) expect(s).toBe('Inter');
+    for (const s of italic.get(6) ?? []) expect(s).toBe('Inter-Italic');
+    for (const s of boldItalic.get(6) ?? []) {
+      expect(s).toBe('Inter-BoldItalic');
+    }
+  });
+
+  it('treats an explicit "Regular" subfamily as no suffix at all', () => {
+    // A family's default face is named after the family, not "X Regular" —
+    // and this is the path every weight-synthesized alias takes ("Inter
+    // Medium" is the Regular member of its own family), so it must stay
+    // byte-identical to the no-subfamily call.
+    const bare = rewriteFontFamilyName(original, 'Inter Medium');
+    const regular = rewriteFontFamilyName(original, 'Inter Medium', 'Regular');
+    expect(regular.equals(bare)).toBe(true);
+  });
+
   it('leaves other name records untouched', () => {
     const out = rewriteFontFamilyName(original, 'Whatever');
     const before = readNameStrings(original);
@@ -110,10 +152,12 @@ describe('rewriteFontFamilyName', () => {
   it('produces bytes that validateFontMetadata can still parse', () => {
     // Original fixture passes validation for weight 500 (Medium, non-italic).
     // Rewriting the family name must not perturb OS/2 or name records other
-    // than the targeted family IDs, so diagnostics should be identical.
-    const before = validateFontMetadata(original, 500, false, 'LifeSans');
+    // than the targeted family IDs, so diagnostics should be identical. Each
+    // side is validated under the family its bytes actually declare, so the
+    // comparison isn't smuggling a FAMILY_MISMATCH through both.
+    const before = validateFontMetadata(original, 500, false, 'Life Sans');
     const out = rewriteFontFamilyName(original, 'Synth Medium');
-    const after = validateFontMetadata(out, 500, false, 'SynthMedium');
+    const after = validateFontMetadata(out, 500, false, 'Synth Medium');
     // Same set of diagnostic codes — name rewrite is orthogonal to OS/2
     // and subfamily (nameID 2/17) checks.
     expect(after.map((d) => d.code).sort()).toEqual(
@@ -253,5 +297,38 @@ describe('format-1 name tables', () => {
   it('still rewrites an ordinary format-0 table', () => {
     const input = Buffer.from(readFileSync(FIXTURE));
     expect(rewriteFontFamilyName(input, 'Renamed')).not.toEqual(input);
+  });
+});
+
+describe('readFontFamilyNames', () => {
+  const original = readFileSync(FIXTURE);
+
+  it('reports every distinct family name the font declares', () => {
+    // The fixture is a Medium shipped as its own family: nameID 1 says
+    // "Life Sans Medium" while nameID 16 still says "Life Sans". Both are
+    // legitimate ways to reach it, so both have to come back.
+    const declared = readFontFamilyNames(original);
+    expect(declared).toContain('Life Sans Medium');
+    expect(declared).toContain('Life Sans');
+    // Deduped across the platform records that repeat each string.
+    expect(new Set(declared).size).toBe(declared.length);
+  });
+
+  it('reads back whatever rewriteFontFamilyName just stamped', () => {
+    const out = rewriteFontFamilyName(original, 'Inter', 'Italic');
+    expect(readFontFamilyNames(out)).toEqual(['Inter']);
+  });
+
+  it('returns nothing for bytes with no readable name table', () => {
+    expect(readFontFamilyNames(Buffer.from('not a font'))).toEqual([]);
+  });
+});
+
+describe('legacySubfamilyName', () => {
+  it('maps the bold/italic pair onto the four-style vocabulary', () => {
+    expect(legacySubfamilyName(false, false)).toBe('Regular');
+    expect(legacySubfamilyName(false, true)).toBe('Italic');
+    expect(legacySubfamilyName(true, false)).toBe('Bold');
+    expect(legacySubfamilyName(true, true)).toBe('Bold Italic');
   });
 });

--- a/packages/shared/src/fonts/sources/__tests__/ttf-validate.test.ts
+++ b/packages/shared/src/fonts/sources/__tests__/ttf-validate.test.ts
@@ -6,6 +6,10 @@ function makeFont(opts: {
   usWeightClass: number;
   name17?: string;
   name2?: string;
+  /** nameID 1 — the family the bytes claim. */
+  name1?: string;
+  /** nameID 16 — typographic family, when the face ships one. */
+  name16?: string;
   /** OS/2.fsType at offset +8 (default 0 = installable/no restriction). */
   fsType?: number;
 }): Buffer {
@@ -16,6 +20,10 @@ function makeFont(opts: {
   };
 
   const records: Array<{ nameID: number; bytes: Buffer }> = [];
+  if (opts.name1 !== undefined)
+    records.push({ nameID: 1, bytes: encode16(opts.name1) });
+  if (opts.name16 !== undefined)
+    records.push({ nameID: 16, bytes: encode16(opts.name16) });
   if (opts.name17 !== undefined)
     records.push({ nameID: 17, bytes: encode16(opts.name17) });
   if (opts.name2 !== undefined)
@@ -191,5 +199,47 @@ describe('validateFontMetadata', () => {
     // usWeightClass matches requested → no weight mismatch. No subfamily
     // expectation for non-standard weights.
     expect(diags).toEqual([]);
+  });
+});
+
+describe('validateFontMetadata — family name', () => {
+  it('flags bytes that answer to a different family than they were resolved as', () => {
+    // The Inter case: an instance of InterVariable.ttf still calls itself
+    // "Inter Variable", so a run saying `rFonts w:ascii="Inter"` finds
+    // nothing. FontRegistry repairs this before validating; a diagnostic
+    // here means the repair could not run.
+    const font = makeFont({
+      usWeightClass: 400,
+      name1: 'Inter Variable',
+      name2: 'Regular',
+      name17: 'Regular',
+    });
+    const diags = validateFontMetadata(font, 400, false, 'Inter');
+    expect(diags.map((d) => d.code)).toContain('FAMILY_MISMATCH');
+    expect(diags.find((d) => d.code === 'FAMILY_MISMATCH')?.message).toContain(
+      'Inter Variable'
+    );
+  });
+
+  it('accepts a match on the typographic family (nameID 16)', () => {
+    // A weight shipped as its own family names itself "Life Sans Medium" in
+    // nameID 1 while nameID 16 still says "Life Sans". Registered under the
+    // typographic name it is perfectly reachable — not a defect.
+    const font = makeFont({
+      usWeightClass: 500,
+      name1: 'Life Sans Medium',
+      name16: 'Life Sans',
+      name2: 'Regular',
+      name17: 'Medium',
+    });
+    const diags = validateFontMetadata(font, 500, false, 'Life Sans');
+    expect(diags.map((d) => d.code)).not.toContain('FAMILY_MISMATCH');
+  });
+
+  it('stays quiet when the font declares no family at all', () => {
+    // Nothing to contradict, and nothing the repair could have fixed.
+    const font = makeFont({ usWeightClass: 400, name2: 'Regular' });
+    const diags = validateFontMetadata(font, 400, false, 'Anything');
+    expect(diags.map((d) => d.code)).not.toContain('FAMILY_MISMATCH');
   });
 });

--- a/packages/shared/src/fonts/sources/ttf-name.ts
+++ b/packages/shared/src/fonts/sources/ttf-name.ts
@@ -298,9 +298,18 @@ function findTable(
 
 /**
  * Read the `name` records a font carries, optionally narrowed to `wanted`
- * nameIDs. Tolerant of malformed tables — a record that would read past the
- * buffer ends the scan rather than throwing, because these bytes come off
- * the network.
+ * nameIDs. Tolerant of malformed tables, because these bytes come off the
+ * network: everything is bounded by the `name` table's own extent, not by
+ * the buffer. `Buffer.slice` clamps an out-of-range window silently rather
+ * than throwing, so without that bound a table claiming more records than it
+ * holds decodes the bytes of whatever table follows it, and a record with a
+ * bogus string offset returns a truncated or foreign name.
+ *
+ * A header that would run past the table ends the scan; a single record
+ * whose string does is skipped, since the other records are still readable
+ * and each one stands alone. Either way the name is not reported, which is
+ * the safe direction — a caller asking "do these bytes answer to family X?"
+ * gets no for an unreadable record instead of a coincidental yes.
  *
  * Shared with `validateFontMetadata` so the checker and the rewriters above
  * cannot disagree about what a font declares.
@@ -313,18 +322,27 @@ export function readNameRecords(
   if (!nt) return [];
   const tableOff = nt.offset;
   if (tableOff + 6 > input.length) return [];
+  // The directory may claim a length past the end of a truncated download.
+  const tableEnd = Math.min(tableOff + nt.length, input.length);
   const count = input.readUInt16BE(tableOff + 2);
   const storage = tableOff + input.readUInt16BE(tableOff + 4);
+  // Records occupy exactly the span between the 6-byte header and the string
+  // storage. Bounding them by the table alone is not enough: an inflated
+  // `count` would keep reading 12-byte "records" out of the string heap,
+  // which is inside the table and decodes to plausible-looking garbage.
+  const recordsEnd = Math.min(storage, tableEnd);
   const out: DecodedNameRecord[] = [];
   for (let i = 0; i < count; i += 1) {
     const ro = tableOff + 6 + i * 12;
-    if (ro + 12 > input.length) break;
+    if (ro + 12 > recordsEnd) break;
     const platformID = input.readUInt16BE(ro);
     const nameID = input.readUInt16BE(ro + 6);
     if (wanted && !wanted.has(nameID)) continue;
     const length = input.readUInt16BE(ro + 8);
     const offset = input.readUInt16BE(ro + 10);
-    const raw = input.slice(storage + offset, storage + offset + length);
+    const start = storage + offset;
+    if (start + length > tableEnd) continue;
+    const raw = input.slice(start, start + length);
     let value: string;
     if (platformID === 1) {
       value = raw.toString('ascii');

--- a/packages/shared/src/fonts/sources/ttf-name.ts
+++ b/packages/shared/src/fonts/sources/ttf-name.ts
@@ -1,13 +1,13 @@
 /**
- * Name-table rewriting for TTF/OTF sfnt fonts. Two public transforms share
- * the rebuild machinery:
+ * Name-table reading and rewriting for TTF/OTF sfnt fonts. Two public
+ * transforms share the rebuild machinery, plus one reader:
  *
  * - `rewriteFontFamilyName` — rewrite `nameID` 1 / 4 / 6 / 16 to a
- *   synthetic family name. Used by the preview-side font stagers so that
- *   running-text references like `"Inter Light"` resolve to the correct
- *   face when the stager registers it with Core Text / fontconfig / GDI
- *   (all of which index by the font's internal `name` table rather than
- *   the filename).
+ *   synthetic family name. Used by `FontRegistry` (so resolved bytes
+ *   declare the family they were resolved as) and by the preview-side
+ *   font stagers (so running-text references like `"Inter Light"` resolve
+ *   to the correct face). Core Text / fontconfig / GDI all index by the
+ *   font's internal `name` table rather than the filename.
  *
  * - `rewriteFontSubfamilyNames` — rewrite `nameID` 2 / 17 to the standard
  *   subfamily strings for a (weight, italic) pair. Used by the variable-
@@ -15,6 +15,10 @@
  *   verbatim, so an instanced Bold would otherwise keep the variable
  *   font's default-instance "Regular" subfamily and trip
  *   `validateFontMetadata`.
+ *
+ * - `readNameRecords` / `readFontFamilyNames` — the reading half, shared
+ *   with `validateFontMetadata` so the checker and the writer cannot
+ *   drift on how a name record is located or decoded.
  *
  * Each transform rebuilds the whole font: new `name` table bytes, new
  * table directory with shifted offsets, recomputed per-table checksums,
@@ -265,26 +269,154 @@ function rewriteNameTable(
   return out;
 }
 
+/** One decoded `name` record: where it came from and what it says. */
+export interface DecodedNameRecord {
+  platformID: number;
+  nameID: number;
+  value: string;
+}
+
+/** Byte range of `tag`'s table within `input`, or null. */
+function findTable(
+  input: Buffer,
+  tag: string
+): { offset: number; length: number } | null {
+  if (input.length < 12) return null;
+  const numTables = input.readUInt16BE(4);
+  for (let i = 0; i < numTables; i += 1) {
+    const eo = 12 + i * 16;
+    if (eo + 16 > input.length) return null;
+    if (input.toString('ascii', eo, eo + 4) === tag) {
+      return {
+        offset: input.readUInt32BE(eo + 8),
+        length: input.readUInt32BE(eo + 12),
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Read the `name` records a font carries, optionally narrowed to `wanted`
+ * nameIDs. Tolerant of malformed tables — a record that would read past the
+ * buffer ends the scan rather than throwing, because these bytes come off
+ * the network.
+ *
+ * Shared with `validateFontMetadata` so the checker and the rewriters above
+ * cannot disagree about what a font declares.
+ */
+export function readNameRecords(
+  input: Buffer,
+  wanted?: Set<number>
+): DecodedNameRecord[] {
+  const nt = findTable(input, 'name');
+  if (!nt) return [];
+  const tableOff = nt.offset;
+  if (tableOff + 6 > input.length) return [];
+  const count = input.readUInt16BE(tableOff + 2);
+  const storage = tableOff + input.readUInt16BE(tableOff + 4);
+  const out: DecodedNameRecord[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const ro = tableOff + 6 + i * 12;
+    if (ro + 12 > input.length) break;
+    const platformID = input.readUInt16BE(ro);
+    const nameID = input.readUInt16BE(ro + 6);
+    if (wanted && !wanted.has(nameID)) continue;
+    const length = input.readUInt16BE(ro + 8);
+    const offset = input.readUInt16BE(ro + 10);
+    const raw = input.slice(storage + offset, storage + offset + length);
+    let value: string;
+    if (platformID === 1) {
+      value = raw.toString('ascii');
+    } else {
+      // UTF-16BE. Buffer has no utf16be decoder — swap to LE and decode.
+      const swapped = Buffer.from(raw);
+      if (swapped.length % 2 === 0) swapped.swap16();
+      value = swapped.toString('utf16le');
+    }
+    out.push({ platformID, nameID, value });
+  }
+  return out;
+}
+
+/**
+ * Every distinct family name a font declares — `nameID` 1 (family) and 16
+ * (typographic/preferred family), deduped, in record order.
+ *
+ * Both count: a weight shipped as its own family names itself "Life Sans
+ * Medium" in nameID 1 while nameID 16 still says "Life Sans", and either
+ * is a legitimate way for a consumer to find it. Callers asking "do these
+ * bytes answer to family X?" must therefore accept a match on either.
+ */
+export function readFontFamilyNames(input: Buffer): string[] {
+  const out: string[] = [];
+  for (const r of readNameRecords(input, FAMILY_LOOKUP_IDS)) {
+    const value = r.value.trim();
+    if (value.length > 0 && !out.includes(value)) out.push(value);
+  }
+  return out;
+}
+
+const FAMILY_LOOKUP_IDS = new Set<number>([1, 16]);
+
+/**
+ * The RIBBI style label a face carries alongside its family name — the
+ * four-style vocabulary `nameID` 2 is restricted to. Used to build the
+ * full (`nameID` 4) and PostScript (`nameID` 6) names, which must stay
+ * distinct across the faces of one family.
+ */
+export function legacySubfamilyName(
+  bold: boolean,
+  italic: boolean
+): 'Regular' | 'Italic' | 'Bold' | 'Bold Italic' {
+  if (bold) return italic ? 'Bold Italic' : 'Bold';
+  return italic ? 'Italic' : 'Regular';
+}
+
 /**
  * Return a copy of `input` whose name table has `nameID` 1/4/6/16 rewritten
  * to `newFamily`. Returns the original buffer unchanged if the font has no
  * `name` table or the sfnt header is invalid.
+ *
+ * `subfamily` is the RIBBI style this face occupies *within* `newFamily`.
+ * The family IDs (1/16) always become `newFamily` alone, but the full name
+ * (4) and PostScript name (6) take the style as a suffix, so the four faces
+ * of one family stay individually addressable — "Inter" / "Inter Italic" /
+ * "Inter Bold" / "Inter Bold Italic", PostScript "Inter" / "Inter-Italic" /
+ * … Two faces sharing a PostScript name is malformed, and Core Text may
+ * refuse the second registration outright.
+ *
+ * Omitted (or "Regular") reproduces the historical behaviour — every
+ * targeted ID becomes `newFamily` — which is correct for a face staged
+ * under a weight-synthesized family of its own ("Inter Medium"), where the
+ * face IS that family's Regular member.
  */
 export function rewriteFontFamilyName(
   input: Buffer,
-  newFamily: string
+  newFamily: string,
+  subfamily?: string
 ): Buffer {
+  // "Regular" is the absence of a style suffix, not a suffix reading
+  // "Regular" — a family's default face is named after the family alone.
+  const style = subfamily && subfamily !== 'Regular' ? subfamily : '';
+  const fullName = style ? `${newFamily} ${style}` : newFamily;
   // PostScript names (nameID 6) are restricted to printable ASCII 33-126
   // minus `[](){}<>/%` per the OpenType spec — fold spaces out and strip
-  // any forbidden chars so Word doesn't silently reject the font.
+  // any forbidden chars so Word doesn't silently reject the font. The
+  // style rides as a hyphenated suffix, the convention every shipped
+  // family uses ("Inter-BoldItalic").
   const psForbidden = /[[\](){}<>/%]/g;
   // eslint-disable-next-line no-control-regex
-  const isAscii = /^[\x00-\x7f]*$/.test(newFamily);
-  const psName = newFamily
-    .replace(/\s+/g, '')
-    .replace(psForbidden, '')
-    // eslint-disable-next-line no-control-regex
-    .replace(/[^\x21-\x7e]/g, '');
+  const isAscii = /^[\x00-\x7f]*$/.test(fullName);
+  const psSafe = (s: string): string =>
+    s
+      .replace(/\s+/g, '')
+      .replace(psForbidden, '')
+      // eslint-disable-next-line no-control-regex
+      .replace(/[^\x21-\x7e]/g, '');
+  const psName = style
+    ? `${psSafe(newFamily)}-${psSafe(style)}`
+    : psSafe(newFamily);
   return rewriteNameTable(input, (r) => {
     if (!FAMILY_NAME_IDS.has(r.nameID)) return { action: 'keep' };
     // Platform 1 (Macintosh Roman) only round-trips ASCII. For non-ASCII
@@ -294,7 +426,9 @@ export function rewriteFontFamilyName(
     // platforms 0 (Unicode) and 3 (Microsoft) carry the UTF-16 form and
     // are what modern consumers prefer anyway.
     if (r.platformID === 1 && !isAscii) return { action: 'drop' };
-    return { action: 'set', value: r.nameID === 6 ? psName : newFamily };
+    if (r.nameID === 6) return { action: 'set', value: psName };
+    if (r.nameID === 4) return { action: 'set', value: fullName };
+    return { action: 'set', value: newFamily };
   });
 }
 
@@ -326,14 +460,7 @@ export function standardSubfamilyNames(
   if (!base) return null;
   return {
     typographic: italic ? `${base} Italic` : base,
-    legacy:
-      weight >= 600
-        ? italic
-          ? 'Bold Italic'
-          : 'Bold'
-        : italic
-          ? 'Italic'
-          : 'Regular',
+    legacy: legacySubfamilyName(weight >= 600, italic),
   };
 }
 

--- a/packages/shared/src/fonts/sources/ttf-validate.ts
+++ b/packages/shared/src/fonts/sources/ttf-validate.ts
@@ -5,6 +5,9 @@
  * 1. Wrong `OS/2.usWeightClass`          (Chivo Light, Mada Regular, Petrona)
  * 2. Duplicate usWeightClass across weights  (Exo Thin/ExtraLight)
  * 3. Non-unique `name` subfamily records     (Inter, Manrope, Recursive)
+ * 4. A family name that isn't the one we resolved the bytes as — an
+ *    instanced `InterVariable.ttf` still calls itself "Inter Variable", a
+ *    vendor CDN static may call itself anything at all
  *
  * We don't throw on mismatch — the pipeline has already tried to fix the
  * bytes where it can (`rewriteFontSubfamilyNames` after variable-font
@@ -14,16 +17,14 @@
  * hatch before they ship a broken document.
  */
 
-import { standardSubfamilyNames } from './ttf-name';
+import {
+  readFontFamilyNames,
+  readNameRecords,
+  standardSubfamilyNames,
+} from './ttf-name';
 
 const HEADER_SIZE = 12;
 const TABLE_RECORD_SIZE = 16;
-
-interface NameProbe {
-  platformID: number;
-  nameID: number;
-  value: string;
-}
 
 function readTable(
   ttf: Buffer,
@@ -50,49 +51,12 @@ function readUsWeightClass(ttf: Buffer): number | null {
   return ttf.readUInt16BE(os2.off + 4);
 }
 
-function readNames(ttf: Buffer, wanted: Set<number>): NameProbe[] {
-  const nt = readTable(ttf, 'name');
-  if (!nt) return [];
-  const tableOff = nt.off;
-  // Name-table header is 6 bytes (format, count, stringOffset) before the
-  // first name record. Reject obviously-truncated tables up front so we
-  // don't read count/storageRel past the buffer's end on malformed fonts.
-  if (tableOff + 6 > ttf.length) return [];
-  const count = ttf.readUInt16BE(tableOff + 2);
-  const storageRel = ttf.readUInt16BE(tableOff + 4);
-  const storage = tableOff + storageRel;
-  const out: NameProbe[] = [];
-  for (let j = 0; j < count; j++) {
-    const r = tableOff + 6 + j * 12;
-    // Each name record is 12 bytes. Stop as soon as the claimed count
-    // would walk past the buffer — a malformed font claiming count=999999
-    // would otherwise read garbage on each iteration.
-    if (r + 12 > ttf.length) break;
-    const platformID = ttf.readUInt16BE(r);
-    const nameID = ttf.readUInt16BE(r + 6);
-    if (!wanted.has(nameID)) continue;
-    const length = ttf.readUInt16BE(r + 8);
-    const offset = ttf.readUInt16BE(r + 10);
-    const raw = ttf.slice(storage + offset, storage + offset + length);
-    let value: string;
-    if (platformID === 1) {
-      value = raw.toString('ascii');
-    } else {
-      // Decode UTF-16BE. Buffer has no direct utf16be support; swap bytes.
-      const swapped = Buffer.from(raw);
-      if (swapped.length % 2 === 0) swapped.swap16();
-      value = swapped.toString('utf16le');
-    }
-    out.push({ platformID, nameID, value });
-  }
-  return out;
-}
-
 export interface FontMetadataDiagnostic {
   code:
     | 'WEIGHT_CLASS_MISMATCH'
     | 'SUBFAMILY_MISMATCH'
-    | 'LEGACY_SUBFAMILY_MISMATCH';
+    | 'LEGACY_SUBFAMILY_MISMATCH'
+    | 'FAMILY_MISMATCH';
   message: string;
 }
 
@@ -122,12 +86,34 @@ export function validateFontMetadata(
   // child process. Permission warnings would be pure noise for every
   // Google Fonts resolution.
 
+  // The bytes must answer to the family they were resolved as, or nothing
+  // downstream can find them: a run says `rFonts w:ascii="Inter"` and the
+  // host matches that against the font's own name table, never against the
+  // registry entry or the filename. `FontRegistry` repairs this before
+  // validating, so reaching here means the repair could not run (no name
+  // table, a format-1 one, non-sfnt bytes) — i.e. the face really will be
+  // unreachable under `familyLabel`.
+  const declaredFamilies = readFontFamilyNames(ttf);
+  if (
+    declaredFamilies.length > 0 &&
+    !declaredFamilies.includes(familyLabel.trim())
+  ) {
+    diags.push({
+      code: 'FAMILY_MISMATCH',
+      message: `Font "${familyLabel}" weight ${weight}${italic ? ' italic' : ''}: name table declares ${declaredFamilies
+        .map((f) => `"${f}"`)
+        .join(
+          ' / '
+        )}, not "${familyLabel}". Referencing runs will not resolve this face.`,
+    });
+  }
+
   const std = standardSubfamilyNames(weight, italic);
   if (!std) return diags;
   const expected17 = std.typographic;
   const expected2 = std.legacy;
 
-  const names = readNames(ttf, new Set([2, 17]));
+  const names = readNameRecords(ttf, new Set([2, 17]));
   for (const n of names) {
     if (n.nameID === 17 && n.value !== expected17) {
       diags.push({


### PR DESCRIPTION
## Summary

Reported as: in `modern-annual-report-1`, paragraphs in text boxes without an explicit `"fontWeight": 500` don't render as Inter in the PDF preview.

The `.docx` was never wrong — `componentDefaults` reach text-box children, and every run carries a family (288 `Inter`, 91 `Inter Medium`, 10 `Inter SemiBold`, 6 `Geist`, identical under both renderers). The preview was staging faces under names the document never asks for. Two independent defects produce that same symptom, and both are invisible on a machine that happens to have the family installed — which is why this shows in the container and not locally.

### 1. Resolved bytes didn't declare the family they were resolved as

`ResolvedFont.family` is a claim about the bytes that every consumer relies on and nothing enforced. A host — Core Text, fontconfig, GDI — finds a face by the family in its `name` table, never by the registry entry or the filename.

Inter resolves through an upstream override that instances `InterVariable.ttf` per weight, and harfbuzz preserves the master's name table, so every instance called itself **"Inter Variable"**. The preview stager renames a face only when the weight synthesizes a family of its own, so `Inter Medium` / `Inter SemiBold` were saved on the way out while weights 400 and 700 — which ride the run's bold/italic toggles on the base family — were staged under a name nothing references.

Matched against the staged set alone (the container's situation):

```
before                              after
"Inter"          -> Geist    ✗      "Inter"          -> Inter
"Inter Medium"   -> Inter Medium    "Inter Medium"   -> Inter Medium
"Inter SemiBold" -> Inter SemiBold  "Inter SemiBold" -> Inter SemiBold
```

`FontRegistry.materializeEntry` now stamps each source with the entry's family — **after** the cache read, so instanced bytes stay keyed on `(url, weight, italic, axes)` and no cached font is invalidated, and **before** validation, so the repair isn't also reported as a defect. Bytes that already answer to the family on **either** nameID 1 or 16 pass through untouched (`LifeSans-Medium.ttf` registered as "Life Sans" resolves via its typographic name; rewriting would clobber a legitimate nameID 1).

The second half matters: stamping naively gives the roman and italic RIBBI faces the same full and PostScript name. `rewriteFontFamilyName` now takes the face's RIBBI style, so family IDs (1/16) become the family alone while full (4) and PostScript (6) names carry the suffix — `Inter` / `Inter-Italic` / `Inter-Bold` / `Inter-BoldItalic`. Two fonts sharing a PostScript name is malformed, and Core Text may refuse the second registration. Omitting the style reproduces the old behaviour byte-for-byte, which is what every weight-synthesized alias relies on ("Inter Medium" is its own family's Regular member) — pinned by a test.

### 2. `bold: true` never fetched a bold face

`collectReferencedWeights` narrows what the preview fetches, but counted only numeric `fontWeight`. `bold: true` is shorthand for `fontWeight: 700` — the schema says so, and the compiler resolves it that way — so a document mixing the two lost its bold face: referencing any numeric weight took it off the "no explicit weights" fallback of `{400, 700}`, and nothing put 700 back.

Now counted, with the compiler's precedence applied per object: a font setting both takes the numeric weight, and its `bold` says nothing about which face is wanted. `modern-annual-report-1` goes from fetching Inter `{400, 500, 600}` to `{400, 500, 600, 700}`.

The two fixes compose: 700 is RIBBI, so the stager doesn't rename it — it's the registry stamp that gives the newly-fetched bold face its correct `Inter` family and distinct `Inter-Bold` PostScript name.

## Why it wasn't caught

`validateFontMetadata` checked nameID 2/17 but not 1/16, so a family-name mismatch was silent. It now emits `FAMILY_MISMATCH`, firing only where the repair could not run — a font with no name table, a format-1 one, or non-sfnt bytes.

## Verification

End to end on `modern-annual-report-1`, through the real collectors, resolution and staging. Referenced weights come out `500, 600, 700`, and every reference the document makes resolves inside the staged set: `"Inter"` → Inter Regular, `"Inter:bold"` → Inter Bold, `"Inter Medium"`, `"Inter SemiBold"`, `"Geist"`. The preview PDF now embeds the staged `Inter` where it previously reached past the staged set to the system copy.

Worth being precise: on a macOS host with Inter installed the rendered PDF is comparable either way — the system font was filling the gap. The staged-only fontconfig match is what demonstrates the fix; the container ships only Liberation/Carlito/Caladea/DejaVu.

10 new tests in `packages/shared` (the InterVariable case, distinct PostScript names across the four RIBBI faces, already-correct bytes untouched, typographic-family match, validator cases, name-table reader) and 10 in `packages/jto` (bold→700, the mixed 500 + `bold: true` case, explicit weight beating its own bold flag, table cells, custom themes, and two through `autoGoogleFontEntries` pinning the delta: mixed doc → `{400, 500, 700}`, same doc without bold → `{400, 500}`, so the narrowing still saves what it was built to save).

## Reviewer notes

- **Cost**: a bold-using document instances one extra face per family on a cold cache (this template: Inter 700, plus Geist 700/700i). That's the price of the bold text rendering at all.
- **No change to generated `.docx`/`.pptx` bytes** — Office output never embeds these fonts. The bytes feed LibreOffice staging and the pptx rasterizer behind docx `visual`, so this can't regress a download.
- The three stagers are comment-only: a note that their RIBBI fast path leans on the registry's stamp, so the skip isn't read as "fine by construction".
- **Pre-existing, left alone**: in `ttf-name.test.ts` the format-1 test calls `rewriteFontSubfamilyNames(input, standardSubfamilyNames('Bold'))` against a `(input, weight, italic)` signature. It's stale and passes vacuously — both calls return the input unchanged. Test files are excluded from typecheck, which is how it survives. Unrelated to this fix.

## Checklist

- [x] Added a changeset (`pnpm changeset`) — two, one per package
- [x] Tests pass (`pnpm check`) — lint, typecheck, and all 20 test tasks green
- [ ] Docs updated (if applicable) — no user-facing surface changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LibreOffice previews now include the correct bold font variant when documents use bold styling.
  * Font files are now consistently identified under their resolved family, improving font selection and rendering across document exports.
  * Font metadata validation now detects family-name mismatches more accurately.
  * Bold and italic font faces remain individually distinguishable when sharing a family.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->