### PR TITLE
feat(fonts): diagnose font bytes no font system can load

### DIFF
--- a/.changeset/font-structure-check.md
+++ b/.changeset/font-structure-check.md
@@ -1,0 +1,32 @@
+---
+'@json-to-office/shared': patch
+---
+
+Corrupt or truncated font bytes are now diagnosed instead of resolving
+silently.
+
+`detectFontFormat` classifies a buffer by its four magic bytes, so a download
+truncated anywhere after byte four is still 'ttf' and flows on as if it were a
+font. Nothing downstream noticed. `validateFontMetadata` had no name records to
+check and usually no readable OS/2 either, so it stayed silent by design; the
+family stamp found no declared family to contradict and no-opped; and the bytes
+staged as a `.ttf` that fontconfig and Core Text refuse. The document rendered
+in a fallback face with nothing anywhere saying why.
+
+`FontRegistry` now runs a structural check first — valid sfnt header, table
+directory within the buffer, `name` and `head` present, glyph outlines present
+as `glyf` + `loca` or `CFF `, and a `name` table that actually yields records —
+and reports the first failure as `FONT_UNREADABLE`, naming the face and what
+about the file is wrong. On failure the family stamp and the metadata checks
+are skipped rather than run against rubble; the source is still returned, since
+this diagnoses the file rather than deciding for the caller whether to ship it.
+
+Deliberately not a full sfnt parser: it answers "will a font system load this",
+not "is this well-formed". Checksums, table contents and glyph data stay out of
+scope, so a failure is always something that stops a face being indexed at all.
+
+Raised in review of #307, which proposed reporting it through `FAMILY_MISMATCH`
+instead. That was declined: a font with no family record isn't misnamed, it is
+unusable, and reporting a file-integrity problem through the family-name
+comparison would mislabel it — and would contradict the validator's documented
+contract of staying quiet when it cannot substantiate a defect.

--- a/.changeset/fonts-resolved-family-stamp.md
+++ b/.changeset/fonts-resolved-family-stamp.md
@@ -1,0 +1,35 @@
+---
+'@json-to-office/shared': patch
+---
+
+Resolved font bytes now declare the family they were resolved as.
+
+`ResolvedFont.family` was a claim about the bytes that nothing enforced. A host
+— Core Text, fontconfig, GDI — finds a face by the family in its `name` table,
+never by the registry entry or the filename, so a source whose name table says
+something else is unreachable from every run that references it. It fails
+silently: on a machine that has the real family installed the reference lands
+there instead, and only a host without it shows the fallback.
+
+Inter is the case that surfaced it. It resolves through an upstream override
+that instances `InterVariable.ttf` per weight, and harfbuzz keeps the master's
+name table — so every instance called itself "Inter Variable". The preview
+stager renames a face only when the weight synthesizes a family of its own, so
+"Inter Medium" and "Inter SemiBold" were saved on the way out while weights 400
+and 700 — which ride the run's bold/italic toggles on the base family — were
+staged under a name nothing asks for. In the preview container, which ships no
+Inter, every paragraph without an explicit `fontWeight` rendered in a fallback
+while the weighted ones came out correct.
+
+`FontRegistry` now stamps each materialized source with the entry's family,
+before validation and after the cache, so instanced bytes stay shareable across
+families and no cached font is invalidated. Bytes that already answer to the
+family — on either nameID 1 or nameID 16 — are passed through untouched.
+Full and PostScript names take the face's RIBBI style as a suffix, so the four
+faces of one family stay individually addressable rather than colliding on
+"Inter" (two fonts sharing a PostScript name is malformed, and Core Text may
+refuse the second registration).
+
+`validateFontMetadata` gained a `FAMILY_MISMATCH` diagnostic for the same
+mismatch, which now fires only when the repair could not run — a font with no
+name table, a format-1 one, or non-sfnt bytes.

--- a/.changeset/preview-bold-weight-fetch.md
+++ b/.changeset/preview-bold-weight-fetch.md
@@ -1,0 +1,22 @@
+---
+'@json-to-office/jto': patch
+---
+
+The preview now fetches a bold face for documents that ask for bold with
+`bold: true`.
+
+`collectReferencedWeights` narrows what the LibreOffice preview fetches to the
+weights a document actually uses, but it only counted numeric `fontWeight`
+values. `bold: true` is shorthand for `fontWeight: 700` — the schema says so and
+the compiler resolves it that way — so a document that mixes the two lost its
+bold face: referencing any numeric weight took it off the "no explicit weights"
+fallback of {400, 700}, and nothing put 700 back. The bold runs then asked the
+host for a face that was never staged, which renders as Inter on a machine with
+Inter installed and as a fallback anywhere else — the preview container ships
+only Liberation/Carlito/Caladea/DejaVu.
+
+`bold: true` now counts as a reference to 700, with the compiler's own
+precedence: a font that sets both takes the numeric weight, and its `bold` says
+nothing about which face is wanted. `modern-annual-report-1` goes from fetching
+Inter {400, 500, 600} to {400, 500, 600, 700}; that extra face per bold-using
+family and cold cache is the cost of the bold text rendering at all.

