### PR TITLE
feat(fonts): diagnose font bytes no font system can load

### DIFF
--- a/.changeset/font-structure-check.md
+++ b/.changeset/font-structure-check.md
@@ -1,0 +1,32 @@
+---
+'@json-to-office/shared': patch
+---
+
+Corrupt or truncated font bytes are now diagnosed instead of resolving
+silently.
+
+`detectFontFormat` classifies a buffer by its four magic bytes, so a download
+truncated anywhere after byte four is still 'ttf' and flows on as if it were a
+font. Nothing downstream noticed. `validateFontMetadata` had no name records to
+check and usually no readable OS/2 either, so it stayed silent by design; the
+family stamp found no declared family to contradict and no-opped; and the bytes
+staged as a `.ttf` that fontconfig and Core Text refuse. The document rendered
+in a fallback face with nothing anywhere saying why.
+
+`FontRegistry` now runs a structural check first — valid sfnt header, table
+directory within the buffer, `name` and `head` present, glyph outlines present
+as `glyf` + `loca` or `CFF `, and a `name` table that actually yields records —
+and reports the first failure as `FONT_UNREADABLE`, naming the face and what
+about the file is wrong. On failure the family stamp and the metadata checks
+are skipped rather than run against rubble; the source is still returned, since
+this diagnoses the file rather than deciding for the caller whether to ship it.
+
+Deliberately not a full sfnt parser: it answers "will a font system load this",
+not "is this well-formed". Checksums, table contents and glyph data stay out of
+scope, so a failure is always something that stops a face being indexed at all.
+
+Raised in review of #307, which proposed reporting it through `FAMILY_MISMATCH`
+instead. That was declined: a font with no family record isn't misnamed, it is
+unusable, and reporting a file-integrity problem through the family-name
+comparison would mislabel it — and would contradict the validator's documented
+contract of staying quiet when it cannot substantiate a defect.

--- a/packages/jto/src/server/services/__tests__/generator-document-registry.test.ts
+++ b/packages/jto/src/server/services/__tests__/generator-document-registry.test.ts
@@ -10,6 +10,8 @@
  * fallback. That is the whole feature, silently inert.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { DocxFormatAdapter } from '@json-to-office/jto-cli';
 import { GeneratorService } from '../generator';
 import { CacheService } from '../cache';
@@ -17,15 +19,25 @@ import { CacheService } from '../cache';
 const FAMILY = 'Acme Brand Sans';
 
 /**
- * A minimal but structurally real TTF: an sfnt header with zero tables. Enough
- * for the data loader's magic-byte sniff, and it keeps the fixture inline.
+ * A real font, registered under a family name of its own.
+ *
+ * An sfnt header with zero tables used to stand in here — enough for the data
+ * loader's magic-byte sniff, which was all the pipeline looked at. It isn't a
+ * font a font system could load, and `validateFontStructure` now says so, so
+ * the stand-in would have this suite asserting the absence of a warning the
+ * pipeline is right to emit. Real bytes also mean the resolution path under
+ * test runs end to end, family stamp included.
+ *
+ * Weight 500 because the fixture is a Medium: registering it as anything else
+ * trips the metadata checks on a question this suite isn't asking.
  */
-function fakeTtfBase64(): string {
-  const buf = Buffer.alloc(12);
-  buf.writeUInt32BE(0x00010000, 0); // sfnt version
-  buf.writeUInt16BE(0, 4); // numTables
-  return buf.toString('base64');
-}
+const REAL_TTF = readFileSync(
+  path.resolve(
+    __dirname,
+    '../../../../../core-docx/src/styles/fonts/life-sans/LifeSans-Medium.ttf'
+  )
+);
+const FIXTURE_WEIGHT = 500;
 
 const docWithRegistry = () => ({
   name: 'docx',
@@ -36,7 +48,13 @@ const docWithRegistry = () => ({
         id: 'acme',
         family: FAMILY,
         category: 'sans',
-        sources: [{ kind: 'data', data: fakeTtfBase64(), weight: 400 }],
+        sources: [
+          {
+            kind: 'data',
+            data: REAL_TTF.toString('base64'),
+            weight: FIXTURE_WEIGHT,
+          },
+        ],
       },
     ],
     metadata: { title: 'registry-materialization' },

--- a/packages/shared/src/fonts/__tests__/registry.test.ts
+++ b/packages/shared/src/fonts/__tests__/registry.test.ts
@@ -364,3 +364,64 @@ describe('FontRegistry family stamping', () => {
     expect(out.sources[0].data.equals(REAL_TTF)).toBe(true);
   });
 });
