### PR TITLE
fix(ci): stop the Windows test job failing on contention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,21 @@ jobs:
 
       - run: pnpm build
 
+      # Turbo runs ten packages at once by default and vitest forks per core
+      # inside each, which on a four-core Windows runner oversubscribes the
+      # box badly enough to read as product failures. Two shapes of it, on
+      # consecutive commits: run 33621956828 gave up on an mcp-server stdio
+      # response after 60s, and 33623795402 lost three `onTaskUpdate` RPCs in
+      # core-docx — birpc's own 60s ceiling — after all 1,995 of its tests had
+      # passed. Neither suite was at fault, and per-case timeouts only move
+      # the next failure somewhere else. Serial costs this job wall-clock and
+      # buys back a machine that can answer. Ubuntu keeps the default; it has
+      # never gone red this way.
       - run: pnpm test
+        if: matrix.os != 'windows-latest'
+
+      - run: pnpm test -- --concurrency=1
+        if: matrix.os == 'windows-latest'
 
   # The suites that need a real LibreOffice and poppler skip themselves when
   # the binaries are absent, so a cold checkout stays green — which also meant

--- a/packages/mcp-server/src/__tests__/fixtures/stdio-harness.ts
+++ b/packages/mcp-server/src/__tests__/fixtures/stdio-harness.ts
@@ -29,6 +29,23 @@ import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 
 const run = promisify(execFile);
 
+/**
+ * How long the raw client waits on the child before it gives up.
+ *
+ * These defaults must stay *under* the smallest budget any callsite declares
+ * (120s, in every `stdio-*.test.ts`) so that a stall is reported with the
+ * stderr transcript below rather than as vitest's bare "test timed out" — but
+ * not so far under that the harness overrides the allowance a callsite chose.
+ * A flat 60s did exactly that: on a loaded Windows runner the first
+ * `tools/call` on a cold child took longer than a minute, and the harness
+ * failed the wait at half the 120s the test had asked for (run 33621956828,
+ * one of four Windows jobs). The runner split is the same one `vitest.base.ts`
+ * makes, and for the same reason: local stays strict, slow runners get room.
+ */
+const SLOW_RUNNER = Boolean(process.env.CI) || process.platform === 'win32';
+const RESPONSE_TIMEOUT_MS = SLOW_RUNNER ? 110_000 : 60_000;
+const STDERR_TIMEOUT_MS = SLOW_RUNNER ? 30_000 : 10_000;
+
 export const packageRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '../../..'
@@ -234,7 +251,12 @@ export async function callTool(
   name: string,
   args: Record<string, unknown>
 ): Promise<ToolEnvelope> {
-  const result = await session.client.callTool({ name, arguments: args });
+  // Same budget as the raw client, for the same reason: the SDK's own default
+  // is 60s, which would expire before any callsite's.
+  const result = await session.client.callTool(
+    { name, arguments: args },
+    { timeout: RESPONSE_TIMEOUT_MS }
+  );
   if (result.isError === true) {
     throw new Error(
       `${name} returned isError: ${JSON.stringify(result.content)}`
@@ -337,7 +359,10 @@ export class RawStdioServer {
    * depends on how loaded the machine is, and a fixed sleep long enough for a
    * busy CI box is a fixed cost on every other run.
    */
-  async waitForStderr(needle: string, timeoutMs = 10_000): Promise<void> {
+  async waitForStderr(
+    needle: string,
+    timeoutMs = STDERR_TIMEOUT_MS
+  ): Promise<void> {
     const deadline = Date.now() + timeoutMs;
     while (!this.stderrText.includes(needle)) {
       if (Date.now() > deadline) {
@@ -374,7 +399,10 @@ export class RawStdioServer {
   }
 
   /** Wait for the response to `id`. */
-  async waitFor(id: number, timeoutMs = 60_000): Promise<JsonRpcMessage> {
+  async waitFor(
+    id: number,
+    timeoutMs = RESPONSE_TIMEOUT_MS
+  ): Promise<JsonRpcMessage> {
     const deadline = Date.now() + timeoutMs;
     for (;;) {
       const message = this.received.get(id);


### PR DESCRIPTION
`test (20, windows-latest)` has gone red on two consecutive commits to `main`, each time with a different suite and neither time because of the suite.

| Run | Symptom |
| --- | --- |
| [33621956828](https://github.com/Wiseair-srl/json-to-office/actions/runs/33621956828) | `stdio-protocol.test.ts` — `No response to request 2 within 60000ms` on the first `tools/call` against a cold child |
| [33623795402](https://github.com/Wiseair-srl/json-to-office/actions/runs/33623795402) | core-docx — three `[vitest-worker]: Timeout calling "onTaskUpdate"`, birpc's own 60s ceiling, *after* all 1,995 of its tests had passed |

One Windows job of four fails; the other three, and every ubuntu job, pass the same commit.

## Two fixes, different levels

**The machine (`ci.yml`).** Turbo runs ten packages at once and vitest forks per core inside each, so a four-core Windows runner ends up with dozens of processes and a main thread that cannot service a worker RPC inside a minute. That is what both failures are. The Windows job now runs `pnpm test -- --concurrency=1`; ubuntu keeps the default, having never gone red this way. It costs that job wall-clock, and it is the only fix that does not just relocate the next timeout.

**The harness (`stdio-harness.ts`).** Independently wrong, and what turned the first failure into a red build: every `stdio-*.test.ts` callsite declares 120s or 180s because a Windows runner needs it, but the harness's own `waitFor` defaulted to a flat 60s and so always expired first — at half the budget the test asked for. The file-level allowances were dead code on the exact runner they were written for. `waitFor` and `waitForStderr` now split on the same `CI || win32` signal `vitest.base.ts` uses (60s→110s, 10s→30s), sized to stay under the smallest callsite budget so the harness's stderr transcript still beats vitest's bare timeout; the shared `callTool` helper passes that budget to the SDK client too, whose own default is the same 60s.

## Verification

Local: `stdio-protocol.test.ts` 11/11, the other five stdio suites 36/36, `tsc --noEmit` / eslint / prettier clean. The concurrency change can only be proven by the Windows jobs on this PR. Test and CI config only, so no changeset.