--- a/packages/jto-ops/src/font-staging/fontconfig-stager.ts
+++ b/packages/jto-ops/src/font-staging/fontconfig-stager.ts
@@ -47,6 +47,11 @@ export class FontconfigStager implements FontStager {
         // Rewrite `name` table so fontconfig indexes the file under the
         // synthetic sub-family ("Inter Light"), matching the doc's
         // `rFonts`/`fontFace` references after synthesizeFamilyName.
+        //
+        // The unrewritten branch (RIBBI: the run rides bold/italic toggles
+        // on the base family) leans on the bytes already declaring
+        // `r.family`. That is FontRegistry's `stampResolvedFamily` — do not
+        // read the skip as "this file is fine by construction".
         const synth = synthesizeFamilyName(r.family, s.weight, s.italic);
         const data =
           synth.family === r.family

--- a/packages/jto-ops/src/font-staging/macos-stager.ts
+++ b/packages/jto-ops/src/font-staging/macos-stager.ts
@@ -217,6 +217,11 @@ export class MacOSCoreTextStager implements FontStager {
         // sub-family the doc references (e.g. "Inter Light"). Without
         // this, Core Text indexes the staged file as "Inter" and
         // LibreOffice can't resolve `rFonts w:ascii="Inter Light"`.
+        //
+        // The unrewritten branch (RIBBI: the run rides bold/italic toggles
+        // on the base family) leans on the bytes already declaring
+        // `r.family`. That is FontRegistry's `stampResolvedFamily` — do not
+        // read the skip as "this file is fine by construction".
         const synth = synthesizeFamilyName(r.family, s.weight, s.italic);
         const data =
           synth.family === r.family

--- a/packages/jto-ops/src/font-staging/windows-stager.ts
+++ b/packages/jto-ops/src/font-staging/windows-stager.ts
@@ -90,6 +90,11 @@ export class WindowsFontStager implements FontStager {
         const suffix = s.italic ? 'i' : 'r';
         // Rewrite the TTF's internal family name so GDI registers the
         // file under the synthetic sub-family the doc references.
+        //
+        // The unrewritten branch (RIBBI: the run rides bold/italic toggles
+        // on the base family) leans on the bytes already declaring
+        // `r.family`. That is FontRegistry's `stampResolvedFamily` — do not
+        // read the skip as "this file is fine by construction".
         const synth = synthesizeFamilyName(r.family, s.weight, s.italic);
         const data =
           synth.family === r.family

--- a/packages/jto/src/server/services/__tests__/collect-referenced-weights.test.ts
+++ b/packages/jto/src/server/services/__tests__/collect-referenced-weights.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { autoGoogleFontEntries, collectReferencedWeights } from '../generator';
+
+/**
+ * The narrowing this feeds decides which faces the LibreOffice preview gets
+ * to stage. A weight the walk misses is a weight the host has to find on its
+ * own — which works on a machine with the family installed and renders a
+ * fallback everywhere else.
+ */
+describe('collectReferencedWeights', () => {
+  it('collects numeric fontWeight values', () => {
+    const doc = {
+      children: [
+        { name: 'paragraph', props: { font: { fontWeight: 500 } } },
+        { name: 'paragraph', props: { font: { fontWeight: 600 } } },
+      ],
+    };
+    expect(collectReferencedWeights(doc, undefined)).toEqual(
+      new Set([500, 600])
+    );
+  });
+
+  it('counts bold: true as a reference to 700', () => {
+    // `bold: true` is shorthand for `fontWeight: 700` (font.ts's schema says
+    // so) and the compiler resolves it to exactly that, so it names a face
+    // the document will ask a host for.
+    const doc = {
+      children: [{ name: 'paragraph', props: { font: { bold: true } } }],
+    };
+    expect(collectReferencedWeights(doc, undefined)).toEqual(new Set([700]));
+  });
+
+  it('covers a document that mixes numeric weights with bold: true', () => {
+    // The regression: referencing 500 took this doc off the "no explicit
+    // weights" fallback of {400, 700}, and nothing put 700 back — so the
+    // bold runs were never staged.
+    const doc = {
+      props: {
+        componentDefaults: { paragraph: { font: { family: 'Inter' } } },
+      },
+      children: [
+        { name: 'paragraph', props: { font: { fontWeight: 500 } } },
+        { name: 'paragraph', props: { font: { bold: true } } },
+      ],
+    };
+    expect(collectReferencedWeights(doc, undefined)).toEqual(
+      new Set([500, 700])
+    );
+  });
+
+  it('lets an explicit fontWeight on the same font win over its bold flag', () => {
+    // Compiler precedence: `fontWeight ?? (bold ? 700 : undefined)`. The run
+    // renders as Medium, so 700 is not a face this font needs.
+    const doc = {
+      children: [
+        {
+          name: 'paragraph',
+          props: { font: { fontWeight: 500, bold: true } },
+        },
+      ],
+    };
+    expect(collectReferencedWeights(doc, undefined)).toEqual(new Set([500]));
+  });
+
+  it('reads bold off every text-bearing shape, not just paragraph fonts', () => {
+    // `bold` lives on table cells and list markers too, and each renders in
+    // the document's family.
+    const doc = {
+      children: [
+        {
+          name: 'table',
+          props: { rows: [{ cells: [{ font: { bold: true } }] }] },
+        },
+      ],
+    };
+    expect(collectReferencedWeights(doc, undefined)).toEqual(new Set([700]));
+  });
+
+  it('walks custom themes as well as the document', () => {
+    const themes = { mine: { styles: { heading1: { bold: true } } } };
+    expect(collectReferencedWeights({ children: [] }, themes)).toEqual(
+      new Set([700])
+    );
+  });
+
+  it('ignores out-of-range and non-numeric fontWeight values', () => {
+    const doc = {
+      children: [
+        { name: 'paragraph', props: { font: { fontWeight: 1000 } } },
+        { name: 'paragraph', props: { font: { fontWeight: 'bold' } } },
+      ],
+    };
+    expect(collectReferencedWeights(doc, undefined)).toEqual(new Set());
+  });
+
+  it('stays empty for a document that references no weight at all', () => {
+    // Still the signal `autoGoogleFontEntries` reads to fall back to
+    // {400, 700} — a bundled theme's own bold styles are out of this walk's
+    // sight, so "nothing referenced" must not mean "fetch Regular only".
+    const doc = {
+      children: [{ name: 'paragraph', props: { text: 'plain' } }],
+    };
+    expect(collectReferencedWeights(doc, undefined)).toEqual(new Set());
+  });
+});
+
+describe('autoGoogleFontEntries — weights reaching the fetcher', () => {
+  it('keeps the bold variant for a doc that mixes fontWeight 500 with bold: true', () => {
+    // End of the chain: Inter resolves through the upstream override, and
+    // the variant filter is what decides whether a bold face is instanced
+    // at all. This is the shape modern-annual-report-1 has.
+    const entries = autoGoogleFontEntries(
+      new Set(['Inter']),
+      new Set(),
+      collectReferencedWeights(
+        {
+          children: [
+            { name: 'paragraph', props: { font: { fontWeight: 500 } } },
+            { name: 'paragraph', props: { font: { bold: true } } },
+          ],
+        },
+        undefined
+      ),
+      false
+    );
+
+    expect(entries).toHaveLength(1);
+    const weights = entries[0].sources.map(
+      (s) => (s as { weight: number }).weight
+    );
+    expect(new Set(weights)).toEqual(new Set([400, 500, 700]));
+  });
+
+  it('narrows to Regular when the doc asks for no bold anywhere', () => {
+    // The saving this narrowing exists for still holds — bold is fetched
+    // because it is referenced, not unconditionally.
+    const entries = autoGoogleFontEntries(
+      new Set(['Inter']),
+      new Set(),
+      collectReferencedWeights(
+        {
+          children: [
+            { name: 'paragraph', props: { font: { fontWeight: 500 } } },
+          ],
+        },
+        undefined
+      ),
+      false
+    );
+
+    const weights = entries[0].sources.map(
+      (s) => (s as { weight: number }).weight
+    );
+    expect(new Set(weights)).toEqual(new Set([400, 500]));
+  });
+});

--- a/packages/jto/src/server/services/__tests__/generator-document-registry.test.ts
+++ b/packages/jto/src/server/services/__tests__/generator-document-registry.test.ts
@@ -10,6 +10,8 @@
  * fallback. That is the whole feature, silently inert.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { DocxFormatAdapter } from '@json-to-office/jto-cli';
 import { GeneratorService } from '../generator';
 import { CacheService } from '../cache';
@@ -17,15 +19,25 @@ import { CacheService } from '../cache';
 const FAMILY = 'Acme Brand Sans';
 
 /**
- * A minimal but structurally real TTF: an sfnt header with zero tables. Enough
- * for the data loader's magic-byte sniff, and it keeps the fixture inline.
+ * A real font, registered under a family name of its own.
+ *
+ * An sfnt header with zero tables used to stand in here — enough for the data
+ * loader's magic-byte sniff, which was all the pipeline looked at. It isn't a
+ * font a font system could load, and `validateFontStructure` now says so, so
+ * the stand-in would have this suite asserting the absence of a warning the
+ * pipeline is right to emit. Real bytes also mean the resolution path under
+ * test runs end to end, family stamp included.
+ *
+ * Weight 500 because the fixture is a Medium: registering it as anything else
+ * trips the metadata checks on a question this suite isn't asking.
  */
-function fakeTtfBase64(): string {
-  const buf = Buffer.alloc(12);
-  buf.writeUInt32BE(0x00010000, 0); // sfnt version
-  buf.writeUInt16BE(0, 4); // numTables
-  return buf.toString('base64');
-}
+const REAL_TTF = readFileSync(
+  path.resolve(
+    __dirname,
+    '../../../../../core-docx/src/styles/fonts/life-sans/LifeSans-Medium.ttf'
+  )
+);
+const FIXTURE_WEIGHT = 500;
 
 const docWithRegistry = () => ({
   name: 'docx',
@@ -36,7 +48,13 @@ const docWithRegistry = () => ({
         id: 'acme',
         family: FAMILY,
         category: 'sans',
-        sources: [{ kind: 'data', data: fakeTtfBase64(), weight: 400 }],
+        sources: [
+          {
+            kind: 'data',
+            data: REAL_TTF.toString('base64'),
+            weight: FIXTURE_WEIGHT,
+          },
+        ],
       },
     ],
     metadata: { title: 'registry-materialization' },

--- a/packages/jto/src/server/services/generator.ts
+++ b/packages/jto/src/server/services/generator.ts
@@ -118,10 +118,28 @@ export function collectReferencedNames(
   return names;
 }
 
+/** A weight the walker will honour: canonical range, numeric. */
+function isReferenceableWeight(v: unknown): v is number {
+  return typeof v === 'number' && v >= 100 && v <= 900;
+}
+
 /**
- * Walk the doc tree + custom themes for `fontWeight` numeric values. Used
+ * Walk the doc tree + custom themes for the weights it references. Used
  * to narrow `autoGoogleFontEntries` so cold-cache runs fetch only the
  * weights the doc actually needs instead of 18 faces per Google family.
+ *
+ * `bold: true` counts as a reference to 700. It is shorthand for exactly
+ * that (see the `fontWeight` schema description), and the compiler resolves
+ * it that way — `applyFontWeightAlias` takes `fontWeight ?? (bold ? 700 :
+ * undefined)`. Collecting only the numeric form made the narrowing lie about
+ * a document that mixes the two: it referenced 500, so the "no explicit
+ * weights" fallback of {400, 700} no longer applied, and the bold runs asked
+ * a host for a face nothing had fetched. Only visible where the family isn't
+ * installed — a container, a colleague's laptop.
+ *
+ * Precedence is per-object, mirroring the compiler: a font that sets both
+ * takes the numeric weight and its `bold` says nothing about which face is
+ * wanted.
  */
 export function collectReferencedWeights(
   config: unknown,
@@ -135,13 +153,12 @@ export function collectReferencedWeights(
       return;
     }
     if (typeof node === 'object') {
-      for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
-        if (
-          k === 'fontWeight' &&
-          typeof v === 'number' &&
-          v >= 100 &&
-          v <= 900
-        ) {
+      const obj = node as Record<string, unknown>;
+      if (obj.bold === true && !isReferenceableWeight(obj.fontWeight)) {
+        weights.add(700);
+      }
+      for (const [k, v] of Object.entries(obj)) {
+        if (k === 'fontWeight' && isReferenceableWeight(v)) {
           weights.add(v);
         } else {
           visit(v);
@@ -241,9 +258,12 @@ export function autoGoogleFontEntries(
     // Narrow the fetched weight set to what the doc actually references.
     // Cold-cache fetches 1 file per (weight × italic) serially — Inter has
     // 18 faces advertised — so docs that only use 400/700 shouldn't pay
-    // for all nine. When the doc references no explicit weights, fall
-    // back to 400/700 (Regular + Bold). When it does, fetch those
-    // weights (intersected with what the family advertises).
+    // for all nine. When the doc references no weight at all — neither a
+    // numeric `fontWeight` nor a `bold: true`, both of which
+    // `collectReferencedWeights` reports — fall back to 400/700 (Regular +
+    // Bold), which also covers weights a bundled theme asks for out of this
+    // walk's sight. When it does, fetch those weights (intersected with
+    // what the family advertises).
     const wanted = (() => {
       if (!referencedWeights || referencedWeights.size === 0) {
         const filtered = match.weights.filter((w) => w === 400 || w === 700);

--- a/packages/shared/src/fonts/__tests__/registry.test.ts
+++ b/packages/shared/src/fonts/__tests__/registry.test.ts
@@ -364,3 +364,64 @@ describe('FontRegistry family stamping', () => {
     expect(out.sources[0].data.equals(REAL_TTF)).toBe(true);
   });
 });
+
+/**
+ * A truncated download keeps its sfnt magic, so `detectFontFormat` still
+ * calls it a TTF and it flows on as if it were a font. Nothing else notices:
+ * the family stamp finds no declared family to contradict, and the metadata
+ * checks have no records to read.
+ */
+describe('FontRegistry structural check', () => {
+  const REAL_TTF = readFileSync(
+    path.resolve(
+      __dirname,
+      '../../../../core-docx/src/styles/fonts/life-sans/LifeSans-Medium.ttf'
+    )
+  );
+
+  const resolveBytes = async (data: Buffer, family = 'Life Sans') => {
+    const entry: FontRegistryEntry = {
+      id: family,
+      family,
+      sources: [
+        {
+          kind: 'data',
+          data: data.toString('base64'),
+          weight: 500,
+          italic: false,
+        },
+      ],
+    };
+    return new FontRegistry({ opts: { extraEntries: [entry] } }).resolve(
+      family
+    );
+  };
+
+  it('warns FONT_UNREADABLE for a truncated font', async () => {
+    const out = await resolveBytes(REAL_TTF.subarray(0, 400));
+    expect(out.warnings.some((w) => w.startsWith('[FONT_UNREADABLE]'))).toBe(
+      true
+    );
+    expect(out.warnings.join('\n')).toContain('Life Sans');
+  });
+
+  it('does not also report metadata defects on bytes it cannot read', async () => {
+    // Past the structural failure every metadata check is reading rubble.
+    const out = await resolveBytes(REAL_TTF.subarray(0, 400));
+    expect(
+      out.warnings.some((w) => w.startsWith('[FONT_METADATA_DEFECT:'))
+    ).toBe(false);
+  });
+
+  it('still returns the source — it diagnoses the file, it does not drop it', async () => {
+    const out = await resolveBytes(REAL_TTF.subarray(0, 400));
+    expect(out.sources).toHaveLength(1);
+  });
+
+  it('stays quiet for a well-formed font', async () => {
+    const out = await resolveBytes(REAL_TTF);
+    expect(out.warnings.some((w) => w.startsWith('[FONT_UNREADABLE]'))).toBe(
+      false
+    );
+  });
+});

--- a/packages/shared/src/fonts/__tests__/registry.test.ts
+++ b/packages/shared/src/fonts/__tests__/registry.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { FontRegistry } from '../registry';
 import type { FontRegistryEntry } from '../../schemas/font-catalog';
 import { detectFontFormat } from '../sources/format';
+import {
+  readFontFamilyNames,
+  readNameRecords,
+  rewriteFontFamilyName,
+} from '../sources/ttf-name';
 
 // A small valid TTF header (0x00010000) padded — enough for format detection.
 const MINIMAL_TTF_BUF = Buffer.concat([
@@ -239,5 +246,121 @@ describe('detectFontFormat', () => {
     expect(detectFontFormat(Buffer.from([0xde, 0xad, 0xbe, 0xef]))).toBe(
       'unknown'
     );
+  });
+});
+
+/**
+ * Resolved bytes must declare the family they were resolved as — nothing
+ * downstream can find them otherwise. A host matches a run's `rFonts
+ * w:ascii="Inter"` against the font's own name table, never against the
+ * registry entry, so bytes calling themselves something else are invisible
+ * to every reference — silently, on any machine that happens to have the
+ * real family installed.
+ */
+describe('FontRegistry family stamping', () => {
+  const REAL_TTF = readFileSync(
+    path.resolve(
+      __dirname,
+      '../../../../core-docx/src/styles/fonts/life-sans/LifeSans-Medium.ttf'
+    )
+  );
+
+  /** A font that calls itself `declared`, registered under `family`. */
+  const registerAs = (
+    family: string,
+    declared: string,
+    sources: Array<{ weight: number; italic: boolean }>
+  ): FontRegistry => {
+    const entry: FontRegistryEntry = {
+      id: family,
+      family,
+      sources: sources.map((s) => ({
+        kind: 'data' as const,
+        data: rewriteFontFamilyName(REAL_TTF, declared).toString('base64'),
+        weight: s.weight,
+        italic: s.italic,
+      })),
+    };
+    return new FontRegistry({ opts: { extraEntries: [entry] } });
+  };
+
+  it('rewrites bytes that declare a different family (the InterVariable case)', async () => {
+    // Weight 400 is the case that broke: the preview stager only renames a
+    // face when the weight synthesizes a distinct family ("Inter Medium"),
+    // so Regular and Bold reach the host under whatever the file says.
+    const out = await registerAs('Inter', 'Inter Variable', [
+      { weight: 400, italic: false },
+    ]).resolve('Inter');
+
+    expect(readFontFamilyNames(out.sources[0].data)).toEqual(['Inter']);
+    // Repaired before validation runs, so it must not also warn. Matched on
+    // the bracketed code — "FAMILY_MISMATCH" is a substring of
+    // "SUBFAMILY_MISMATCH", which the fixture legitimately trips.
+    expect(
+      out.warnings.some((w) =>
+        w.includes('[FONT_METADATA_DEFECT:FAMILY_MISMATCH]')
+      )
+    ).toBe(false);
+  });
+
+  it('keeps the faces of one family individually addressable', async () => {
+    // All four RIBBI faces share the family name, so PostScript names have
+    // to differ — two fonts with the same PostScript name is malformed, and
+    // Core Text may refuse to register the second one.
+    const out = await registerAs('Inter', 'Inter Variable', [
+      { weight: 400, italic: false },
+      { weight: 400, italic: true },
+      { weight: 700, italic: false },
+      { weight: 700, italic: true },
+    ]).resolve('Inter');
+
+    const psNames = out.sources.map(
+      (s) => readNameRecords(s.data, new Set([6]))[0]?.value
+    );
+    expect(psNames).toEqual([
+      'Inter',
+      'Inter-Italic',
+      'Inter-Bold',
+      'Inter-BoldItalic',
+    ]);
+    expect(new Set(psNames).size).toBe(psNames.length);
+  });
+
+  it('leaves bytes that already answer to the family untouched', async () => {
+    // Costs a name-table rebuild, and a legitimately-named static has
+    // nothing to gain from one.
+    const out = await registerAs('Life Sans', 'Life Sans', [
+      { weight: 500, italic: false },
+    ]).resolve('Life Sans');
+
+    expect(
+      out.sources[0].data.equals(rewriteFontFamilyName(REAL_TTF, 'Life Sans'))
+    ).toBe(true);
+  });
+
+  it('accepts a match on the typographic family without rewriting', async () => {
+    // The fixture ships nameID 1 "Life Sans Medium" / nameID 16 "Life Sans".
+    // Registered as "Life Sans" it already resolves — rewriting would clobber
+    // a legitimate nameID 1.
+    const entry: FontRegistryEntry = {
+      id: 'Life Sans',
+      family: 'Life Sans',
+      sources: [
+        {
+          kind: 'data',
+          data: REAL_TTF.toString('base64'),
+          weight: 500,
+          italic: false,
+        },
+      ],
+    };
+    const out = await new FontRegistry({
+      opts: { extraEntries: [entry] },
+    }).resolve('Life Sans');
+
+    expect(readFontFamilyNames(out.sources[0].data)).toContain(
+      'Life Sans Medium'
+    );
+    expect(out.sources[0].data.equals(REAL_TTF)).toBe(true);
   });
 });

--- a/packages/shared/src/fonts/index.ts
+++ b/packages/shared/src/fonts/index.ts
@@ -33,7 +33,11 @@ export {
   type SynthesizedFamily,
 } from './synthesize';
 
-export { rewriteFontFamilyName } from './sources/ttf-name';
+export {
+  rewriteFontFamilyName,
+  readFontFamilyNames,
+  legacySubfamilyName,
+} from './sources/ttf-name';
 
 // Pure (URL + array membership) and browser-safe, so the playground preview
 // can apply the same host policy as the Node fetchers.

--- a/packages/shared/src/fonts/registry.ts
+++ b/packages/shared/src/fonts/registry.ts
@@ -20,6 +20,11 @@ import { loadDataFontSource } from './sources/data-loader';
 import { fetchGoogleFontSources } from './sources/google-fetcher';
 import { fetchUrlFontSource } from './sources/url-fetcher';
 import { validateFontMetadata } from './sources/ttf-validate';
+import {
+  readFontFamilyNames,
+  rewriteFontFamilyName,
+  standardSubfamilyNames,
+} from './sources/ttf-name';
 import { FontMemoryCache } from './cache/memory-cache';
 
 /**
@@ -86,6 +91,52 @@ export interface FontRegistryInput {
    * its `fs.promises.readFile` bootstrap) into client bundles.
    */
   variableLoader?: FontVariableLoader;
+}
+
+/**
+ * Make the bytes declare the family they were resolved as.
+ *
+ * `ResolvedFont.family` is a claim about the bytes that every consumer
+ * relies on and that nothing used to enforce. A host — Core Text,
+ * fontconfig, GDI — finds a face by the family in its `name` table, never
+ * by the registry entry or the filename, so a source whose name table says
+ * something else is unreachable from the runs that reference it. It fails
+ * silently: on a machine that happens to have the real family installed the
+ * reference lands there instead, and only a host without it (a container,
+ * a colleague's laptop) shows the fallback.
+ *
+ * The case that forced this: Inter resolves through an upstream override
+ * that instances `InterVariable.ttf` per weight, and harfbuzz keeps the
+ * master's name table — so every instance called itself "Inter Variable".
+ * The weighted faces were saved by the preview stager renaming them to
+ * "Inter Medium" / "Inter SemiBold" on the way out; weights 400 and 700
+ * kept the family name unchanged (they ride the run's bold/italic toggles
+ * instead), so those alone were staged under a name no run asks for.
+ *
+ * Matching on ANY declared name (family or typographic family) keeps a
+ * legitimately-named static untouched: LifeSans-Medium.ttf registered as
+ * "Life Sans" already answers to it via nameID 16, even though nameID 1
+ * says "Life Sans Medium". Only bytes that answer to nothing get rewritten.
+ */
+function stampResolvedFamily(
+  source: ResolvedFontSource,
+  family: string
+): ResolvedFontSource {
+  if (source.format !== 'ttf' && source.format !== 'otf') return source;
+  const declared = readFontFamilyNames(source.data);
+  // Nothing declared: no claim to contradict, and nothing to repair against.
+  if (declared.length === 0 || declared.includes(family)) return source;
+  // The style this face occupies within `family`. The family IDs become
+  // `family` for all four RIBBI faces, so full/PostScript names have to
+  // carry the style or roman and italic collide on both.
+  const subfamily = standardSubfamilyNames(
+    source.weight,
+    source.italic
+  )?.legacy;
+  return {
+    ...source,
+    data: rewriteFontFamilyName(source.data, family, subfamily),
+  };
 }
 
 export class FontRegistry {
@@ -155,7 +206,8 @@ export class FontRegistry {
     for (const source of entry.sources) {
       try {
         const materialized = await this.materializeSource(source, warnings);
-        for (const s of materialized) {
+        for (const raw of materialized) {
+          const s = stampResolvedFamily(raw, entry.family);
           if (s.format === 'ttf' || s.format === 'otf') {
             for (const d of validateFontMetadata(
               s.data,

--- a/packages/shared/src/fonts/registry.ts
+++ b/packages/shared/src/fonts/registry.ts
@@ -20,6 +20,7 @@ import { loadDataFontSource } from './sources/data-loader';
 import { fetchGoogleFontSources } from './sources/google-fetcher';
 import { fetchUrlFontSource } from './sources/url-fetcher';
 import { validateFontMetadata } from './sources/ttf-validate';
+import { validateFontStructure } from './sources/ttf-structure';
 import {
   readFontFamilyNames,
   rewriteFontFamilyName,
@@ -207,8 +208,28 @@ export class FontRegistry {
       try {
         const materialized = await this.materializeSource(source, warnings);
         for (const raw of materialized) {
+          const sfnt = raw.format === 'ttf' || raw.format === 'otf';
+          // Can a font system load these bytes at all? Asked first, and on
+          // failure asked instead of everything below: the stamp has no name
+          // table to write into and the metadata checks no records to read,
+          // so both would quietly do nothing and report nothing. The source
+          // is still returned — this diagnoses the file, it doesn't decide
+          // for the caller whether to ship it.
+          const broken = sfnt
+            ? validateFontStructure(
+                raw.data,
+                raw.weight,
+                raw.italic,
+                entry.family
+              )
+            : null;
+          if (broken) {
+            warnings.push(`[${broken.code}] ${broken.message}`);
+            sources.push(raw);
+            continue;
+          }
           const s = stampResolvedFamily(raw, entry.family);
-          if (s.format === 'ttf' || s.format === 'otf') {
+          if (sfnt) {
             for (const d of validateFontMetadata(
               s.data,
               s.weight,

--- a/packages/shared/src/fonts/sources/__tests__/ttf-name.test.ts
+++ b/packages/shared/src/fonts/sources/__tests__/ttf-name.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import {
   legacySubfamilyName,
   readFontFamilyNames,
+  readNameRecords,
   rewriteFontFamilyName,
   rewriteFontSubfamilyNames,
   standardSubfamilyNames,
@@ -330,5 +331,51 @@ describe('legacySubfamilyName', () => {
     expect(legacySubfamilyName(false, true)).toBe('Italic');
     expect(legacySubfamilyName(true, false)).toBe('Bold');
     expect(legacySubfamilyName(true, true)).toBe('Bold Italic');
+  });
+});
+
+describe('readNameRecords bounds', () => {
+  const original = readFileSync(FIXTURE);
+
+  it('does not decode records past the end of the name table', () => {
+    // `Buffer.slice` clamps instead of throwing, so a count larger than the
+    // table holds used to walk into whatever table follows and decode its
+    // bytes as name records.
+    const buf = Buffer.from(original);
+    const { offset } = nameTableSpan(buf);
+    const realCount = buf.readUInt16BE(offset + 2);
+    buf.writeUInt16BE(realCount + 40, offset + 2);
+
+    expect(readNameRecords(buf)).toHaveLength(readNameRecords(original).length);
+    expect(readFontFamilyNames(buf)).toEqual(readFontFamilyNames(original));
+  });
+
+  it('skips a record whose string runs past the table, keeping the rest', () => {
+    // One bad record shouldn't cost the font every other name it declares.
+    const buf = Buffer.from(original);
+    const { offset, length } = nameTableSpan(buf);
+    // First record: point its string at the table's last byte and claim the
+    // string is longer than the table.
+    buf.writeUInt16BE(length, offset + 6 + 8);
+    buf.writeUInt16BE(0xfff0, offset + 6 + 10);
+
+    const records = readNameRecords(buf);
+    expect(records).toHaveLength(readNameRecords(original).length - 1);
+    // Nothing decoded from beyond the table — the skipped record's id is
+    // simply absent rather than carrying foreign bytes.
+    const firstId = original.readUInt16BE(offset + 6 + 6);
+    const before = readNameRecords(original).filter(
+      (r) => r.nameID === firstId
+    );
+    const after = records.filter((r) => r.nameID === firstId);
+    expect(after).toHaveLength(before.length - 1);
+  });
+
+  it('reports nothing for a table whose string offset is out of range', () => {
+    const buf = Buffer.from(original);
+    const { offset } = nameTableSpan(buf);
+    buf.writeUInt16BE(0xfff0, offset + 4); // storage offset past the table
+    expect(readNameRecords(buf)).toEqual([]);
+    expect(readFontFamilyNames(buf)).toEqual([]);
   });
 });

--- a/packages/shared/src/fonts/sources/__tests__/ttf-name.test.ts
+++ b/packages/shared/src/fonts/sources/__tests__/ttf-name.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import {
+  legacySubfamilyName,
+  readFontFamilyNames,
   rewriteFontFamilyName,
   rewriteFontSubfamilyNames,
   standardSubfamilyNames,
@@ -85,6 +87,46 @@ describe('rewriteFontFamilyName', () => {
     for (const s of psNames) expect(s).toBe('SynthLight');
   });
 
+  it('keeps full + PostScript names distinct across a family when given a subfamily', () => {
+    // The four RIBBI faces share one family name and are told apart by the
+    // style bits, so nameID 4/6 have to carry the style or roman and italic
+    // become indistinguishable — Core Text may then refuse to register the
+    // second of the pair at all.
+    const roman = readNameStrings(rewriteFontFamilyName(original, 'Inter'));
+    const italic = readNameStrings(
+      rewriteFontFamilyName(original, 'Inter', 'Italic')
+    );
+    const boldItalic = readNameStrings(
+      rewriteFontFamilyName(original, 'Inter', 'Bold Italic')
+    );
+
+    // Family IDs are the family alone, in every face.
+    for (const names of [roman, italic, boldItalic]) {
+      for (const id of [1, 16]) {
+        for (const s of names.get(id) ?? []) expect(s).toBe('Inter');
+      }
+    }
+    for (const s of roman.get(4) ?? []) expect(s).toBe('Inter');
+    for (const s of italic.get(4) ?? []) expect(s).toBe('Inter Italic');
+    for (const s of boldItalic.get(4) ?? [])
+      expect(s).toBe('Inter Bold Italic');
+    for (const s of roman.get(6) ?? []) expect(s).toBe('Inter');
+    for (const s of italic.get(6) ?? []) expect(s).toBe('Inter-Italic');
+    for (const s of boldItalic.get(6) ?? []) {
+      expect(s).toBe('Inter-BoldItalic');
+    }
+  });
+
+  it('treats an explicit "Regular" subfamily as no suffix at all', () => {
+    // A family's default face is named after the family, not "X Regular" —
+    // and this is the path every weight-synthesized alias takes ("Inter
+    // Medium" is the Regular member of its own family), so it must stay
+    // byte-identical to the no-subfamily call.
+    const bare = rewriteFontFamilyName(original, 'Inter Medium');
+    const regular = rewriteFontFamilyName(original, 'Inter Medium', 'Regular');
+    expect(regular.equals(bare)).toBe(true);
+  });
+
   it('leaves other name records untouched', () => {
     const out = rewriteFontFamilyName(original, 'Whatever');
     const before = readNameStrings(original);
@@ -110,10 +152,12 @@ describe('rewriteFontFamilyName', () => {
   it('produces bytes that validateFontMetadata can still parse', () => {
     // Original fixture passes validation for weight 500 (Medium, non-italic).
     // Rewriting the family name must not perturb OS/2 or name records other
-    // than the targeted family IDs, so diagnostics should be identical.
-    const before = validateFontMetadata(original, 500, false, 'LifeSans');
+    // than the targeted family IDs, so diagnostics should be identical. Each
+    // side is validated under the family its bytes actually declare, so the
+    // comparison isn't smuggling a FAMILY_MISMATCH through both.
+    const before = validateFontMetadata(original, 500, false, 'Life Sans');
     const out = rewriteFontFamilyName(original, 'Synth Medium');
-    const after = validateFontMetadata(out, 500, false, 'SynthMedium');
+    const after = validateFontMetadata(out, 500, false, 'Synth Medium');
     // Same set of diagnostic codes — name rewrite is orthogonal to OS/2
     // and subfamily (nameID 2/17) checks.
     expect(after.map((d) => d.code).sort()).toEqual(
@@ -253,5 +297,38 @@ describe('format-1 name tables', () => {
   it('still rewrites an ordinary format-0 table', () => {
     const input = Buffer.from(readFileSync(FIXTURE));
     expect(rewriteFontFamilyName(input, 'Renamed')).not.toEqual(input);
+  });
+});
+
+describe('readFontFamilyNames', () => {
+  const original = readFileSync(FIXTURE);
+
+  it('reports every distinct family name the font declares', () => {
+    // The fixture is a Medium shipped as its own family: nameID 1 says
+    // "Life Sans Medium" while nameID 16 still says "Life Sans". Both are
+    // legitimate ways to reach it, so both have to come back.
+    const declared = readFontFamilyNames(original);
+    expect(declared).toContain('Life Sans Medium');
+    expect(declared).toContain('Life Sans');
+    // Deduped across the platform records that repeat each string.
+    expect(new Set(declared).size).toBe(declared.length);
+  });
+
+  it('reads back whatever rewriteFontFamilyName just stamped', () => {
+    const out = rewriteFontFamilyName(original, 'Inter', 'Italic');
+    expect(readFontFamilyNames(out)).toEqual(['Inter']);
+  });
+
+  it('returns nothing for bytes with no readable name table', () => {
+    expect(readFontFamilyNames(Buffer.from('not a font'))).toEqual([]);
+  });
+});
+
+describe('legacySubfamilyName', () => {
+  it('maps the bold/italic pair onto the four-style vocabulary', () => {
+    expect(legacySubfamilyName(false, false)).toBe('Regular');
+    expect(legacySubfamilyName(false, true)).toBe('Italic');
+    expect(legacySubfamilyName(true, false)).toBe('Bold');
+    expect(legacySubfamilyName(true, true)).toBe('Bold Italic');
   });
 });

--- a/packages/shared/src/fonts/sources/__tests__/ttf-structure.test.ts
+++ b/packages/shared/src/fonts/sources/__tests__/ttf-structure.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { validateFontStructure } from '../ttf-structure';
+
+const FIXTURE = path.resolve(
+  __dirname,
+  '../../../../../core-docx/src/styles/fonts/life-sans/LifeSans-Medium.ttf'
+);
+
+/** Byte range of a table's directory entry in an sfnt. */
+function directoryEntry(buf: Buffer, tag: string): number {
+  const numTables = buf.readUInt16BE(4);
+  for (let i = 0; i < numTables; i += 1) {
+    const eo = 12 + i * 16;
+    if (buf.toString('ascii', eo, eo + 4) === tag) return eo;
+  }
+  throw new Error(`no ${tag} table`);
+}
+
+/** A `name` table with one readable record, so the readability probe passes. */
+function nameTable(value: string): Buffer {
+  const encoded = Buffer.alloc(value.length * 2);
+  for (let i = 0; i < value.length; i += 1) {
+    encoded.writeUInt16BE(value.charCodeAt(i), i * 2);
+  }
+  const header = Buffer.alloc(18);
+  header.writeUInt16BE(0, 0); // format 0
+  header.writeUInt16BE(1, 2); // one record
+  header.writeUInt16BE(18, 4); // storage starts after the record
+  header.writeUInt16BE(3, 6); // platform 3
+  header.writeUInt16BE(1, 8);
+  header.writeUInt16BE(1033, 10);
+  header.writeUInt16BE(1, 12); // nameID 1
+  header.writeUInt16BE(encoded.length, 14);
+  header.writeUInt16BE(0, 16);
+  return Buffer.concat([header, encoded]);
+}
+
+/**
+ * Assemble an sfnt from table stubs. The checker reads the envelope, never a
+ * table's contents, so stub bytes are enough — and building the file here
+ * keeps the CFF case self-contained rather than reaching for a shipped
+ * template asset that template work is free to move.
+ */
+function buildFontWith(
+  version: number,
+  tables: Array<{ tag: string; data?: Buffer }>
+): Buffer {
+  const directorySize = 12 + tables.length * 16;
+  const bodies = tables.map((t) => t.data ?? Buffer.alloc(16));
+  const total = directorySize + bodies.reduce((sum, b) => sum + b.length, 0);
+  const buf = Buffer.alloc(total);
+  buf.writeUInt32BE(version, 0);
+  buf.writeUInt16BE(tables.length, 4);
+  let cursor = directorySize;
+  tables.forEach((t, i) => {
+    const eo = 12 + i * 16;
+    buf.write(t.tag, eo, 4, 'ascii');
+    buf.writeUInt32BE(cursor, eo + 8);
+    buf.writeUInt32BE(bodies[i].length, eo + 12);
+    bodies[i].copy(buf, cursor);
+    cursor += bodies[i].length;
+  });
+  return buf;
+}
+
+describe('validateFontStructure', () => {
+  const real = readFileSync(FIXTURE);
+
+  describe('loadable fonts', () => {
+    it('passes a real TrueType font', () => {
+      expect(validateFontStructure(real, 500, false, 'Life Sans')).toBeNull();
+    });
+
+    it('passes a CFF-flavoured OpenType font', () => {
+      // 'OTTO' + CFF outlines instead of glyf/loca — the other half of what
+      // the pipeline resolves.
+      const otf = buildFontWith(0x4f54544f, [
+        { tag: 'CFF ' },
+        { tag: 'head' },
+        { tag: 'name', data: nameTable('Clash Display') },
+      ]);
+      expect(
+        validateFontStructure(otf, 400, false, 'Clash Display')
+      ).toBeNull();
+    });
+
+    it('passes the legacy "true" sfnt version', () => {
+      const font = buildFontWith(0x74727565, [
+        { tag: 'glyf' },
+        { tag: 'loca' },
+        { tag: 'head' },
+        { tag: 'name', data: nameTable('Legacy') },
+      ]);
+      expect(validateFontStructure(font, 400, false, 'Legacy')).toBeNull();
+    });
+  });
+
+  describe('truncation — the case detectFontFormat cannot see', () => {
+    it('flags a font truncated mid-directory', () => {
+      // Still starts with the sfnt magic, so `detectFontFormat` calls it a
+      // TTF and every downstream check stays silent.
+      const truncated = real.subarray(0, 40);
+      const diag = validateFontStructure(truncated, 500, false, 'Life Sans');
+      expect(diag?.code).toBe('FONT_UNREADABLE');
+      expect(diag?.message).toContain('truncated');
+    });
+
+    it('flags a font whose directory survives but whose tables do not', () => {
+      const truncated = real.subarray(0, 12 + 16 * real.readUInt16BE(4) + 64);
+      const diag = validateFontStructure(truncated, 500, false, 'Life Sans');
+      expect(diag?.code).toBe('FONT_UNREADABLE');
+      expect(diag?.message).toContain('truncated');
+    });
+
+    it('flags bytes shorter than an sfnt header', () => {
+      const diag = validateFontStructure(
+        Buffer.from([0x00, 0x01, 0x00, 0x00]),
+        400,
+        false,
+        'Stub'
+      );
+      expect(diag?.code).toBe('FONT_UNREADABLE');
+      expect(diag?.message).toContain('shorter than an sfnt header');
+    });
+
+    it('flags an empty table directory', () => {
+      // The shape of the registry suite's minimal buffer: magic plus zeros.
+      const buf = Buffer.concat([
+        Buffer.from([0x00, 0x01, 0x00, 0x00]),
+        Buffer.alloc(64),
+      ]);
+      const diag = validateFontStructure(buf, 400, false, 'Minimal');
+      expect(diag?.code).toBe('FONT_UNREADABLE');
+      expect(diag?.message).toContain('directory is empty');
+    });
+  });
+
+  describe('missing or unreadable tables', () => {
+    it('flags a font with no name table', () => {
+      const buf = Buffer.from(real);
+      buf.write('xxxx', directoryEntry(buf, 'name'), 4, 'ascii');
+      const diag = validateFontStructure(buf, 500, false, 'Life Sans');
+      expect(diag?.code).toBe('FONT_UNREADABLE');
+      expect(diag?.message).toContain('no "name" table');
+    });
+
+    it('flags a font with no head table', () => {
+      const buf = Buffer.from(real);
+      buf.write('xxxx', directoryEntry(buf, 'head'), 4, 'ascii');
+      expect(
+        validateFontStructure(buf, 500, false, 'Life Sans')?.message
+      ).toContain('no "head" table');
+    });
+
+    it('flags a font carrying no glyph outlines', () => {
+      const buf = Buffer.from(real);
+      buf.write('xxxx', directoryEntry(buf, 'glyf'), 4, 'ascii');
+      expect(
+        validateFontStructure(buf, 500, false, 'Life Sans')?.message
+      ).toContain('no glyph outlines');
+    });
+
+    it('flags a name table present but unreadable', () => {
+      // Present in the directory, but its string storage points outside the
+      // table — every record is skipped, so nothing can index the face.
+      const buf = Buffer.from(real);
+      const eo = directoryEntry(buf, 'name');
+      buf.writeUInt16BE(0xfff0, buf.readUInt32BE(eo + 8) + 4);
+      expect(
+        validateFontStructure(buf, 500, false, 'Life Sans')?.message
+      ).toContain('no readable records');
+    });
+
+    it('flags a table whose directory entry points past the end', () => {
+      const buf = Buffer.from(real);
+      buf.writeUInt32BE(buf.length + 1024, directoryEntry(buf, 'name') + 8);
+      const diag = validateFontStructure(buf, 500, false, 'Life Sans');
+      expect(diag?.code).toBe('FONT_UNREADABLE');
+      expect(diag?.message).toContain('"name" table runs to byte');
+    });
+  });
+
+  it('rejects bytes that are not sfnt at all', () => {
+    const diag = validateFontStructure(
+      Buffer.alloc(64, 0x41),
+      400,
+      false,
+      'NotAFont'
+    );
+    expect(diag?.code).toBe('FONT_UNREADABLE');
+    expect(diag?.message).toContain('neither TrueType nor OpenType');
+  });
+
+  it('names the face and says what goes wrong for a reader', () => {
+    const diag = validateFontStructure(
+      real.subarray(0, 40),
+      700,
+      true,
+      'Life Sans'
+    );
+    expect(diag?.message).toContain('Font "Life Sans" weight 700 italic');
+    expect(diag?.message).toContain('renders in a fallback');
+  });
+
+  it('does not flag a stub directory that satisfies every requirement', () => {
+    // Guards against over-strictness: the check reads the envelope, never a
+    // table's contents, so a font with unusual table lengths still passes.
+    const font = buildFontWith(0x00010000, [
+      { tag: 'glyf', data: Buffer.alloc(3) },
+      { tag: 'loca', data: Buffer.alloc(1) },
+      { tag: 'head', data: Buffer.alloc(54) },
+      { tag: 'name', data: nameTable('Odd') },
+      { tag: 'DSIG', data: Buffer.alloc(0) },
+    ]);
+    expect(validateFontStructure(font, 400, false, 'Odd')).toBeNull();
+  });
+});

--- a/packages/shared/src/fonts/sources/__tests__/ttf-validate.test.ts
+++ b/packages/shared/src/fonts/sources/__tests__/ttf-validate.test.ts
@@ -6,6 +6,10 @@ function makeFont(opts: {
   usWeightClass: number;
   name17?: string;
   name2?: string;
+  /** nameID 1 — the family the bytes claim. */
+  name1?: string;
+  /** nameID 16 — typographic family, when the face ships one. */
+  name16?: string;
   /** OS/2.fsType at offset +8 (default 0 = installable/no restriction). */
   fsType?: number;
 }): Buffer {
@@ -16,6 +20,10 @@ function makeFont(opts: {
   };
 
   const records: Array<{ nameID: number; bytes: Buffer }> = [];
+  if (opts.name1 !== undefined)
+    records.push({ nameID: 1, bytes: encode16(opts.name1) });
+  if (opts.name16 !== undefined)
+    records.push({ nameID: 16, bytes: encode16(opts.name16) });
   if (opts.name17 !== undefined)
     records.push({ nameID: 17, bytes: encode16(opts.name17) });
   if (opts.name2 !== undefined)
@@ -191,5 +199,47 @@ describe('validateFontMetadata', () => {
     // usWeightClass matches requested → no weight mismatch. No subfamily
     // expectation for non-standard weights.
     expect(diags).toEqual([]);
+  });
+});
+
+describe('validateFontMetadata — family name', () => {
+  it('flags bytes that answer to a different family than they were resolved as', () => {
+    // The Inter case: an instance of InterVariable.ttf still calls itself
+    // "Inter Variable", so a run saying `rFonts w:ascii="Inter"` finds
+    // nothing. FontRegistry repairs this before validating; a diagnostic
+    // here means the repair could not run.
+    const font = makeFont({
+      usWeightClass: 400,
+      name1: 'Inter Variable',
+      name2: 'Regular',
+      name17: 'Regular',
+    });
+    const diags = validateFontMetadata(font, 400, false, 'Inter');
+    expect(diags.map((d) => d.code)).toContain('FAMILY_MISMATCH');
+    expect(diags.find((d) => d.code === 'FAMILY_MISMATCH')?.message).toContain(
+      'Inter Variable'
+    );
+  });
+
+  it('accepts a match on the typographic family (nameID 16)', () => {
+    // A weight shipped as its own family names itself "Life Sans Medium" in
+    // nameID 1 while nameID 16 still says "Life Sans". Registered under the
+    // typographic name it is perfectly reachable — not a defect.
+    const font = makeFont({
+      usWeightClass: 500,
+      name1: 'Life Sans Medium',
+      name16: 'Life Sans',
+      name2: 'Regular',
+      name17: 'Medium',
+    });
+    const diags = validateFontMetadata(font, 500, false, 'Life Sans');
+    expect(diags.map((d) => d.code)).not.toContain('FAMILY_MISMATCH');
+  });
+
+  it('stays quiet when the font declares no family at all', () => {
+    // Nothing to contradict, and nothing the repair could have fixed.
+    const font = makeFont({ usWeightClass: 400, name2: 'Regular' });
+    const diags = validateFontMetadata(font, 400, false, 'Anything');
+    expect(diags.map((d) => d.code)).not.toContain('FAMILY_MISMATCH');
   });
 });

--- a/packages/shared/src/fonts/sources/ttf-name.ts
+++ b/packages/shared/src/fonts/sources/ttf-name.ts
@@ -298,9 +298,18 @@ function findTable(
 
 /**
  * Read the `name` records a font carries, optionally narrowed to `wanted`
- * nameIDs. Tolerant of malformed tables — a record that would read past the
- * buffer ends the scan rather than throwing, because these bytes come off
- * the network.
+ * nameIDs. Tolerant of malformed tables, because these bytes come off the
+ * network: everything is bounded by the `name` table's own extent, not by
+ * the buffer. `Buffer.slice` clamps an out-of-range window silently rather
+ * than throwing, so without that bound a table claiming more records than it
+ * holds decodes the bytes of whatever table follows it, and a record with a
+ * bogus string offset returns a truncated or foreign name.
+ *
+ * A header that would run past the table ends the scan; a single record
+ * whose string does is skipped, since the other records are still readable
+ * and each one stands alone. Either way the name is not reported, which is
+ * the safe direction — a caller asking "do these bytes answer to family X?"
+ * gets no for an unreadable record instead of a coincidental yes.
  *
  * Shared with `validateFontMetadata` so the checker and the rewriters above
  * cannot disagree about what a font declares.
@@ -313,18 +322,27 @@ export function readNameRecords(
   if (!nt) return [];
   const tableOff = nt.offset;
   if (tableOff + 6 > input.length) return [];
+  // The directory may claim a length past the end of a truncated download.
+  const tableEnd = Math.min(tableOff + nt.length, input.length);
   const count = input.readUInt16BE(tableOff + 2);
   const storage = tableOff + input.readUInt16BE(tableOff + 4);
+  // Records occupy exactly the span between the 6-byte header and the string
+  // storage. Bounding them by the table alone is not enough: an inflated
+  // `count` would keep reading 12-byte "records" out of the string heap,
+  // which is inside the table and decodes to plausible-looking garbage.
+  const recordsEnd = Math.min(storage, tableEnd);
   const out: DecodedNameRecord[] = [];
   for (let i = 0; i < count; i += 1) {
     const ro = tableOff + 6 + i * 12;
-    if (ro + 12 > input.length) break;
+    if (ro + 12 > recordsEnd) break;
     const platformID = input.readUInt16BE(ro);
     const nameID = input.readUInt16BE(ro + 6);
     if (wanted && !wanted.has(nameID)) continue;
     const length = input.readUInt16BE(ro + 8);
     const offset = input.readUInt16BE(ro + 10);
-    const raw = input.slice(storage + offset, storage + offset + length);
+    const start = storage + offset;
+    if (start + length > tableEnd) continue;
+    const raw = input.slice(start, start + length);
     let value: string;
     if (platformID === 1) {
       value = raw.toString('ascii');

--- a/packages/shared/src/fonts/sources/ttf-name.ts
+++ b/packages/shared/src/fonts/sources/ttf-name.ts
@@ -1,13 +1,13 @@
 /**
- * Name-table rewriting for TTF/OTF sfnt fonts. Two public transforms share
- * the rebuild machinery:
+ * Name-table reading and rewriting for TTF/OTF sfnt fonts. Two public
+ * transforms share the rebuild machinery, plus one reader:
  *
  * - `rewriteFontFamilyName` — rewrite `nameID` 1 / 4 / 6 / 16 to a
- *   synthetic family name. Used by the preview-side font stagers so that
- *   running-text references like `"Inter Light"` resolve to the correct
- *   face when the stager registers it with Core Text / fontconfig / GDI
- *   (all of which index by the font's internal `name` table rather than
- *   the filename).
+ *   synthetic family name. Used by `FontRegistry` (so resolved bytes
+ *   declare the family they were resolved as) and by the preview-side
+ *   font stagers (so running-text references like `"Inter Light"` resolve
+ *   to the correct face). Core Text / fontconfig / GDI all index by the
+ *   font's internal `name` table rather than the filename.
  *
  * - `rewriteFontSubfamilyNames` — rewrite `nameID` 2 / 17 to the standard
  *   subfamily strings for a (weight, italic) pair. Used by the variable-
@@ -15,6 +15,10 @@
  *   verbatim, so an instanced Bold would otherwise keep the variable
  *   font's default-instance "Regular" subfamily and trip
  *   `validateFontMetadata`.
+ *
+ * - `readNameRecords` / `readFontFamilyNames` — the reading half, shared
+ *   with `validateFontMetadata` so the checker and the writer cannot
+ *   drift on how a name record is located or decoded.
  *
  * Each transform rebuilds the whole font: new `name` table bytes, new
  * table directory with shifted offsets, recomputed per-table checksums,
@@ -265,26 +269,154 @@ function rewriteNameTable(
   return out;
 }
 
+/** One decoded `name` record: where it came from and what it says. */
+export interface DecodedNameRecord {
+  platformID: number;
+  nameID: number;
+  value: string;
+}
+
+/** Byte range of `tag`'s table within `input`, or null. */
+function findTable(
+  input: Buffer,
+  tag: string
+): { offset: number; length: number } | null {
+  if (input.length < 12) return null;
+  const numTables = input.readUInt16BE(4);
+  for (let i = 0; i < numTables; i += 1) {
+    const eo = 12 + i * 16;
+    if (eo + 16 > input.length) return null;
+    if (input.toString('ascii', eo, eo + 4) === tag) {
+      return {
+        offset: input.readUInt32BE(eo + 8),
+        length: input.readUInt32BE(eo + 12),
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Read the `name` records a font carries, optionally narrowed to `wanted`
+ * nameIDs. Tolerant of malformed tables — a record that would read past the
+ * buffer ends the scan rather than throwing, because these bytes come off
+ * the network.
+ *
+ * Shared with `validateFontMetadata` so the checker and the rewriters above
+ * cannot disagree about what a font declares.
+ */
+export function readNameRecords(
+  input: Buffer,
+  wanted?: Set<number>
+): DecodedNameRecord[] {
+  const nt = findTable(input, 'name');
+  if (!nt) return [];
+  const tableOff = nt.offset;
+  if (tableOff + 6 > input.length) return [];
+  const count = input.readUInt16BE(tableOff + 2);
+  const storage = tableOff + input.readUInt16BE(tableOff + 4);
+  const out: DecodedNameRecord[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const ro = tableOff + 6 + i * 12;
+    if (ro + 12 > input.length) break;
+    const platformID = input.readUInt16BE(ro);
+    const nameID = input.readUInt16BE(ro + 6);
+    if (wanted && !wanted.has(nameID)) continue;
+    const length = input.readUInt16BE(ro + 8);
+    const offset = input.readUInt16BE(ro + 10);
+    const raw = input.slice(storage + offset, storage + offset + length);
+    let value: string;
+    if (platformID === 1) {
+      value = raw.toString('ascii');
+    } else {
+      // UTF-16BE. Buffer has no utf16be decoder — swap to LE and decode.
+      const swapped = Buffer.from(raw);
+      if (swapped.length % 2 === 0) swapped.swap16();
+      value = swapped.toString('utf16le');
+    }
+    out.push({ platformID, nameID, value });
+  }
+  return out;
+}
+
+/**
+ * Every distinct family name a font declares — `nameID` 1 (family) and 16
+ * (typographic/preferred family), deduped, in record order.
+ *
+ * Both count: a weight shipped as its own family names itself "Life Sans
+ * Medium" in nameID 1 while nameID 16 still says "Life Sans", and either
+ * is a legitimate way for a consumer to find it. Callers asking "do these
+ * bytes answer to family X?" must therefore accept a match on either.
+ */
+export function readFontFamilyNames(input: Buffer): string[] {
+  const out: string[] = [];
+  for (const r of readNameRecords(input, FAMILY_LOOKUP_IDS)) {
+    const value = r.value.trim();
+    if (value.length > 0 && !out.includes(value)) out.push(value);
+  }
+  return out;
+}
+
+const FAMILY_LOOKUP_IDS = new Set<number>([1, 16]);
+
+/**
+ * The RIBBI style label a face carries alongside its family name — the
+ * four-style vocabulary `nameID` 2 is restricted to. Used to build the
+ * full (`nameID` 4) and PostScript (`nameID` 6) names, which must stay
+ * distinct across the faces of one family.
+ */
+export function legacySubfamilyName(
+  bold: boolean,
+  italic: boolean
+): 'Regular' | 'Italic' | 'Bold' | 'Bold Italic' {
+  if (bold) return italic ? 'Bold Italic' : 'Bold';
+  return italic ? 'Italic' : 'Regular';
+}
+
 /**
  * Return a copy of `input` whose name table has `nameID` 1/4/6/16 rewritten
  * to `newFamily`. Returns the original buffer unchanged if the font has no
  * `name` table or the sfnt header is invalid.
+ *
+ * `subfamily` is the RIBBI style this face occupies *within* `newFamily`.
+ * The family IDs (1/16) always become `newFamily` alone, but the full name
+ * (4) and PostScript name (6) take the style as a suffix, so the four faces
+ * of one family stay individually addressable — "Inter" / "Inter Italic" /
+ * "Inter Bold" / "Inter Bold Italic", PostScript "Inter" / "Inter-Italic" /
+ * … Two faces sharing a PostScript name is malformed, and Core Text may
+ * refuse the second registration outright.
+ *
+ * Omitted (or "Regular") reproduces the historical behaviour — every
+ * targeted ID becomes `newFamily` — which is correct for a face staged
+ * under a weight-synthesized family of its own ("Inter Medium"), where the
+ * face IS that family's Regular member.
  */
 export function rewriteFontFamilyName(
   input: Buffer,
-  newFamily: string
+  newFamily: string,
+  subfamily?: string
 ): Buffer {
+  // "Regular" is the absence of a style suffix, not a suffix reading
+  // "Regular" — a family's default face is named after the family alone.
+  const style = subfamily && subfamily !== 'Regular' ? subfamily : '';
+  const fullName = style ? `${newFamily} ${style}` : newFamily;
   // PostScript names (nameID 6) are restricted to printable ASCII 33-126
   // minus `[](){}<>/%` per the OpenType spec — fold spaces out and strip
-  // any forbidden chars so Word doesn't silently reject the font.
+  // any forbidden chars so Word doesn't silently reject the font. The
+  // style rides as a hyphenated suffix, the convention every shipped
+  // family uses ("Inter-BoldItalic").
   const psForbidden = /[[\](){}<>/%]/g;
   // eslint-disable-next-line no-control-regex
-  const isAscii = /^[\x00-\x7f]*$/.test(newFamily);
-  const psName = newFamily
-    .replace(/\s+/g, '')
-    .replace(psForbidden, '')
-    // eslint-disable-next-line no-control-regex
-    .replace(/[^\x21-\x7e]/g, '');
+  const isAscii = /^[\x00-\x7f]*$/.test(fullName);
+  const psSafe = (s: string): string =>
+    s
+      .replace(/\s+/g, '')
+      .replace(psForbidden, '')
+      // eslint-disable-next-line no-control-regex
+      .replace(/[^\x21-\x7e]/g, '');
+  const psName = style
+    ? `${psSafe(newFamily)}-${psSafe(style)}`
+    : psSafe(newFamily);
   return rewriteNameTable(input, (r) => {
     if (!FAMILY_NAME_IDS.has(r.nameID)) return { action: 'keep' };
     // Platform 1 (Macintosh Roman) only round-trips ASCII. For non-ASCII
@@ -294,7 +426,9 @@ export function rewriteFontFamilyName(
     // platforms 0 (Unicode) and 3 (Microsoft) carry the UTF-16 form and
     // are what modern consumers prefer anyway.
     if (r.platformID === 1 && !isAscii) return { action: 'drop' };
-    return { action: 'set', value: r.nameID === 6 ? psName : newFamily };
+    if (r.nameID === 6) return { action: 'set', value: psName };
+    if (r.nameID === 4) return { action: 'set', value: fullName };
+    return { action: 'set', value: newFamily };
   });
 }
 
@@ -326,14 +460,7 @@ export function standardSubfamilyNames(
   if (!base) return null;
   return {
     typographic: italic ? `${base} Italic` : base,
-    legacy:
-      weight >= 600
-        ? italic
-          ? 'Bold Italic'
-          : 'Bold'
-        : italic
-          ? 'Italic'
-          : 'Regular',
+    legacy: legacySubfamilyName(weight >= 600, italic),
   };
 }
 

--- a/packages/shared/src/fonts/sources/ttf-structure.ts
+++ b/packages/shared/src/fonts/sources/ttf-structure.ts
@@ -1,0 +1,123 @@
+/**
+ * Structural sanity check for TTF/OTF bytes — can a font system load this at
+ * all? Answered before `validateFontMetadata`, which asks the narrower
+ * question of whether a loadable font's metadata says the right things.
+ *
+ * The gap this closes: `detectFontFormat` classifies by the four magic bytes
+ * alone, so a download truncated anywhere after byte four is still 'ttf' and
+ * flows on as if it were a font. Nothing downstream notices. The metadata
+ * validator has no name records to check and usually no readable OS/2
+ * either, so it stays silent by design; `FontRegistry`'s family stamp finds
+ * no declared family to contradict and no-ops; and the bytes stage as a
+ * `.ttf` that fontconfig and Core Text refuse, so the document renders in a
+ * fallback face with nothing anywhere saying why.
+ *
+ * Deliberately NOT a full sfnt parser. It answers "will this load", not "is
+ * this well-formed" — checksums, table-specific contents and glyph data are
+ * out of scope. Every check here is one a font system performs before it can
+ * index a face at all, which is what makes a failure worth a warning rather
+ * than a matter of taste.
+ */
+
+import { readNameRecords } from './ttf-name';
+
+export interface FontStructureDiagnostic {
+  code: 'FONT_UNREADABLE';
+  message: string;
+}
+
+/** sfnt versions a font system will attempt to load. */
+const SFNT_VERSIONS = new Set<number>([
+  0x00010000, // TrueType outlines
+  0x4f54544f, // 'OTTO' — CFF outlines
+  0x74727565, // 'true'
+  0x74797031, // 'typ1'
+]);
+
+const HEADER_SIZE = 12;
+const TABLE_RECORD_SIZE = 16;
+
+/**
+ * Inspect the sfnt envelope of a font we are about to hand to a font system.
+ * Returns the first thing that makes it unloadable, or null.
+ *
+ * One diagnostic, not a list: past the first structural failure every later
+ * check is reading rubble, and a caller can only act on the file as a whole
+ * anyway.
+ */
+export function validateFontStructure(
+  ttf: Buffer,
+  weight: number,
+  italic: boolean,
+  familyLabel: string
+): FontStructureDiagnostic | null {
+  const face = `Font "${familyLabel}" weight ${weight}${italic ? ' italic' : ''}`;
+  const unreadable = (reason: string): FontStructureDiagnostic => ({
+    code: 'FONT_UNREADABLE',
+    message: `${face}: ${reason} The face will not resolve; text referencing it renders in a fallback.`,
+  });
+
+  if (ttf.length < HEADER_SIZE) {
+    return unreadable(
+      `${ttf.length} bytes is shorter than an sfnt header — the download is truncated or empty.`
+    );
+  }
+  const version = ttf.readUInt32BE(0);
+  if (!SFNT_VERSIONS.has(version)) {
+    return unreadable(
+      `sfnt version 0x${version.toString(16).padStart(8, '0')} is neither TrueType nor OpenType.`
+    );
+  }
+
+  const numTables = ttf.readUInt16BE(4);
+  if (numTables === 0) return unreadable('its table directory is empty.');
+  const directoryEnd = HEADER_SIZE + numTables * TABLE_RECORD_SIZE;
+  if (directoryEnd > ttf.length) {
+    return unreadable(
+      `its directory claims ${numTables} tables (${directoryEnd} bytes) but the file is ${ttf.length} bytes — truncated.`
+    );
+  }
+
+  // Directory offsets in range. A table pointing past the end is the shape a
+  // truncated download takes once it keeps enough bytes for the directory.
+  const tags = new Set<string>();
+  for (let i = 0; i < numTables; i += 1) {
+    const ro = HEADER_SIZE + i * TABLE_RECORD_SIZE;
+    const tag = ttf.toString('ascii', ro, ro + 4);
+    const offset = ttf.readUInt32BE(ro + 8);
+    const length = ttf.readUInt32BE(ro + 12);
+    if (offset + length > ttf.length) {
+      return unreadable(
+        `its "${tag}" table runs to byte ${offset + length} but the file is ${ttf.length} bytes — truncated.`
+      );
+    }
+    tags.add(tag);
+  }
+
+  // `name` carries the family every consumer looks a face up by, and `head`
+  // the units-per-em every consumer scales it with. Neither is optional.
+  for (const required of ['name', 'head']) {
+    if (!tags.has(required)) {
+      return unreadable(`it has no "${required}" table.`);
+    }
+  }
+
+  // Outlines: glyf + loca (TrueType) or a CFF table (OpenType). Without them
+  // there is nothing to draw, whatever else the file carries.
+  const hasTrueTypeOutlines = tags.has('glyf') && tags.has('loca');
+  const hasCffOutlines = tags.has('CFF ') || tags.has('CFF2');
+  if (!hasTrueTypeOutlines && !hasCffOutlines) {
+    return unreadable(
+      'it carries no glyph outlines (neither "glyf" + "loca" nor "CFF ").'
+    );
+  }
+
+  // Present is not the same as readable: the reader bounds every record by
+  // the table's own extent, so a `name` table with a corrupt header or
+  // out-of-range string offsets yields nothing and the face is unindexable.
+  if (readNameRecords(ttf).length === 0) {
+    return unreadable('its "name" table carries no readable records.');
+  }
+
+  return null;
+}

--- a/packages/shared/src/fonts/sources/ttf-validate.ts
+++ b/packages/shared/src/fonts/sources/ttf-validate.ts
@@ -5,6 +5,9 @@
  * 1. Wrong `OS/2.usWeightClass`          (Chivo Light, Mada Regular, Petrona)
  * 2. Duplicate usWeightClass across weights  (Exo Thin/ExtraLight)
  * 3. Non-unique `name` subfamily records     (Inter, Manrope, Recursive)
+ * 4. A family name that isn't the one we resolved the bytes as — an
+ *    instanced `InterVariable.ttf` still calls itself "Inter Variable", a
+ *    vendor CDN static may call itself anything at all
  *
  * We don't throw on mismatch — the pipeline has already tried to fix the
  * bytes where it can (`rewriteFontSubfamilyNames` after variable-font
@@ -14,16 +17,14 @@
  * hatch before they ship a broken document.
  */
 
-import { standardSubfamilyNames } from './ttf-name';
+import {
+  readFontFamilyNames,
+  readNameRecords,
+  standardSubfamilyNames,
+} from './ttf-name';
 
 const HEADER_SIZE = 12;
 const TABLE_RECORD_SIZE = 16;
-
-interface NameProbe {
-  platformID: number;
-  nameID: number;
-  value: string;
-}
 
 function readTable(
   ttf: Buffer,
@@ -50,49 +51,12 @@ function readUsWeightClass(ttf: Buffer): number | null {
   return ttf.readUInt16BE(os2.off + 4);
 }
 
-function readNames(ttf: Buffer, wanted: Set<number>): NameProbe[] {
-  const nt = readTable(ttf, 'name');
-  if (!nt) return [];
-  const tableOff = nt.off;
-  // Name-table header is 6 bytes (format, count, stringOffset) before the
-  // first name record. Reject obviously-truncated tables up front so we
-  // don't read count/storageRel past the buffer's end on malformed fonts.
-  if (tableOff + 6 > ttf.length) return [];
-  const count = ttf.readUInt16BE(tableOff + 2);
-  const storageRel = ttf.readUInt16BE(tableOff + 4);
-  const storage = tableOff + storageRel;
-  const out: NameProbe[] = [];
-  for (let j = 0; j < count; j++) {
-    const r = tableOff + 6 + j * 12;
-    // Each name record is 12 bytes. Stop as soon as the claimed count
-    // would walk past the buffer — a malformed font claiming count=999999
-    // would otherwise read garbage on each iteration.
-    if (r + 12 > ttf.length) break;
-    const platformID = ttf.readUInt16BE(r);
-    const nameID = ttf.readUInt16BE(r + 6);
-    if (!wanted.has(nameID)) continue;
-    const length = ttf.readUInt16BE(r + 8);
-    const offset = ttf.readUInt16BE(r + 10);
-    const raw = ttf.slice(storage + offset, storage + offset + length);
-    let value: string;
-    if (platformID === 1) {
-      value = raw.toString('ascii');
-    } else {
-      // Decode UTF-16BE. Buffer has no direct utf16be support; swap bytes.
-      const swapped = Buffer.from(raw);
-      if (swapped.length % 2 === 0) swapped.swap16();
-      value = swapped.toString('utf16le');
-    }
-    out.push({ platformID, nameID, value });
-  }
-  return out;
-}
-
 export interface FontMetadataDiagnostic {
   code:
     | 'WEIGHT_CLASS_MISMATCH'
     | 'SUBFAMILY_MISMATCH'
-    | 'LEGACY_SUBFAMILY_MISMATCH';
+    | 'LEGACY_SUBFAMILY_MISMATCH'
+    | 'FAMILY_MISMATCH';
   message: string;
 }
 
@@ -122,12 +86,34 @@ export function validateFontMetadata(
   // child process. Permission warnings would be pure noise for every
   // Google Fonts resolution.
 
+  // The bytes must answer to the family they were resolved as, or nothing
+  // downstream can find them: a run says `rFonts w:ascii="Inter"` and the
+  // host matches that against the font's own name table, never against the
+  // registry entry or the filename. `FontRegistry` repairs this before
+  // validating, so reaching here means the repair could not run (no name
+  // table, a format-1 one, non-sfnt bytes) — i.e. the face really will be
+  // unreachable under `familyLabel`.
+  const declaredFamilies = readFontFamilyNames(ttf);
+  if (
+    declaredFamilies.length > 0 &&
+    !declaredFamilies.includes(familyLabel.trim())
+  ) {
+    diags.push({
+      code: 'FAMILY_MISMATCH',
+      message: `Font "${familyLabel}" weight ${weight}${italic ? ' italic' : ''}: name table declares ${declaredFamilies
+        .map((f) => `"${f}"`)
+        .join(
+          ' / '
+        )}, not "${familyLabel}". Referencing runs will not resolve this face.`,
+    });
+  }
+
   const std = standardSubfamilyNames(weight, italic);
   if (!std) return diags;
   const expected17 = std.typographic;
   const expected2 = std.legacy;
 
-  const names = readNames(ttf, new Set([2, 17]));
+  const names = readNameRecords(ttf, new Set([2, 17]));
   for (const n of names) {
     if (n.nameID === 17 && n.value !== expected17) {
       diags.push({


### PR DESCRIPTION
## Summary

Follow-up to #307, **stacked on that branch** — the structural check calls the bounded `readNameRecords` introduced there, so it can't sit on `main` yet. Base retargets to `main` automatically when #307 merges.

A download truncated anywhere after its first four bytes keeps the sfnt magic, so `detectFontFormat` still calls it a `ttf` and it flows on as if it were a font. Nothing downstream noticed:

- `validateFontMetadata` has no name records to check and usually no readable `OS/2` either, so it stays silent — by design; it reports defects it can substantiate.
- `stampResolvedFamily` finds no declared family to contradict and no-ops.
- The bytes stage as a `.ttf` that fontconfig and Core Text refuse.

Net effect: the document renders in a fallback face, and nothing anywhere says why — the same silent-fallback class of failure #307 was about, arrived at from the other direction.

## What this adds

`validateFontStructure` (`packages/shared/src/fonts/sources/ttf-structure.ts`), run by `FontRegistry` before the family stamp and the metadata pass:

- valid sfnt header and a recognized version
- table directory non-empty and within the buffer
- every directory entry's `offset + length` within the buffer
- `name` and `head` present
- glyph outlines present — `glyf` + `loca`, or `CFF ` / `CFF2`
- the `name` table actually yields records (present ≠ readable: the bounded reader from #307 returns nothing for a corrupt header or out-of-range string offsets)

The first failure is reported as `FONT_UNREADABLE`, naming the face and what about the file is wrong:

```
[FONT_UNREADABLE] Font "Life Sans" weight 500: its "DSIG" table runs to byte 79968
but the file is 400 bytes — truncated. The face will not resolve; text referencing
it renders in a fallback.
```

On failure the stamp and metadata checks are skipped rather than run against rubble. **The source is still returned** — this diagnoses the file, it doesn't decide for the caller whether to ship it. Dropping unusable bytes from staging is defensible (they cost a disk write and a cache key for a render identical to the fontless one, the argument `rasterize-faces.ts` already makes about WOFF) but it's a behavioural change beyond diagnosing, so it's not here.

Deliberately **not** a full sfnt parser: it answers "will a font system load this", not "is this well-formed". Checksums, table contents and glyph data stay out of scope, so a failure is always something that stops a face being indexed at all — which is what makes it worth a warning rather than a matter of taste.

## Why a new code rather than `FAMILY_MISMATCH`

CodeRabbit proposed reporting this through `FAMILY_MISMATCH` on #307 ([thread](https://github.com/Wiseair-srl/json-to-office/pull/307#discussion_r3898808294)). Declined there, and this is the part that was worth doing instead: a font with no family record isn't misnamed, it's unusable — no host can register it under any name — so reporting a file-integrity problem through the family-name comparison points a reader at the wrong problem, and would contradict the two pre-existing tests asserting the metadata validator stays quiet when it cannot substantiate a defect.

## Verification

- **No false positives on real fonts**: 35 checked — the repo's LifeSans fixture, the five ClashDisplay CFF/OTF template assets, and the 29-file template font pack — plus the live Google-fetched Geist statics and harfbuzz-instanced Inter variable faces the pipeline actually resolves. All silent.
- **End to end**: a document declaring a truncated font in `props.fontRegistry` now surfaces the warning to the caller; before this it produced none.
- 15 unit tests (truncation at three points, missing `name` / `head` / outlines, empty directory, out-of-range directory entry, present-but-unreadable `name`, non-sfnt bytes, plus TrueType / CFF / legacy `true` happy paths and an over-strictness guard) and 4 registry-level tests.
- Every affected package's suite passes run on its own: shared 229, jto 473, jto-ops 112, core-docx 2007, core-pptx 762, mcp-server 547. Note `pnpm check` runs 13 packages in parallel against 5s timeouts and produces a moving flake under that load — two different tests timed out on two runs here and both pass in isolation.

## Reviewer notes

- **One test fixture changed.** `generator-document-registry.test.ts` used an sfnt header with zero tables, described in its own comment as "structurally real" and "enough for the data loader's magic-byte sniff" — which was true when the magic bytes were all anything looked at. It is not a font, the new check correctly flags it, and asserting the absence of that warning would be asserting the wrong thing. Replaced with the real LifeSans Medium (at weight 500, matching the fixture, so unrelated metadata checks stay quiet), which also puts real bytes through the resolution path that suite exists to test.
- **Pre-existing, not addressed**: `resolveDocumentFonts` re-emits every registry warning under `context.code: 'FONT_UNRESOLVED'`, so `[FONT_METADATA_DEFECT:…]` and now `[FONT_UNREADABLE]` all reach clients wearing the same outer code, with the real one in the message text. That conflation is what made the fixture change necessary rather than a one-line filter. Worth untangling in its own change — it's shared with core-pptx.

## Checklist

- [x] Added a changeset (`pnpm changeset`)
- [x] Tests pass (`pnpm check`) — per-package, run serially; see the flake note above
- [ ] Docs updated (if applicable) — no user-facing surface changed