+
+/**
+ * A truncated download keeps its sfnt magic, so `detectFontFormat` still
+ * calls it a TTF and it flows on as if it were a font. Nothing else notices:
+ * the family stamp finds no declared family to contradict, and the metadata
+ * checks have no records to read.
+ */
+describe('FontRegistry structural check', () => {
+  const REAL_TTF = readFileSync(
+    path.resolve(
+      __dirname,
+      '../../../../core-docx/src/styles/fonts/life-sans/LifeSans-Medium.ttf'
+    )
+  );
+
+  const resolveBytes = async (data: Buffer, family = 'Life Sans') => {
+    const entry: FontRegistryEntry = {
+      id: family,
+      family,
+      sources: [
+        {
+          kind: 'data',
+          data: data.toString('base64'),
+          weight: 500,
+          italic: false,
+        },
+      ],
+    };
+    return new FontRegistry({ opts: { extraEntries: [entry] } }).resolve(
+      family
+    );
+  };
+
+  it('warns FONT_UNREADABLE for a truncated font', async () => {
+    const out = await resolveBytes(REAL_TTF.subarray(0, 400));
+    expect(out.warnings.some((w) => w.startsWith('[FONT_UNREADABLE]'))).toBe(
+      true
+    );
+    expect(out.warnings.join('\n')).toContain('Life Sans');
+  });
+
+  it('does not also report metadata defects on bytes it cannot read', async () => {
+    // Past the structural failure every metadata check is reading rubble.
+    const out = await resolveBytes(REAL_TTF.subarray(0, 400));
+    expect(
+      out.warnings.some((w) => w.startsWith('[FONT_METADATA_DEFECT:'))
+    ).toBe(false);
+  });
+
+  it('still returns the source — it diagnoses the file, it does not drop it', async () => {
+    const out = await resolveBytes(REAL_TTF.subarray(0, 400));
+    expect(out.sources).toHaveLength(1);
+  });
+
+  it('stays quiet for a well-formed font', async () => {
+    const out = await resolveBytes(REAL_TTF);
+    expect(out.warnings.some((w) => w.startsWith('[FONT_UNREADABLE]'))).toBe(
+      false
+    );
+  });
+});

--- a/packages/shared/src/fonts/registry.ts
+++ b/packages/shared/src/fonts/registry.ts
@@ -20,6 +20,7 @@ import { loadDataFontSource } from './sources/data-loader';
 import { fetchGoogleFontSources } from './sources/google-fetcher';
 import { fetchUrlFontSource } from './sources/url-fetcher';
 import { validateFontMetadata } from './sources/ttf-validate';
+import { validateFontStructure } from './sources/ttf-structure';
 import {
   readFontFamilyNames,
   rewriteFontFamilyName,
@@ -207,8 +208,28 @@ export class FontRegistry {
       try {
         const materialized = await this.materializeSource(source, warnings);
         for (const raw of materialized) {
+          const sfnt = raw.format === 'ttf' || raw.format === 'otf';
+          // Can a font system load these bytes at all? Asked first, and on
+          // failure asked instead of everything below: the stamp has no name
+          // table to write into and the metadata checks no records to read,
+          // so both would quietly do nothing and report nothing. The source
+          // is still returned — this diagnoses the file, it doesn't decide
+          // for the caller whether to ship it.
+          const broken = sfnt
+            ? validateFontStructure(
+                raw.data,
+                raw.weight,
+                raw.italic,
+                entry.family
+              )
+            : null;
+          if (broken) {
+            warnings.push(`[${broken.code}] ${broken.message}`);
+            sources.push(raw);
+            continue;
+          }
           const s = stampResolvedFamily(raw, entry.family);
-          if (s.format === 'ttf' || s.format === 'otf') {
+          if (sfnt) {
             for (const d of validateFontMetadata(
               s.data,
               s.weight,

--- a/packages/shared/src/fonts/sources/__tests__/ttf-structure.test.ts
+++ b/packages/shared/src/fonts/sources/__tests__/ttf-structure.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { validateFontStructure } from '../ttf-structure';
+
+const FIXTURE = path.resolve(
+  __dirname,
+  '../../../../../core-docx/src/styles/fonts/life-sans/LifeSans-Medium.ttf'
+);
+
+/** Byte range of a table's directory entry in an sfnt. */
+function directoryEntry(buf: Buffer, tag: string): number {
+  const numTables = buf.readUInt16BE(4);
+  for (let i = 0; i < numTables; i += 1) {
+    const eo = 12 + i * 16;
+    if (buf.toString('ascii', eo, eo + 4) === tag) return eo;
+  }
+  throw new Error(`no ${tag} table`);
+}
+
+/** A `name` table with one readable record, so the readability probe passes. */
+function nameTable(value: string): Buffer {
+  const encoded = Buffer.alloc(value.length * 2);
+  for (let i = 0; i < value.length; i += 1) {
+    encoded.writeUInt16BE(value.charCodeAt(i), i * 2);
+  }
+  const header = Buffer.alloc(18);
+  header.writeUInt16BE(0, 0); // format 0
+  header.writeUInt16BE(1, 2); // one record
+  header.writeUInt16BE(18, 4); // storage starts after the record
+  header.writeUInt16BE(3, 6); // platform 3
+  header.writeUInt16BE(1, 8);
+  header.writeUInt16BE(1033, 10);
+  header.writeUInt16BE(1, 12); // nameID 1
+  header.writeUInt16BE(encoded.length, 14);
+  header.writeUInt16BE(0, 16);
+  return Buffer.concat([header, encoded]);
+}
+
+/**
+ * Assemble an sfnt from table stubs. The checker reads the envelope, never a
+ * table's contents, so stub bytes are enough — and building the file here
+ * keeps the CFF case self-contained rather than reaching for a shipped
+ * template asset that template work is free to move.
+ */
+function buildFontWith(
+  version: number,
+  tables: Array<{ tag: string; data?: Buffer }>
+): Buffer {
+  const directorySize = 12 + tables.length * 16;
+  const bodies = tables.map((t) => t.data ?? Buffer.alloc(16));
+  const total = directorySize + bodies.reduce((sum, b) => sum + b.length, 0);
+  const buf = Buffer.alloc(total);
+  buf.writeUInt32BE(version, 0);
+  buf.writeUInt16BE(tables.length, 4);
+  let cursor = directorySize;
+  tables.forEach((t, i) => {
+    const eo = 12 + i * 16;
+    buf.write(t.tag, eo, 4, 'ascii');
+    buf.writeUInt32BE(cursor, eo + 8);
+    buf.writeUInt32BE(bodies[i].length, eo + 12);
+    bodies[i].copy(buf, cursor);
+    cursor += bodies[i].length;
+  });
+  return buf;
+}
+
+describe('validateFontStructure', () => {
+  const real = readFileSync(FIXTURE);
+
+  describe('loadable fonts', () => {
+    it('passes a real TrueType font', () => {
+      expect(validateFontStructure(real, 500, false, 'Life Sans')).toBeNull();
+    });
+
+    it('passes a CFF-flavoured OpenType font', () => {
+      // 'OTTO' + CFF outlines instead of glyf/loca — the other half of what
+      // the pipeline resolves.
+      const otf = buildFontWith(0x4f54544f, [
+        { tag: 'CFF ' },
+        { tag: 'head' },
+        { tag: 'name', data: nameTable('Clash Display') },
+      ]);
+      expect(
+        validateFontStructure(otf, 400, false, 'Clash Display')
+      ).toBeNull();
+    });
+
+    it('passes the legacy "true" sfnt version', () => {
+      const font = buildFontWith(0x74727565, [
+        { tag: 'glyf' },
+        { tag: 'loca' },
+        { tag: 'head' },
+        { tag: 'name', data: nameTable('Legacy') },
+      ]);
+      expect(validateFontStructure(font, 400, false, 'Legacy')).toBeNull();
+    });
+  });
+
+  describe('truncation — the case detectFontFormat cannot see', () => {
+    it('flags a font truncated mid-directory', () => {
+      // Still starts with the sfnt magic, so `detectFontFormat` calls it a
+      // TTF and every downstream check stays silent.
+      const truncated = real.subarray(0, 40);
+      const diag = validateFontStructure(truncated, 500, false, 'Life Sans');
+      expect(diag?.code).toBe('FONT_UNREADABLE');
+      expect(diag?.message).toContain('truncated');
+    });
+
+    it('flags a font whose directory survives but whose tables do not', () => {
+      const truncated = real.subarray(0, 12 + 16 * real.readUInt16BE(4) + 64);
+      const diag = validateFontStructure(truncated, 500, false, 'Life Sans');
+      expect(diag?.code).toBe('FONT_UNREADABLE');
+      expect(diag?.message).toContain('truncated');
+    });
+
+    it('flags bytes shorter than an sfnt header', () => {
+      const diag = validateFontStructure(
+        Buffer.from([0x00, 0x01, 0x00, 0x00]),
+        400,
+        false,
+        'Stub'
+      );
+      expect(diag?.code).toBe('FONT_UNREADABLE');
+      expect(diag?.message).toContain('shorter than an sfnt header');
+    });
+
+    it('flags an empty table directory', () => {
+      // The shape of the registry suite's minimal buffer: magic plus zeros.
+      const buf = Buffer.concat([
+        Buffer.from([0x00, 0x01, 0x00, 0x00]),
+        Buffer.alloc(64),
+      ]);
+      const diag = validateFontStructure(buf, 400, false, 'Minimal');
+      expect(diag?.code).toBe('FONT_UNREADABLE');
+      expect(diag?.message).toContain('directory is empty');
+    });
+  });
+
+  describe('missing or unreadable tables', () => {
+    it('flags a font with no name table', () => {
+      const buf = Buffer.from(real);
+      buf.write('xxxx', directoryEntry(buf, 'name'), 4, 'ascii');
+      const diag = validateFontStructure(buf, 500, false, 'Life Sans');
+      expect(diag?.code).toBe('FONT_UNREADABLE');
+      expect(diag?.message).toContain('no "name" table');
+    });
+
+    it('flags a font with no head table', () => {
+      const buf = Buffer.from(real);
+      buf.write('xxxx', directoryEntry(buf, 'head'), 4, 'ascii');
+      expect(
+        validateFontStructure(buf, 500, false, 'Life Sans')?.message
+      ).toContain('no "head" table');
+    });
+
+    it('flags a font carrying no glyph outlines', () => {
+      const buf = Buffer.from(real);
+      buf.write('xxxx', directoryEntry(buf, 'glyf'), 4, 'ascii');
+      expect(
+        validateFontStructure(buf, 500, false, 'Life Sans')?.message
+      ).toContain('no glyph outlines');
+    });
+
+    it('flags a name table present but unreadable', () => {
+      // Present in the directory, but its string storage points outside the
+      // table — every record is skipped, so nothing can index the face.
+      const buf = Buffer.from(real);
+      const eo = directoryEntry(buf, 'name');
+      buf.writeUInt16BE(0xfff0, buf.readUInt32BE(eo + 8) + 4);
+      expect(
+        validateFontStructure(buf, 500, false, 'Life Sans')?.message
+      ).toContain('no readable records');
+    });
+
+    it('flags a table whose directory entry points past the end', () => {
+      const buf = Buffer.from(real);
+      buf.writeUInt32BE(buf.length + 1024, directoryEntry(buf, 'name') + 8);
+      const diag = validateFontStructure(buf, 500, false, 'Life Sans');
+      expect(diag?.code).toBe('FONT_UNREADABLE');
+      expect(diag?.message).toContain('"name" table runs to byte');
+    });
+  });
+
+  it('rejects bytes that are not sfnt at all', () => {
+    const diag = validateFontStructure(
+      Buffer.alloc(64, 0x41),
+      400,
+      false,
+      'NotAFont'
+    );
+    expect(diag?.code).toBe('FONT_UNREADABLE');
+    expect(diag?.message).toContain('neither TrueType nor OpenType');
+  });
+
+  it('names the face and says what goes wrong for a reader', () => {
+    const diag = validateFontStructure(
+      real.subarray(0, 40),
+      700,
+      true,
+      'Life Sans'
+    );
+    expect(diag?.message).toContain('Font "Life Sans" weight 700 italic');
+    expect(diag?.message).toContain('renders in a fallback');
+  });
+
+  it('does not flag a stub directory that satisfies every requirement', () => {
+    // Guards against over-strictness: the check reads the envelope, never a
+    // table's contents, so a font with unusual table lengths still passes.
+    const font = buildFontWith(0x00010000, [
+      { tag: 'glyf', data: Buffer.alloc(3) },
+      { tag: 'loca', data: Buffer.alloc(1) },
+      { tag: 'head', data: Buffer.alloc(54) },
+      { tag: 'name', data: nameTable('Odd') },
+      { tag: 'DSIG', data: Buffer.alloc(0) },
+    ]);
+    expect(validateFontStructure(font, 400, false, 'Odd')).toBeNull();
+  });
+});

--- a/packages/shared/src/fonts/sources/ttf-structure.ts
+++ b/packages/shared/src/fonts/sources/ttf-structure.ts
@@ -1,0 +1,123 @@
+/**
+ * Structural sanity check for TTF/OTF bytes — can a font system load this at
+ * all? Answered before `validateFontMetadata`, which asks the narrower
+ * question of whether a loadable font's metadata says the right things.
+ *
+ * The gap this closes: `detectFontFormat` classifies by the four magic bytes
+ * alone, so a download truncated anywhere after byte four is still 'ttf' and
+ * flows on as if it were a font. Nothing downstream notices. The metadata
+ * validator has no name records to check and usually no readable OS/2
+ * either, so it stays silent by design; `FontRegistry`'s family stamp finds
+ * no declared family to contradict and no-ops; and the bytes stage as a
+ * `.ttf` that fontconfig and Core Text refuse, so the document renders in a
+ * fallback face with nothing anywhere saying why.
+ *
+ * Deliberately NOT a full sfnt parser. It answers "will this load", not "is
+ * this well-formed" — checksums, table-specific contents and glyph data are
+ * out of scope. Every check here is one a font system performs before it can
+ * index a face at all, which is what makes a failure worth a warning rather
+ * than a matter of taste.
+ */
+
+import { readNameRecords } from './ttf-name';
+
+export interface FontStructureDiagnostic {
+  code: 'FONT_UNREADABLE';
+  message: string;
+}
+
+/** sfnt versions a font system will attempt to load. */
+const SFNT_VERSIONS = new Set<number>([
+  0x00010000, // TrueType outlines
+  0x4f54544f, // 'OTTO' — CFF outlines
+  0x74727565, // 'true'
+  0x74797031, // 'typ1'
+]);
+
+const HEADER_SIZE = 12;
+const TABLE_RECORD_SIZE = 16;
+
+/**
+ * Inspect the sfnt envelope of a font we are about to hand to a font system.
+ * Returns the first thing that makes it unloadable, or null.
+ *
+ * One diagnostic, not a list: past the first structural failure every later
+ * check is reading rubble, and a caller can only act on the file as a whole
+ * anyway.
+ */
+export function validateFontStructure(
+  ttf: Buffer,
+  weight: number,
+  italic: boolean,
+  familyLabel: string
+): FontStructureDiagnostic | null {
+  const face = `Font "${familyLabel}" weight ${weight}${italic ? ' italic' : ''}`;
+  const unreadable = (reason: string): FontStructureDiagnostic => ({
+    code: 'FONT_UNREADABLE',
+    message: `${face}: ${reason} The face will not resolve; text referencing it renders in a fallback.`,
+  });
+
+  if (ttf.length < HEADER_SIZE) {
+    return unreadable(
+      `${ttf.length} bytes is shorter than an sfnt header — the download is truncated or empty.`
+    );
+  }
+  const version = ttf.readUInt32BE(0);
+  if (!SFNT_VERSIONS.has(version)) {
+    return unreadable(
+      `sfnt version 0x${version.toString(16).padStart(8, '0')} is neither TrueType nor OpenType.`
+    );
+  }
+
+  const numTables = ttf.readUInt16BE(4);
+  if (numTables === 0) return unreadable('its table directory is empty.');
+  const directoryEnd = HEADER_SIZE + numTables * TABLE_RECORD_SIZE;
+  if (directoryEnd > ttf.length) {
+    return unreadable(
+      `its directory claims ${numTables} tables (${directoryEnd} bytes) but the file is ${ttf.length} bytes — truncated.`
+    );
+  }
+
+  // Directory offsets in range. A table pointing past the end is the shape a
+  // truncated download takes once it keeps enough bytes for the directory.
+  const tags = new Set<string>();
+  for (let i = 0; i < numTables; i += 1) {
+    const ro = HEADER_SIZE + i * TABLE_RECORD_SIZE;
+    const tag = ttf.toString('ascii', ro, ro + 4);
+    const offset = ttf.readUInt32BE(ro + 8);
+    const length = ttf.readUInt32BE(ro + 12);
+    if (offset + length > ttf.length) {
+      return unreadable(
+        `its "${tag}" table runs to byte ${offset + length} but the file is ${ttf.length} bytes — truncated.`
+      );
+    }
+    tags.add(tag);
+  }
+
+  // `name` carries the family every consumer looks a face up by, and `head`
+  // the units-per-em every consumer scales it with. Neither is optional.
+  for (const required of ['name', 'head']) {
+    if (!tags.has(required)) {
+      return unreadable(`it has no "${required}" table.`);
+    }
+  }
+
+  // Outlines: glyf + loca (TrueType) or a CFF table (OpenType). Without them
+  // there is nothing to draw, whatever else the file carries.
+  const hasTrueTypeOutlines = tags.has('glyf') && tags.has('loca');
+  const hasCffOutlines = tags.has('CFF ') || tags.has('CFF2');
+  if (!hasTrueTypeOutlines && !hasCffOutlines) {
+    return unreadable(
+      'it carries no glyph outlines (neither "glyf" + "loca" nor "CFF ").'
+    );
+  }
+
+  // Present is not the same as readable: the reader bounds every record by
+  // the table's own extent, so a `name` table with a corrupt header or
+  // out-of-range string offsets yields nothing and the face is unindexable.
+  if (readNameRecords(ttf).length === 0) {
+    return unreadable('its "name" table carries no readable records.');
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Follow-up to #307, now merged. Supersedes #308, which carried this same commit: it was opened stacked on #307's branch, and deleting that branch after the merge closed it with no way to reopen or retarget it. Same branch, same commit, rebased onto `main`.

A download truncated anywhere after its first four bytes keeps the sfnt magic, so `detectFontFormat` still calls it a `ttf` and it flows on as if it were a font. Nothing downstream noticed:

- `validateFontMetadata` has no name records to check and usually no readable `OS/2` either, so it stays silent — by design; it reports defects it can substantiate.
- `stampResolvedFamily` finds no declared family to contradict and no-ops.
- The bytes stage as a `.ttf` that fontconfig and Core Text refuse.

Net effect: the document renders in a fallback face, and nothing anywhere says why — the same silent-fallback class of failure #307 was about, arrived at from the other direction.

## What this adds

`validateFontStructure` (`packages/shared/src/fonts/sources/ttf-structure.ts`), run by `FontRegistry` before the family stamp and the metadata pass:

- valid sfnt header and a recognized version
- table directory non-empty and within the buffer
- every directory entry's `offset + length` within the buffer
- `name` and `head` present
- glyph outlines present — `glyf` + `loca`, or `CFF ` / `CFF2`
- the `name` table actually yields records (present ≠ readable: the bounded reader from #307 returns nothing for a corrupt header or out-of-range string offsets)

The first failure is reported as `FONT_UNREADABLE`, naming the face and what about the file is wrong:

```
[FONT_UNREADABLE] Font "Life Sans" weight 500: its "DSIG" table runs to byte 79968
but the file is 400 bytes — truncated. The face will not resolve; text referencing
it renders in a fallback.
```

On failure the stamp and metadata checks are skipped rather than run against rubble. **The source is still returned** — this diagnoses the file, it doesn't decide for the caller whether to ship it. Dropping unusable bytes from staging is defensible (they cost a disk write and a cache key for a render identical to the fontless one, the argument `rasterize-faces.ts` already makes about WOFF) but it's a behavioural change beyond diagnosing, so it's not here.

Deliberately **not** a full sfnt parser: it answers "will a font system load this", not "is this well-formed". Checksums, table contents and glyph data stay out of scope, so a failure is always something that stops a face being indexed at all — which is what makes it worth a warning rather than a matter of taste.

## Why a new code rather than `FAMILY_MISMATCH`

CodeRabbit proposed reporting this through `FAMILY_MISMATCH` on #307 ([thread](https://github.com/Wiseair-srl/json-to-office/pull/307#discussion_r3898808294)). Declined there, and this is the part that was worth doing instead: a font with no family record isn't misnamed, it's unusable — no host can register it under any name — so reporting a file-integrity problem through the family-name comparison points a reader at the wrong problem, and would contradict the two pre-existing tests asserting the metadata validator stays quiet when it cannot substantiate a defect.

## Verification

- **No false positives on real fonts**: 35 checked — the repo's LifeSans fixture, the five ClashDisplay CFF/OTF template assets, and the 29-file template font pack — plus the live Google-fetched Geist statics and harfbuzz-instanced Inter variable faces the pipeline actually resolves. All silent.
- **End to end**: a document declaring a truncated font in `props.fontRegistry` now surfaces the warning to the caller; before this it produced none.
- 15 unit tests (truncation at three points, missing `name` / `head` / outlines, empty directory, out-of-range directory entry, present-but-unreadable `name`, non-sfnt bytes, plus TrueType / CFF / legacy `true` happy paths and an over-strictness guard) and 4 registry-level tests.
- Every affected package's suite passes run on its own: shared 229, jto 473, jto-ops 112, core-docx 2007, core-pptx 762, mcp-server 547. Note `pnpm check` runs 13 packages in parallel against 5s timeouts and produces a moving flake under that load — two different tests timed out on two runs here and both pass in isolation. This is also the first CI run on this work: the workflow only triggers on PRs targeting `main`, so nothing ran while it was stacked.

## Reviewer notes

- **One test fixture changed.** `generator-document-registry.test.ts` used an sfnt header with zero tables, described in its own comment as "structurally real" and "enough for the data loader's magic-byte sniff" — which was true when the magic bytes were all anything looked at. It is not a font, the new check correctly flags it, and asserting the absence of that warning would be asserting the wrong thing. Replaced with the real LifeSans Medium (at weight 500, matching the fixture, so unrelated metadata checks stay quiet), which also puts real bytes through the resolution path that suite exists to test.
- **Pre-existing, not addressed**: `resolveDocumentFonts` re-emits every registry warning under `context.code: 'FONT_UNRESOLVED'`, so `[FONT_METADATA_DEFECT:…]` and now `[FONT_UNREADABLE]` all reach clients wearing the same outer code, with the real one in the message text. That conflation is what made the fixture change necessary rather than a one-line filter. Worth untangling in its own change — it's shared with core-pptx.

## Checklist

- [x] Added a changeset (`pnpm changeset`)
- [x] Tests pass (`pnpm check`) — per-package, run serially; see the flake note above
- [ ] Docs updated (if applicable) — no user-facing surface changed
