### PR TITLE
Clear the runway for #328: pptx theme guard, and the ten decisions settled

### DIFF
--- a/.changeset/eval-tree-stability-guard.md
+++ b/.changeset/eval-tree-stability-guard.md
@@ -1,0 +1,9 @@
+---
+'@json-to-office/mcp-server': patch
+---
+
+A run set now knows whether the product moved underneath it.
+
+The manifest was assembled after the last brief, so it described the tree the scorecard was written against rather than the tree any brief actually ran on. A variance run shared a working tree with another session that landed a feature and rebuilt at minute 58 of 76: the twelve runs already finished were measuring the old build, the six that followed died with `does not provide an export named ...` because the process still held the previous `@json-to-office/quality` in its module graph, and the manifest recorded one clean final SHA. The only surviving evidence that anything had happened was a file mtime.
+
+So the tree is captured before the first brief and compared after the last, and a set that straddles a change says so on its own first line. Git alone is not enough — runs import the built packages, so `pnpm build` on an unchanged commit changes the product and leaves no trace in git. The fingerprint covers each package's compiled entry point.

--- a/.changeset/pptx-bundled-theme-guard.md
+++ b/.changeset/pptx-bundled-theme-guard.md
@@ -1,0 +1,11 @@
+---
+'@json-to-office/core-pptx': patch
+---
+
+Adds the bundled-theme schema guard PPTX never had.
+
+DOCX has validated its bundled themes since they shipped dead `componentDefaults.table` properties that no renderer read and the validator rejects. PPTX had no equivalent, and needs one more than DOCX does: its themes are TypeScript object literals rather than JSON files, so nothing ever ran them past `ThemeConfigSchema` — `tsc` checks them against the hand-written `PptxThemeConfig` interface, which is a different thing and has drifted before.
+
+The timing is the point. `ir/compiler.ts` reads `ctx.theme.defaults.fontSize` unguarded, so a theme the schema would have rejected surfaces as a TypeError deep in the compiler rather than as a diagnostic naming the field. Survivable while three hand-written themes are the whole set; not survivable once themes carry type ladders, spacing scales and chrome recipes.
+
+Each theme is validated as a literal and again after a JSON round trip, since `undefined` members vanish on the way and that is how an optional property that is secretly required goes unnoticed. The registry is checked too: `getPptxTheme` falls back to the default on a miss, so a theme whose `name` disagrees with its key is a lookup that silently returns something else wearing the wrong label.

--- a/.changeset/rejudge-cli-and-fingerprint-fixes.md
+++ b/.changeset/rejudge-cli-and-fingerprint-fixes.md
@@ -1,0 +1,15 @@
+---
+'@json-to-office/core-pptx': patch
+---
+
+Fixes four defects in the eval harness and tightens the pptx theme-lookup test, all found by review on #357.
+
+`buildFingerprint` recorded only each package's `dist/index.js`, but `tsup` builds `cli` and `index` as separate entries and a run executes `mcp-server/dist/cli.js`. A CLI-only rebuild therefore left the fingerprint unchanged — invisible to the one check whose entire job is noticing that the compiled product moved under a measurement. It now covers every top-level `dist/*.js`.
+
+The rejudge CLI read an option's value as its positional argument: `--scorecard out/sc.json runs/foo` resolved a runs directory of `out/sc.json`, joined `runs` onto it and wrote `rejudge.json` inside it — a documented invocation producing nothing, or ENOTDIR when the value is a file.
+
+Its two counts disagreed with each other about the same document. A run whose stored judgement carried no `wouldShip` satisfied both predicates, because `undefined !== true` is a change, and printed "1 document(s) re-judged, unchanged since; 1 changed their wouldShip answer". Both counts now require an original verdict, exactly as the `pairs()` helper already did.
+
+`summarise` built an agreement report for `level` and `genericness` even when no stored verdict carried them. `bootstrapKappa([])` answers `n: 0, rawAgreement: 0, kappa: NaN`, which serialises to `null` and prints as "NaN" — a missing measurement wearing the shape of a measurement. Those fields are now omitted, and the CLI says so.
+
+The new pptx bundled-theme test asserted only that `getPptxTheme(name)` returns something schema-valid, which a lookup returning the default theme for every name would satisfy. It now asserts identity against the registry.

--- a/.changeset/rejudge-instrument.md
+++ b/.changeset/rejudge-instrument.md
@@ -1,0 +1,11 @@
+---
+'@json-to-office/mcp-server': patch
+---
+
+The judge can now be measured against itself, and the first look is not reassuring.
+
+Every taste number this programme reports rests on one absolute verdict per document, which is worth exactly as much as its repeatability — a quantity nobody had measured. Four stored contact sheets from the cold baseline, re-judged a day later with the same rubric and the same model, changed three of four `wouldShip` answers. One of the three flipped to "would not ship" while the same call scored the document level 4 and genericness 1, its two best marks.
+
+`pnpm rejudge <run-dir>` re-judges a recorded set from the contact sheets already on disk, so a full corpus costs one judge call per document and no authoring at all, and reports Cohen's kappa per rubric field. Kappa rather than agreement: on a corpus where four in five documents are unshippable, a judge that says no to everything agrees with itself 80% of the time and has said nothing.
+
+If the spot check holds at n=40, the cold-versus-assisted comparison in §1 measures the judge and not the product, and the graded fields — which moved far less, none by more than one step — are the part worth keeping. The recorded baselines now carry that caveat.

--- a/docs/architecture/phase-1-theme-schema-map.md
+++ b/docs/architecture/phase-1-theme-schema-map.md
@@ -9,6 +9,10 @@ Read it with `docs/architecture/design-quality-10x.md` §5B open — that is the
 
 ## Verdict
 
+> **Status, 2026-09-05.** Tasks 1 and 2 are done, shipped in #355 (`ef65176` plus the pptx
+> bundled-theme guard). The decisions section at the bottom is settled. Phase 1 starts at task 3,
+> and task 8 has been split out as #328b — see decision 5.
+
 Phase 1 as specced is buildable, and #328 is mostly additive — but only if the first commit fixes
 `ensureThemeDefaults`, which is a whitelist rebuild (packages/core-
 docx/src/themes/defaults.ts:138-164), not a merge: it already silently deletes the schema-legal
@@ -114,7 +118,7 @@ id/version/description/formats/rendererTargets/parameters/rules and nothing else
 
 ## Tasks, in order
 
-### 1. Make ensureThemeDefaults a merge, not a whitelist rebuild — plus a round-trip guard test
+### 1. Make ensureThemeDefaults a merge, not a whitelist rebuild — plus a round-trip guard test — DONE (#355, `ef65176`)
 
 Risk: **low**
 
@@ -132,7 +136,7 @@ Files:
 - `packages/core-docx/src/themes/defaults.ts`
 - `packages/core-docx/src/themes/__tests__/bundled-themes.test.ts`
 
-### 2. Close the pptx theme validation holes before any extended theme file exists
+### 2. Close the pptx theme validation holes before any extended theme file exists — DONE (#355)
 
 Risk: **medium**
 
@@ -271,7 +275,7 @@ Files:
 - `packages/core-pptx/src/core/generationContext.ts`
 - `packages/core-docx/src/styles/utils/layoutUtils.ts`
 
-### 8. Chrome recipes and motif: wire the dead Header/Footer styles — MOVES GOLDENS
+### 8. Chrome recipes and motif: wire the dead Header/Footer styles — MOVES GOLDENS — SPLIT TO #328b
 
 Risk: **high**
 
@@ -331,35 +335,103 @@ Files:
 - `docs/reference/theme-schema.md`
 - `docs/guide/themes.md`
 
-## Decisions this needs before it starts
+## Decisions this needs before it starts — SETTLED 2026-09-05
 
-None of these has a default the map is willing to pick on its own.
+Answered by Paolo on 2026-09-05, after Phase 0 merged (#355). Each answer is recorded under its
+question with the evidence it rests on; the questions are kept verbatim so the reasoning stays
+readable next to what was asked.
+
+Two of the ten did not survive contact with the code. **#9's binary is false** — the map asks
+whether `light` is repurposed or retired and the answer is neither. **#10's arithmetic is wrong in
+the direction that matters**, and is corrected in place below rather than left for a reader to
+trust.
 
 1. New palette roles as a `palette` sibling block (my proposal), or widen both closed `colors`
    objects?
 
+**Settled: the `palette` sibling.** Widening is not a design choice, it is a breaking change to
+both formats. The two `colors` schemas use hex patterns where neither is a superset of the other —
+docx `HexColorSchema` is `^(#[0-9A-Fa-f]{6}|[a-zA-Z][a-zA-Z0-9]*)$` (shared-docx/schemas/font.ts:14),
+pptx is a local `^#?[0-9A-Fa-f]{6}$` (shared-pptx/schemas/theme.ts:78). A token name like
+`"positive": "accent"` is legal in docx and rejected by pptx; a bare `1B3A5C` is the other way
+round. `palette` values are a plain `Type.String()`, so both formats accept either, and the cost is
+one fallback line per resolver. It is also reversible: `palette` can fold into `colors` in a future
+major once the patterns are unified.
+
 2. Do new roles become authorable component colours? Adding to SEMANTIC_COLOR_NAMES regenerates every
    pptx component schema.
+
+**Settled: no, not in #328.** Adding to `SEMANTIC_COLOR_NAMES` regenerates every pptx component
+schema — a large change to the published surface in exchange for a convenience. The roles resolve
+in the theme, which is where they are consumed. Revisit if a component ever needs to name one
+directly.
 
 3. Type roles as one neutral shared vocabulary (my proposal), or format-native styles that cannot
    share tokens?
 
+**Settled: one neutral shared vocabulary.** The point of Phase 1 is that a paired deck and report
+match; format-native styles that cannot share tokens defeat that by construction. `TypeRoleSchema`
+already projects onto each format's own preset shape, which is where the formats are allowed to
+differ.
+
 4. `sage` would name two unrelated designs — docx Calibri sage-green, pptx Helvetica greyscale. One
    name or two?
 
+**Settled: two names.** One name meaning Calibri sage-green in docx and Helvetica greyscale in pptx
+is precisely the "a theme swap changes colours, not design" failure this programme exists to end.
+Cheap to fix now, expensive once #331's aliases ship it.
+
 5. Chrome recipes + motif inside #328, or split to #328b so the gate opens sooner?
+
+**Settled: split to #328b.** Task 8 is the only high-risk task, the only one that moves goldens en
+masse, and the only one that needs machinery that does not exist — chrome paragraphs carry
+text/alignment/font/spacing and no tab stops, so a `n / N` right-aligned confidential footer needs
+the chrome path widened first. Nothing behind the gate wants it: #329–#333 need palette, typography
+and spacing, and chrome recipes' only consumer is Phase 2's blocks (#334–#337). Splitting opens the
+gate for five issues and isolates the one task with zero prior art.
 
 6. PptxThemeConfig rewritten as Static<typeof ThemeConfigSchema>, or keep the hand interface plus an
    agreement test?
 
+**Settled: rewrite as `Static<typeof ThemeConfigSchema>`.** The hand interface has already drifted
+from the schema — `core-pptx/src/themes/__tests__/bundled-themes.test.ts` exists because nothing ran
+the built-in themes past `ThemeConfigSchema` while `tsc` checked them against the interface.
+Deriving the type removes the class of bug; an agreement test keeps two things in sync forever.
+
 7. Does docx `props.theme` gain an inline-object branch, for pptx parity?
 
+**Settled: yes, but a separate ticket.** Parity worth having, not a gate dependency, and nothing in
+#328–#333 waits on it.
+
 8. fontWeight fix and `case` inside #328 (moves one golden), or a separate ticket?
+
+**Settled: inside #328.** The type-role ladder cannot be built without per-role weight, and the fix
+moves exactly one golden. Splitting a one-golden change costs more ceremony than it saves.
 
 9. Is the docx `light` font role repurposed as `display`, or retired? It duplicates `heading` in all
    three themes and no style references it.
 
+**Settled: neither — leave `light` alone.** The question offers a false binary. The claim it rests
+on ("no style references it") is true of the three bundled themes and false of the corpus:
+`core-docx/src/__tests__/fixtures/corpus-theme.ts` uses `font: 'light'` in three cases, so it is a
+live component prop with golden coverage. Retiring it breaks that prop; repurposing it as `display`
+silently changes what existing documents render. The two are different axes anyway — `light` is a
+font _family_ slot, `typography.roles.display` is a type role — so they do not compete. Give
+`display` its own role and leave `light` where it is.
+
 10. Does the corpus get pinned to a frozen theme, so #331 moves ~26 goldens instead of ~337?
+
+**Settled: pin the corpus — and the question's arithmetic is backwards.** Verified 2026-09-05:
+there are 273 docx goldens and 64 pptx (337 together, which is where the "~337" came from — it was
+the total, not the docx move). Only 31 docx fixtures name a theme (26 `minimal`, 3 `devportal`,
+2 `vermilion`) and **not one of the 113 pptx cases names one at all**. Theme-less docx resolves to
+`minimal` at `core-docx/src/core/generationContext.ts:97`, which is exactly what #331 repoints.
+
+So the 26 that pin `minimal` are the ones that would NOT move, and unpinned #331 moves roughly
+242 docx + all 64 pptx ≈ **306 goldens**, not 26. Pinning is a mechanical commit — ~306 fixtures
+gain an explicit theme and no golden moves, because the resolved theme is identical — after which
+#331 moves ~0. The diff under review becomes "fixtures made explicit" instead of "306 goldens
+moved".
 
 ## Tripwires
 

--- a/packages/core-pptx/src/themes/__tests__/bundled-themes.test.ts
+++ b/packages/core-pptx/src/themes/__tests__/bundled-themes.test.ts
@@ -63,9 +63,16 @@ describe('built-in pptx themes', () => {
 });
 
 describe('the theme lookup', () => {
-  it.each(names)('getPptxTheme(%s) returns a valid theme', (name) => {
-    expect(errorsFor(getPptxTheme(name))).toEqual([]);
-  });
+  it.each(names)(
+    'getPptxTheme(%s) returns the theme registered for it',
+    (name) => {
+      // Identity, not just validity: a lookup that returned the default theme
+      // for every name would satisfy the schema and break the contract.
+      const theme = getPptxTheme(name);
+      expect(theme).toBe(pptxThemes[name]);
+      expect(errorsFor(theme)).toEqual([]);
+    }
+  );
 
   it('falls back to the default theme, and says so separately', () => {
     // The fallback is deliberate and documented; `hasPptxTheme` is the only

--- a/packages/core-pptx/src/themes/__tests__/bundled-themes.test.ts
+++ b/packages/core-pptx/src/themes/__tests__/bundled-themes.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Every built-in PPTX theme must satisfy the theme schema.
+ *
+ * The DOCX twin (`core-docx/src/themes/__tests__/bundled-themes.test.ts`)
+ * exists because themes once shipped with dead `componentDefaults.table`
+ * properties that no renderer read and the validator rejects. PPTX had no
+ * equivalent guard at all, and it is the format that needs one more: its
+ * themes are TypeScript object literals rather than JSON files, so nothing
+ * ever runs them past `ThemeConfigSchema` — `tsc` checks them against the
+ * hand-written `PptxThemeConfig` interface, which is a different thing and
+ * has drifted from the schema before.
+ *
+ * The timing matters. `ir/compiler.ts` reads `ctx.theme.defaults.fontSize`
+ * unguarded, so a theme the schema would have rejected surfaces as a
+ * TypeError deep in the compiler rather than as a diagnostic naming the
+ * field. That is survivable while three hand-written themes are the whole
+ * set; it stops being survivable the moment the extended schema lands and
+ * themes grow type ladders, spacing scales and chrome recipes (#328).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { validatePptxTheme } from '@json-to-office/shared-pptx';
+import {
+  DEFAULT_PPTX_THEME,
+  getPptxTheme,
+  hasPptxTheme,
+  pptxThemes,
+} from '../defaults';
+
+function errorsFor(theme: unknown): string[] {
+  const result = validatePptxTheme(theme);
+  return result.valid
+    ? []
+    : result.errors.map((error) => `${error.path}: ${error.message}`);
+}
+
+const names = Object.keys(pptxThemes).sort();
+
+describe('built-in pptx themes', () => {
+  it('registers the themes the docs and the schema enum promise', () => {
+    expect(names).toEqual(['dark', 'default', 'minimal']);
+  });
+
+  it.each(names)('%s validates against the theme schema', (name) => {
+    expect(errorsFor(pptxThemes[name])).toEqual([]);
+  });
+
+  it.each(names)('%s survives the round trip through JSON', (name) => {
+    // What reaches a `--theme-path` consumer is parsed JSON, not the literal:
+    // `undefined` members vanish on the way, which is exactly how an optional
+    // property that is secretly required goes unnoticed.
+    expect(errorsFor(JSON.parse(JSON.stringify(pptxThemes[name])))).toEqual([]);
+  });
+
+  it('names each theme the same way it is registered', () => {
+    // `getPptxTheme` falls back to the default on a miss, so a theme whose
+    // `name` disagrees with its key is a lookup that silently returns
+    // something else wearing the wrong label.
+    for (const name of names) {
+      expect(pptxThemes[name].name).toBe(name);
+    }
+  });
+});
+
+describe('the theme lookup', () => {
+  it.each(names)('getPptxTheme(%s) returns a valid theme', (name) => {
+    expect(errorsFor(getPptxTheme(name))).toEqual([]);
+  });
+
+  it('falls back to the default theme, and says so separately', () => {
+    // The fallback is deliberate and documented; `hasPptxTheme` is the only
+    // way a caller can tell a real built-in from a name that missed.
+    expect(getPptxTheme('no-such-theme')).toBe(DEFAULT_PPTX_THEME);
+    expect(hasPptxTheme('no-such-theme')).toBe(false);
+    expect(hasPptxTheme('minimal')).toBe(true);
+  });
+});

--- a/packages/design-evals/baselines/README.md
+++ b/packages/design-evals/baselines/README.md
@@ -55,3 +55,20 @@ standard error near 9 points, so a gap smaller than that is not a result.
 The assisted set carries `skillExcluded`: the skill ships a 4 MB template
 library and scripts the agent had no tools to use, so that run measures the
 ceiling of the skill's _guidance_, not of everything it ships.
+
+## Re-judging a recorded set
+
+`pnpm rejudge <run-dir>` judges the contact sheets a set already produced, without
+re-authoring anything, and reports how much the judge agrees with itself.
+
+It exists because a spot check found that it often does not. Four stored
+documents from the cold baseline, re-judged a day later with the same rubric and
+the same model, changed three of the four `wouldShip` answers — including one
+the judge scored level 4 and genericness 1, its two best marks, while answering
+"no". Graded fields moved far less: no level moved by more than one step.
+
+That ordering matters for how these baselines may be read. The rubric's graded
+scores look usable; the binary shipping verdict, which is the metric §1 leads
+with, may be mostly the instrument. Until a full re-judge puts a kappa on it,
+treat every `wouldShip` comparison in this directory — including the paired cold
+versus assisted analysis — as unproven rather than as a result.

--- a/packages/design-evals/package.json
+++ b/packages/design-evals/package.json
@@ -13,7 +13,8 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage --passWithNoTests"
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "rejudge": "tsx src/rejudge-cli.ts"
   },
   "dependencies": {
     "@json-to-office/jto-ops": "workspace:^",

--- a/packages/design-evals/src/cli.ts
+++ b/packages/design-evals/src/cli.ts
@@ -29,7 +29,7 @@ import {
   type Brief,
   type Corpus,
 } from './corpus.js';
-import { buildManifest } from './manifest.js';
+import { buildManifest, treeState } from './manifest.js';
 import { loadSkill, type LoadedSkill } from './skill.js';
 import type { RunMetrics } from './metrics.js';
 import { runBrief } from './runner.js';
@@ -205,6 +205,10 @@ export async function main(argv: readonly string[]): Promise<number> {
 
   const runs: RunMetrics[] = [];
   const started = Date.now();
+  // Before the first brief, not after the last: a manifest assembled at the
+  // end describes the tree the SCORECARD was written against, which is not
+  // necessarily the tree any of the briefs ran against.
+  const atStart = treeState(root);
   const attempts = briefs.flatMap((brief) =>
     Array.from({ length: options.repeat }, (_, pass) => ({ brief, pass }))
   );
@@ -240,6 +244,7 @@ export async function main(argv: readonly string[]): Promise<number> {
     runs,
     manifest: buildManifest({
       repoRoot: root,
+      atStart,
       model: options.model,
       modelParameters: { maxTurns: options.maxTurns },
       serverInstructions: SERVER_INSTRUCTIONS,
@@ -277,6 +282,19 @@ export async function main(argv: readonly string[]): Promise<number> {
 
   const { totals } = scorecard;
   line('');
+  if (!scorecard.manifest.treeStableDuringRun) {
+    // Above everything, including contamination: a set measured across a
+    // rebuild is not one product's numbers, and no other line on this
+    // scorecard means what it says.
+    line(
+      'WARNING: the revision or the build changed while these briefs were running — ' +
+        'this set mixes two products and cannot be compared with any baseline'
+    );
+    line(
+      `  started ${scorecard.manifest.gitShaAtStart.slice(0, 7)} / build ${scorecard.manifest.buildFingerprintAtStart.slice(0, 7)}, ` +
+        `ended ${scorecard.manifest.gitSha.slice(0, 7)} / build ${scorecard.manifest.buildFingerprint.slice(0, 7)}`
+    );
+  }
   if (totals.contaminated > 0) {
     // Loud, and above the judge line: a contaminated set is not a baseline.
     line(

--- a/packages/design-evals/src/manifest.test.ts
+++ b/packages/design-evals/src/manifest.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -221,5 +223,62 @@ describe('tree stability across a run', () => {
     const manifest = buildManifest(base);
     expect(manifest.treeStableDuringRun).toBe(true);
     expect(manifest.gitShaAtStart).toBe(manifest.gitSha);
+  });
+});
+
+describe('buildFingerprint covers every compiled entry point', () => {
+  /** A fake workspace: `packages/<name>/dist/<files>`, each with content. */
+  async function workspace(
+    packages: Record<string, Record<string, string>>
+  ): Promise<string> {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'jto-fingerprint-'));
+    for (const [name, files] of Object.entries(packages)) {
+      const dist = path.join(root, 'packages', name, 'dist');
+      await fs.mkdir(dist, { recursive: true });
+      for (const [file, content] of Object.entries(files)) {
+        await fs.writeFile(path.join(dist, file), content);
+      }
+    }
+    return root;
+  }
+
+  it('notices a rebuild that touched only the CLI entry', async () => {
+    // The regression: `tsup` builds `cli` and `index` as separate entries, and
+    // `serverCommand` launches `mcp-server/dist/cli.js`. Fingerprinting only
+    // `index.js` left a CLI-only rebuild invisible to the one check whose job
+    // is noticing that the compiled product moved under a measurement.
+    const root = await workspace({
+      'mcp-server': { 'index.js': 'index', 'cli.js': 'cli' },
+    });
+    const before = buildFingerprint(root);
+
+    await fs.writeFile(
+      path.join(root, 'packages/mcp-server/dist/cli.js'),
+      'cli, rebuilt and longer'
+    );
+
+    expect(buildFingerprint(root)).not.toBe(before);
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('still records an unbuilt package as absent', async () => {
+    // Both readings come from the SAME root, so the built package's size and
+    // mtime are identical across them and the only thing that moved is the
+    // unbuilt package appearing. Comparing two temp roots would have passed
+    // whatever the code did, since their mtimes differ anyway.
+    const root = await workspace({ built: { 'index.js': 'x' } });
+    const builtOnly = buildFingerprint(root);
+
+    await fs.mkdir(path.join(root, 'packages', 'unbuilt'), { recursive: true });
+
+    expect(buildFingerprint(root)).not.toBe(UNAVAILABLE);
+    expect(buildFingerprint(root)).not.toBe(builtOnly);
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('answers UNAVAILABLE when there is no packages directory', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'jto-empty-'));
+    expect(buildFingerprint(root)).toBe(UNAVAILABLE);
+    await fs.rm(root, { recursive: true, force: true });
   });
 });

--- a/packages/design-evals/src/manifest.test.ts
+++ b/packages/design-evals/src/manifest.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  buildFingerprint,
   buildManifest,
   endpointClass,
   fontInventory,
@@ -162,5 +163,63 @@ describe('fontInventory', () => {
     const fonts = fontInventory();
     expect(Array.isArray(fonts)).toBe(true);
     expect(fonts).toEqual([...fonts].sort());
+  });
+});
+
+describe('tree stability across a run', () => {
+  const base = {
+    repoRoot,
+    model: 'claude-sonnet-5',
+    modelParameters: {},
+    serverInstructions: 'instructions',
+    mode: 'cold' as const,
+    maxRetries: 1,
+    agentSdkVersion: '0.3.259',
+  };
+
+  it('is stable when the tree the run started on is the tree it ended on', () => {
+    const manifest = buildManifest({
+      ...base,
+      atStart: {
+        gitSha: gitState(repoRoot).sha,
+        buildFingerprint: buildFingerprint(repoRoot),
+      },
+    });
+    expect(manifest.treeStableDuringRun).toBe(true);
+    expect(manifest.gitShaAtStart).toBe(manifest.gitSha);
+  });
+
+  it('is unstable when the compiled workspace moved under the run', () => {
+    // The real failure: another session ran `pnpm build` at minute 58 of a
+    // 76-minute set. Nothing in git changed for the runs already finished, and
+    // the manifest — assembled at the end — looked clean.
+    const manifest = buildManifest({
+      ...base,
+      atStart: {
+        gitSha: gitState(repoRoot).sha,
+        buildFingerprint: 'a-build-that-is-no-longer-on-disk',
+      },
+    });
+    expect(manifest.treeStableDuringRun).toBe(false);
+    expect(manifest.buildFingerprintAtStart).not.toBe(
+      manifest.buildFingerprint
+    );
+  });
+
+  it('is unstable when the revision moved under the run', () => {
+    const manifest = buildManifest({
+      ...base,
+      atStart: {
+        gitSha: '0000000000000000000000000000000000000000',
+        buildFingerprint: buildFingerprint(repoRoot),
+      },
+    });
+    expect(manifest.treeStableDuringRun).toBe(false);
+  });
+
+  it('claims stability rather than inventing it when no start state was captured', () => {
+    const manifest = buildManifest(base);
+    expect(manifest.treeStableDuringRun).toBe(true);
+    expect(manifest.gitShaAtStart).toBe(manifest.gitSha);
   });
 });

--- a/packages/design-evals/src/manifest.ts
+++ b/packages/design-evals/src/manifest.ts
@@ -14,7 +14,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -24,6 +24,27 @@ export interface RunManifest {
   gitSha: string;
   /** True when the tree had uncommitted changes: the SHA does not describe it. */
   gitDirty: boolean;
+  /** The revision the FIRST brief started against. */
+  gitShaAtStart: string;
+  /** Identity of the compiled workspace when the first brief started. */
+  buildFingerprintAtStart: string;
+  /** The same, after the last brief finished. */
+  buildFingerprint: string;
+  /**
+   * False when the revision or the compiled output moved while briefs were in
+   * flight — which makes the set a mixture of two products rather than a
+   * measurement of one.
+   *
+   * This is not hypothetical. A variance run of six briefs shared a working
+   * tree with another session that landed a feature and rebuilt at minute 58;
+   * the twelve pptx briefs already measured were pre-change, the six docx
+   * briefs after it died with `does not provide an export named ...` because
+   * the process still held the old `@json-to-office/quality` in its module
+   * graph, and the manifest — built at the END of the run — recorded only the
+   * final SHA and looked perfectly clean. Seventy-six minutes of runs, and the
+   * only evidence that anything was wrong was a mtime.
+   */
+  treeStableDuringRun: boolean;
   packageVersions: Record<string, string>;
   agentSdkVersion: string;
   /** The exact model identifier the runs were made with. */
@@ -101,6 +122,50 @@ function probeVersion(command: string, args: readonly string[]): string {
   return text === '' ? UNAVAILABLE : (text.split('\n')[0] as string).trim();
 }
 
+/**
+ * A cheap identity for the COMPILED workspace.
+ *
+ * Runs import the built packages, not the sources, so a git SHA does not say
+ * what the agent actually talked to: `pnpm build` between two runs of the same
+ * commit changes the product and nothing in git. Size and mtime of each
+ * package's entry point are enough — the question is only ever "did this move
+ * while I was measuring", never "what exactly changed".
+ */
+export function buildFingerprint(repoRoot: string): string {
+  const packagesDir = path.join(repoRoot, 'packages');
+  const parts: string[] = [];
+  let names: string[];
+  try {
+    names = readdirSync(packagesDir).sort();
+  } catch {
+    return UNAVAILABLE;
+  }
+  for (const name of names) {
+    const entry = path.join(packagesDir, name, 'dist', 'index.js');
+    try {
+      const stat = statSync(entry);
+      parts.push(`${name}:${stat.size}:${Math.round(stat.mtimeMs)}`);
+    } catch {
+      // A package with no dist is not built; its absence is part of the state.
+      parts.push(`${name}:absent`);
+    }
+  }
+  return sha256(parts.join('\n'));
+}
+
+/** Revision plus compiled identity — everything that makes a run reproducible. */
+export interface TreeState {
+  gitSha: string;
+  buildFingerprint: string;
+}
+
+export function treeState(repoRoot: string): TreeState {
+  return {
+    gitSha: gitState(repoRoot).sha,
+    buildFingerprint: buildFingerprint(repoRoot),
+  };
+}
+
 export function sha256(value: string): string {
   return createHash('sha256').update(value).digest('hex');
 }
@@ -167,6 +232,14 @@ function packageVersion(packageJsonPath: string): string {
 
 export interface ManifestInput {
   repoRoot: string;
+  /**
+   * The tree as it was before the first brief ran. Optional only so a caller
+   * that genuinely cannot capture it still gets a manifest; when it is absent
+   * the manifest says the run was stable because it has nothing to compare,
+   * which is the weaker claim and is labelled as such by the two identical
+   * `AtStart` fields.
+   */
+  atStart?: TreeState;
   model: string;
   modelParameters: Record<string, unknown>;
   serverInstructions: string;
@@ -225,9 +298,20 @@ export function buildManifest(input: ManifestInput): RunManifest {
     'jto-ops',
   ];
 
+  const fingerprint = buildFingerprint(input.repoRoot);
+  const atStart = input.atStart ?? {
+    gitSha: git.sha,
+    buildFingerprint: fingerprint,
+  };
+
   return {
     gitSha: git.sha,
     gitDirty: git.dirty,
+    gitShaAtStart: atStart.gitSha,
+    buildFingerprintAtStart: atStart.buildFingerprint,
+    buildFingerprint: fingerprint,
+    treeStableDuringRun:
+      atStart.gitSha === git.sha && atStart.buildFingerprint === fingerprint,
     packageVersions: Object.fromEntries(
       packages.map((name) => [
         `@json-to-office/${name}`,

--- a/packages/design-evals/src/manifest.ts
+++ b/packages/design-evals/src/manifest.ts
@@ -128,8 +128,14 @@ function probeVersion(command: string, args: readonly string[]): string {
  * Runs import the built packages, not the sources, so a git SHA does not say
  * what the agent actually talked to: `pnpm build` between two runs of the same
  * commit changes the product and nothing in git. Size and mtime of each
- * package's entry point are enough — the question is only ever "did this move
+ * compiled entry point are enough — the question is only ever "did this move
  * while I was measuring", never "what exactly changed".
+ *
+ * EVERY top-level `dist/*.js`, not just `index.js`. `tsup` builds `cli` and
+ * `index` as separate entries, and the file a run actually executes is
+ * `mcp-server/dist/cli.js` (see `serverCommand`) — so fingerprinting only
+ * `index.js` left a CLI-only rebuild invisible to the one check whose whole
+ * job is noticing that the compiled product moved.
  */
 export function buildFingerprint(repoRoot: string): string {
   const packagesDir = path.join(repoRoot, 'packages');
@@ -141,13 +147,28 @@ export function buildFingerprint(repoRoot: string): string {
     return UNAVAILABLE;
   }
   for (const name of names) {
-    const entry = path.join(packagesDir, name, 'dist', 'index.js');
+    const dist = path.join(packagesDir, name, 'dist');
+    let entries: string[];
     try {
-      const stat = statSync(entry);
-      parts.push(`${name}:${stat.size}:${Math.round(stat.mtimeMs)}`);
+      entries = readdirSync(dist)
+        .filter((file) => file.endsWith('.js'))
+        .sort();
     } catch {
       // A package with no dist is not built; its absence is part of the state.
       parts.push(`${name}:absent`);
+      continue;
+    }
+    if (entries.length === 0) {
+      parts.push(`${name}:absent`);
+      continue;
+    }
+    for (const file of entries) {
+      try {
+        const stat = statSync(path.join(dist, file));
+        parts.push(`${name}/${file}:${stat.size}:${Math.round(stat.mtimeMs)}`);
+      } catch {
+        parts.push(`${name}/${file}:absent`);
+      }
     }
   }
   return sha256(parts.join('\n'));

--- a/packages/design-evals/src/rejudge-cli.test.ts
+++ b/packages/design-evals/src/rejudge-cli.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The rejudge CLI's argument handling and its two counts.
+ *
+ * Both defects here are the same shape: a rule that reads one thing as another
+ * and produces a plausible answer rather than an error. An option's value read
+ * as the runs directory sends the whole run at a path that holds nothing; a
+ * run with no original verdict counted as both compared and changed prints two
+ * numbers that contradict each other about one document.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { runsDirArgument, verdictCounts } from './rejudge-cli.js';
+
+describe('runsDirArgument', () => {
+  it('takes the positional argument when it comes first', () => {
+    expect(runsDirArgument(['runs/foo', '--scorecard', 'out/sc.json'])).toBe(
+      'runs/foo'
+    );
+  });
+
+  it('does not read an option value as the runs directory', () => {
+    // The regression: `argv.find(arg => !arg.startsWith('--'))` answered
+    // `out/sc.json`, which then had `runs` joined onto it and `rejudge.json`
+    // written inside it — a documented invocation producing nothing, or
+    // ENOTDIR when the value is a file.
+    for (const argv of [
+      ['--scorecard', 'out/sc.json', 'runs/foo'],
+      ['--briefs', 'a,b', 'runs/foo'],
+      ['--judge', 'claude-opus-5', 'runs/foo'],
+      ['--scorecard', 'out/sc.json', '--briefs', 'a,b', 'runs/foo'],
+    ]) {
+      expect(runsDirArgument(argv), argv.join(' ')).toBe('runs/foo');
+    }
+  });
+
+  it('leaves a valueless flag alone', () => {
+    expect(runsDirArgument(['--judge-api', 'runs/foo'])).toBe('runs/foo');
+  });
+
+  it('answers undefined when only options were given', () => {
+    expect(runsDirArgument(['--scorecard', 'out/sc.json'])).toBeUndefined();
+    expect(runsDirArgument([])).toBeUndefined();
+  });
+
+  it('does not consume a value that is itself an option', () => {
+    // `--scorecard --judge-api runs/foo` is a mistake, but the runs directory
+    // is still unambiguous and should not be swallowed.
+    expect(runsDirArgument(['--scorecard', '--judge-api', 'runs/foo'])).toBe(
+      'runs/foo'
+    );
+  });
+});
+
+describe('verdictCounts', () => {
+  const run = (
+    briefId: string,
+    then: { wouldShip?: boolean },
+    now?: { wouldShip: boolean; level: number; genericness: number }
+  ) => ({ briefId, then, ...(now && { now }) });
+
+  it('counts a document that kept its answer as compared and not changed', () => {
+    expect(
+      verdictCounts([
+        run(
+          'a',
+          { wouldShip: true },
+          { wouldShip: true, level: 3, genericness: 2 }
+        ),
+      ])
+    ).toEqual({ compared: 1, changed: 0 });
+  });
+
+  it('counts a document that flipped as both compared and changed', () => {
+    expect(
+      verdictCounts([
+        run(
+          'a',
+          { wouldShip: true },
+          { wouldShip: false, level: 3, genericness: 2 }
+        ),
+      ])
+    ).toEqual({ compared: 1, changed: 1 });
+  });
+
+  it('excludes a run with no original verdict from both counts', () => {
+    // The regression: `undefined !== true` is a change, so one such document
+    // printed "1 re-judged, unchanged since; 1 changed" about itself.
+    expect(
+      verdictCounts([
+        run('a', {}, { wouldShip: true, level: 3, genericness: 2 }),
+      ])
+    ).toEqual({ compared: 0, changed: 0 });
+  });
+
+  it('excludes a run that was never re-judged', () => {
+    expect(verdictCounts([run('a', { wouldShip: true })])).toEqual({
+      compared: 0,
+      changed: 0,
+    });
+  });
+});

--- a/packages/design-evals/src/rejudge-cli.ts
+++ b/packages/design-evals/src/rejudge-cli.ts
@@ -1,0 +1,83 @@
+/** `pnpm rejudge <runs-dir> --scorecard <path>` — the judge against itself. */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { rejudge } from './rejudge.js';
+
+function value(argv: readonly string[], name: string): string | undefined {
+  const index = argv.indexOf(`--${name}`);
+  if (index === -1) return undefined;
+  const next = argv[index + 1];
+  return next !== undefined && !next.startsWith('--') ? next : undefined;
+}
+
+export async function main(
+  argv: readonly string[],
+  line: (text: string) => void = console.log
+): Promise<number> {
+  const positional = argv.find((arg) => !arg.startsWith('--'));
+  if (!positional) {
+    line('usage: pnpm rejudge <runs-dir> [--scorecard <path>] [--briefs a,b]');
+    return 1;
+  }
+  const runsDir = path.resolve(positional, 'runs');
+  const scorecardPath =
+    value(argv, 'scorecard') ?? path.resolve(positional, 'scorecard.json');
+
+  const report = await rejudge({
+    runsDir,
+    scorecardPath,
+    judgeModel: value(argv, 'judge') ?? 'claude-opus-5',
+    useApiKey: argv.includes('--judge-api'),
+    ...(value(argv, 'briefs') !== undefined && {
+      briefs: value(argv, 'briefs') as string,
+    }),
+    onProgress: (message) => line(message),
+  });
+
+  const out = path.resolve(positional, 'rejudge.json');
+  await fs.writeFile(out, JSON.stringify(report, null, 2));
+
+  line('');
+  const changed = report.runs.filter(
+    (run) => run.now && run.now.wouldShip !== run.then.wouldShip
+  );
+  const compared = report.runs.filter((run) => run.now).length;
+  line(
+    `${compared} document(s) re-judged, unchanged since; ` +
+      `${changed.length} changed their wouldShip answer`
+  );
+  if (report.agreement) {
+    const { wouldShip, level, genericness, levelMovedMoreThanOne } =
+      report.agreement;
+    const interval = wouldShip.interval
+      ? ` (95% ${wouldShip.interval.low.toFixed(2)}..${wouldShip.interval.high.toFixed(2)})`
+      : '';
+    line(
+      `wouldShip: ${(wouldShip.rawAgreement * 100).toFixed(0)}% agreement, ` +
+        `kappa ${wouldShip.kappa.toFixed(2)}${interval}`
+    );
+    line(
+      `level: ${(level.rawAgreement * 100).toFixed(0)}% exact, kappa ${level.kappa.toFixed(2)}, ` +
+        `${levelMovedMoreThanOne} moved more than one step`
+    );
+    line(
+      `genericness: ${(genericness.rawAgreement * 100).toFixed(0)}% exact, kappa ${genericness.kappa.toFixed(2)}`
+    );
+    // The number the programme actually rests on, said plainly.
+    if (wouldShip.kappa < 0.6) {
+      line('');
+      line(
+        'WARNING: the judge does not reproduce its own shipping verdict. ' +
+          'No phase delta measured with it means anything until this is fixed.'
+      );
+    }
+  }
+  line(out);
+  return 0;
+}
+
+if (process.argv[1] && process.argv[1].endsWith('rejudge-cli.ts')) {
+  process.exitCode = await main(process.argv.slice(2));
+}

--- a/packages/design-evals/src/rejudge-cli.ts
+++ b/packages/design-evals/src/rejudge-cli.ts
@@ -3,7 +3,10 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import { rejudge } from './rejudge.js';
+import { rejudge, type RejudgedRun } from './rejudge.js';
+
+/** Options that take a value, so their value is never read as the runs dir. */
+const VALUED_OPTIONS = ['scorecard', 'judge', 'briefs'] as const;
 
 function value(argv: readonly string[], name: string): string | undefined {
   const index = argv.indexOf(`--${name}`);
@@ -12,11 +15,60 @@ function value(argv: readonly string[], name: string): string | undefined {
   return next !== undefined && !next.startsWith('--') ? next : undefined;
 }
 
+/**
+ * The first argument that is neither an option nor an option's value.
+ *
+ * `argv.find(arg => !arg.startsWith('--'))` reads
+ * `--scorecard out/sc.json runs/foo` as a runs directory of `out/sc.json`,
+ * which then has `runs` joined onto it and `rejudge.json` written inside it —
+ * a documented invocation producing either nothing or ENOTDIR.
+ */
+export function runsDirArgument(argv: readonly string[]): string | undefined {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg.startsWith('--')) {
+      const name = arg.slice(2);
+      const takesValue = (VALUED_OPTIONS as readonly string[]).includes(name);
+      const next = argv[index + 1];
+      if (takesValue && next !== undefined && !next.startsWith('--')) {
+        index += 1;
+      }
+      continue;
+    }
+    return arg;
+  }
+  return undefined;
+}
+
+/**
+ * How many documents were comparable, and how many moved.
+ *
+ * Both counts require an original verdict, exactly as `pairs()` does. A run
+ * whose stored judgement carried no `wouldShip` used to satisfy both
+ * predicates at once — `undefined !== true` is a change — and print
+ * "1 document(s) re-judged, unchanged since; 1 changed their wouldShip
+ * answer" about one document.
+ */
+export function verdictCounts(runs: readonly RejudgedRun[]): {
+  compared: number;
+  changed: number;
+} {
+  const comparable = runs.filter(
+    (run) => run.now !== undefined && typeof run.then.wouldShip === 'boolean'
+  );
+  return {
+    compared: comparable.length,
+    changed: comparable.filter(
+      (run) => run.now!.wouldShip !== run.then.wouldShip
+    ).length,
+  };
+}
+
 export async function main(
   argv: readonly string[],
   line: (text: string) => void = console.log
 ): Promise<number> {
-  const positional = argv.find((arg) => !arg.startsWith('--'));
+  const positional = runsDirArgument(argv);
   if (!positional) {
     line('usage: pnpm rejudge <runs-dir> [--scorecard <path>] [--briefs a,b]');
     return 1;
@@ -40,13 +92,10 @@ export async function main(
   await fs.writeFile(out, JSON.stringify(report, null, 2));
 
   line('');
-  const changed = report.runs.filter(
-    (run) => run.now && run.now.wouldShip !== run.then.wouldShip
-  );
-  const compared = report.runs.filter((run) => run.now).length;
+  const { compared, changed } = verdictCounts(report.runs);
   line(
     `${compared} document(s) re-judged, unchanged since; ` +
-      `${changed.length} changed their wouldShip answer`
+      `${changed} changed their wouldShip answer`
   );
   if (report.agreement) {
     const { wouldShip, level, genericness, levelMovedMoreThanOne } =
@@ -58,12 +107,18 @@ export async function main(
       `wouldShip: ${(wouldShip.rawAgreement * 100).toFixed(0)}% agreement, ` +
         `kappa ${wouldShip.kappa.toFixed(2)}${interval}`
     );
+    // A field nothing could be compared on is said to be absent rather than
+    // printed as 0% and NaN, which read as measurements.
     line(
-      `level: ${(level.rawAgreement * 100).toFixed(0)}% exact, kappa ${level.kappa.toFixed(2)}, ` +
-        `${levelMovedMoreThanOne} moved more than one step`
+      level
+        ? `level: ${(level.rawAgreement * 100).toFixed(0)}% exact, kappa ${level.kappa.toFixed(2)}, ` +
+            `${levelMovedMoreThanOne} moved more than one step`
+        : 'level: no stored verdict carried it, nothing to compare'
     );
     line(
-      `genericness: ${(genericness.rawAgreement * 100).toFixed(0)}% exact, kappa ${genericness.kappa.toFixed(2)}`
+      genericness
+        ? `genericness: ${(genericness.rawAgreement * 100).toFixed(0)}% exact, kappa ${genericness.kappa.toFixed(2)}`
+        : 'genericness: no stored verdict carried it, nothing to compare'
     );
     // The number the programme actually rests on, said plainly.
     if (wouldShip.kappa < 0.6) {

--- a/packages/design-evals/src/rejudge.test.ts
+++ b/packages/design-evals/src/rejudge.test.ts
@@ -92,3 +92,47 @@ describe('summarise', () => {
     expect(summarise(runs)?.levelMovedMoreThanOne).toBe(1);
   });
 });
+
+describe('summarise with a field nothing can be compared on', () => {
+  it('omits the metric rather than reporting NaN as a measurement', () => {
+    // A stored verdict that carried `wouldShip` and no rubric numbers: the
+    // shipping answer is comparable, the other two are not. `bootstrapKappa([])`
+    // answers `n: 0, rawAgreement: 0, kappa: NaN`, and a report carrying that
+    // reads as a measurement of perfect disagreement.
+    const agreement = summarise([
+      run(
+        'a',
+        { wouldShip: true },
+        { wouldShip: true, level: 3, genericness: 2 }
+      ),
+      run(
+        'b',
+        { wouldShip: false },
+        { wouldShip: false, level: 4, genericness: 1 }
+      ),
+    ]);
+
+    expect(agreement?.wouldShip.n).toBe(2);
+    expect(agreement?.level).toBeUndefined();
+    expect(agreement?.genericness).toBeUndefined();
+    expect(agreement?.levelMovedMoreThanOne).toBe(0);
+  });
+
+  it('still reports a field every stored verdict carried', () => {
+    const agreement = summarise([
+      run(
+        'a',
+        { wouldShip: true, level: 3, genericness: 2 },
+        { wouldShip: true, level: 3, genericness: 2 }
+      ),
+      run(
+        'b',
+        { wouldShip: false, level: 2, genericness: 4 },
+        { wouldShip: false, level: 2, genericness: 4 }
+      ),
+    ]);
+
+    expect(agreement?.level?.n).toBe(2);
+    expect(agreement?.genericness?.n).toBe(2);
+  });
+});

--- a/packages/design-evals/src/rejudge.test.ts
+++ b/packages/design-evals/src/rejudge.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { pairs, summarise, type RejudgedRun } from './rejudge.js';
+
+const run = (
+  briefId: string,
+  then: RejudgedRun['then'],
+  now?: RejudgedRun['now']
+): RejudgedRun => ({ briefId, then, ...(now && { now }) });
+
+describe('pairs', () => {
+  it('keeps only documents that carry both judgements', () => {
+    const runs = [
+      run(
+        'a',
+        { wouldShip: true },
+        { wouldShip: false, level: 3, genericness: 2 }
+      ),
+      // Never re-judged: a missing contact sheet is not a disagreement.
+      run('b', { wouldShip: true }),
+      // Judged now but not then: an unjudged baseline run is not one either.
+      run('c', {}, { wouldShip: true, level: 4, genericness: 1 }),
+    ];
+    expect(pairs<boolean>(runs, (v) => v.wouldShip)).toEqual([
+      { a: true, b: false },
+    ]);
+  });
+});
+
+describe('summarise', () => {
+  it('reports nothing rather than a perfect score when nothing was compared', () => {
+    expect(summarise([run('a', { wouldShip: true })])).toBeUndefined();
+  });
+
+  it('gives a judge that reproduces itself a kappa of one', () => {
+    const runs = [
+      run(
+        'a',
+        { wouldShip: true, level: 4, genericness: 2 },
+        { wouldShip: true, level: 4, genericness: 2 }
+      ),
+      run(
+        'b',
+        { wouldShip: false, level: 3, genericness: 3 },
+        { wouldShip: false, level: 3, genericness: 3 }
+      ),
+      run(
+        'c',
+        { wouldShip: false, level: 2, genericness: 4 },
+        { wouldShip: false, level: 2, genericness: 4 }
+      ),
+    ];
+    expect(summarise(runs)?.wouldShip.kappa).toBe(1);
+    expect(summarise(runs)?.levelMovedMoreThanOne).toBe(0);
+  });
+
+  it('does not credit a judge that only ever says no', () => {
+    // Eighty per cent raw agreement and no information: the case kappa exists
+    // for, and the reason the CLI reports kappa rather than agreement.
+    const runs = [
+      ...Array.from({ length: 4 }, (_, index) =>
+        run(
+          `no-${index}`,
+          { wouldShip: false, level: 3, genericness: 3 },
+          { wouldShip: false, level: 3, genericness: 3 }
+        )
+      ),
+      run(
+        'yes',
+        { wouldShip: true, level: 4, genericness: 2 },
+        { wouldShip: false, level: 3, genericness: 3 }
+      ),
+    ];
+    const report = summarise(runs);
+    expect(report?.wouldShip.rawAgreement).toBe(0.8);
+    expect(report?.wouldShip.kappa).toBe(0);
+  });
+
+  it('counts levels that moved by more than one step', () => {
+    const runs = [
+      run(
+        'a',
+        { wouldShip: true, level: 4, genericness: 2 },
+        { wouldShip: true, level: 2, genericness: 2 }
+      ),
+      run(
+        'b',
+        { wouldShip: false, level: 3, genericness: 3 },
+        { wouldShip: false, level: 4, genericness: 3 }
+      ),
+    ];
+    expect(summarise(runs)?.levelMovedMoreThanOne).toBe(1);
+  });
+});

--- a/packages/design-evals/src/rejudge.ts
+++ b/packages/design-evals/src/rejudge.ts
@@ -47,8 +47,9 @@ export interface RejudgeReport {
   /** Self-agreement, per rubric field. Absent when nothing could be compared. */
   agreement?: {
     wouldShip: KappaReport;
-    level: KappaReport;
-    genericness: KappaReport;
+    /** Absent when no stored verdict carried this field to compare against. */
+    level?: KappaReport;
+    genericness?: KappaReport;
     /** Documents whose level moved by more than one step. */
     levelMovedMoreThanOne: number;
   };
@@ -85,10 +86,17 @@ export function summarise(
   const ship = pairs<boolean>(runs, (v) => v.wouldShip);
   if (ship.length === 0) return undefined;
   const levels = pairs<number>(runs, (v) => v.level);
+  const genericness = pairs<number>(runs, (v) => v.genericness);
+  // A field with no pairs is omitted rather than reported: `bootstrapKappa([])`
+  // answers `n: 0, rawAgreement: 0, kappa: NaN`, and a report carrying that is
+  // worse than one carrying nothing — NaN serialises to `null` and prints as
+  // "NaN", both of which read as a measurement.
   return {
     wouldShip: bootstrapKappa(ship),
-    level: bootstrapKappa(levels),
-    genericness: bootstrapKappa(pairs<number>(runs, (v) => v.genericness)),
+    ...(levels.length > 0 && { level: bootstrapKappa(levels) }),
+    ...(genericness.length > 0 && {
+      genericness: bootstrapKappa(genericness),
+    }),
     levelMovedMoreThanOne: levels.filter(
       (rating) => Math.abs(rating.a - rating.b) > 1
     ).length,

--- a/packages/design-evals/src/rejudge.ts
+++ b/packages/design-evals/src/rejudge.ts
@@ -1,0 +1,184 @@
+/**
+ * The judge, measured against itself.
+ *
+ * Every number this programme reports about taste comes from one absolute
+ * verdict per document, and an absolute verdict is only worth as much as its
+ * repeatability. A spot check of four stored contact sheets, re-judged a day
+ * later with the same rubric and the same model, changed three of the four
+ * `wouldShip` answers — one of them on a document the judge simultaneously
+ * scored level 4 and genericness 1, its two best marks. If that rate holds, the
+ * cold-versus-assisted comparison the spec leads with is measuring the judge.
+ *
+ * So this re-judges a recorded set WITHOUT re-authoring it. The documents are
+ * fixed, the rubric is fixed, and the only thing that varies is the judge; any
+ * disagreement it finds is the instrument's own noise. It reads the contact
+ * sheets already on disk rather than rendering again, so a full corpus costs
+ * one judge call per document and nothing else.
+ *
+ * Kappa rather than agreement: on a corpus where four in five documents are
+ * unshippable, a judge that says "no" to everything agrees with itself 80% of
+ * the time and has said nothing.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import type { Brief } from './corpus.js';
+import { developmentCorpusDir, loadCorpus, selectBriefs } from './corpus.js';
+import { agentVision, anthropicVision, judgeDocument } from './judge.js';
+import type { KappaReport } from './statistics.js';
+import { bootstrapKappa, type Rating } from './statistics.js';
+
+/** One document, judged twice. */
+export interface RejudgedRun {
+  briefId: string;
+  then: { wouldShip?: boolean; level?: number; genericness?: number };
+  now?: { wouldShip: boolean; level: number; genericness: number };
+  /** Why this document could not be re-judged, when it could not be. */
+  error?: string;
+}
+
+export interface RejudgeReport {
+  /** The set that was re-judged. */
+  source: string;
+  judgeModel: string;
+  judgedAt: string;
+  runs: RejudgedRun[];
+  /** Self-agreement, per rubric field. Absent when nothing could be compared. */
+  agreement?: {
+    wouldShip: KappaReport;
+    level: KappaReport;
+    genericness: KappaReport;
+    /** Documents whose level moved by more than one step. */
+    levelMovedMoreThanOne: number;
+  };
+}
+
+interface RecordedRun {
+  briefId: string;
+  judge?: { wouldShip?: boolean; level?: number; genericness?: number };
+}
+
+/** Pairs where BOTH judgements exist; anything else cannot be an agreement. */
+export function pairs<T extends string | number | boolean>(
+  runs: readonly RejudgedRun[],
+  read: (verdict: {
+    wouldShip?: boolean;
+    level?: number;
+    genericness?: number;
+  }) => T | undefined
+): Rating<T>[] {
+  const found: Rating<T>[] = [];
+  for (const run of runs) {
+    if (!run.now) continue;
+    const a = read(run.then);
+    const b = read(run.now);
+    if (a === undefined || b === undefined) continue;
+    found.push({ a, b });
+  }
+  return found;
+}
+
+export function summarise(
+  runs: readonly RejudgedRun[]
+): RejudgeReport['agreement'] {
+  const ship = pairs<boolean>(runs, (v) => v.wouldShip);
+  if (ship.length === 0) return undefined;
+  const levels = pairs<number>(runs, (v) => v.level);
+  return {
+    wouldShip: bootstrapKappa(ship),
+    level: bootstrapKappa(levels),
+    genericness: bootstrapKappa(pairs<number>(runs, (v) => v.genericness)),
+    levelMovedMoreThanOne: levels.filter(
+      (rating) => Math.abs(rating.a - rating.b) > 1
+    ).length,
+  };
+}
+
+export interface RejudgeOptions {
+  /** Directory holding `runs/<briefId>/contact-sheet.png`. */
+  runsDir: string;
+  /** Scorecard or committed baseline carrying the recorded verdicts. */
+  scorecardPath: string;
+  judgeModel: string;
+  useApiKey: boolean;
+  briefs?: string;
+  corpusDir?: string;
+  onProgress?: (message: string) => void;
+}
+
+export async function rejudge(options: RejudgeOptions): Promise<RejudgeReport> {
+  const recorded = JSON.parse(
+    await fs.readFile(options.scorecardPath, 'utf8')
+  ) as { runs: RecordedRun[] };
+
+  const corpus = await loadCorpus(options.corpusDir ?? developmentCorpusDir());
+  const wanted = selectBriefs(corpus, options.briefs);
+  const byId = new Map<string, Brief>(
+    wanted.map((brief) => [brief.id, brief] as const)
+  );
+
+  const call = options.useApiKey
+    ? anthropicVision({ model: options.judgeModel })
+    : agentVision({ model: options.judgeModel });
+
+  // A set may hold repeats of the same brief; the first recorded verdict for
+  // each is the one a committed baseline reports, so it is the one to match.
+  const seen = new Set<string>();
+  const runs: RejudgedRun[] = [];
+  for (const record of recorded.runs) {
+    const brief = byId.get(record.briefId);
+    if (!brief || seen.has(record.briefId)) continue;
+    seen.add(record.briefId);
+
+    const then = record.judge ?? {};
+    const sheetPath = path.join(
+      options.runsDir,
+      record.briefId,
+      'contact-sheet.png'
+    );
+    let png: Buffer;
+    try {
+      png = await fs.readFile(sheetPath);
+    } catch {
+      // A run that failed never produced a sheet. Recorded, not silently
+      // dropped: a re-judge over 34 of 40 documents is a different number
+      // from one over 40.
+      runs.push({ briefId: record.briefId, then, error: 'no contact sheet' });
+      continue;
+    }
+
+    options.onProgress?.(`${runs.length + 1} ${record.briefId}`);
+    try {
+      const judged = await judgeDocument({
+        brief,
+        sheet: { png, label: record.briefId },
+        call,
+      });
+      runs.push({
+        briefId: record.briefId,
+        then,
+        now: {
+          wouldShip: judged.verdict.wouldShip,
+          level: judged.verdict.level,
+          genericness: judged.verdict.genericness,
+        },
+      });
+    } catch (error) {
+      runs.push({
+        briefId: record.briefId,
+        then,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const agreement = summarise(runs);
+  return {
+    source: options.scorecardPath,
+    judgeModel: options.judgeModel,
+    judgedAt: new Date().toISOString(),
+    runs,
+    ...(agreement && { agreement }),
+  };
+}


### PR DESCRIPTION
Four commits that clear the runway for #328, from two sessions working the same
branch. All green, all small, and they touch disjoint files.

## Unblocking Phase 1

**`test(pptx)`** — the bundled-theme schema guard PPTX never had. DOCX has
validated its themes since they shipped dead `componentDefaults.table`
properties the validator rejects; PPTX had no equivalent, and needs one more,
because its themes are TypeScript literals rather than JSON files. Nothing ever
ran them past `ThemeConfigSchema` — `tsc` checks them against the hand-written
`PptxThemeConfig` interface, which is a different thing and has drifted.

The timing is the point: `ir/compiler.ts` reads `ctx.theme.defaults.fontSize`
unguarded, so a theme the schema would reject surfaces as a TypeError deep in
the compiler rather than a diagnostic naming the field. Survivable for three
hand-written themes; not once themes carry type ladders and chrome recipes.

Mutation-checked three ways: a dead `componentDefaults.table` property, a
missing `colors` slot, and a theme whose `name` disagrees with its registry key.

**`docs`** — the ten decisions the Phase 1 map deliberately refused to pick for
itself, now settled, each recorded under its own question with the evidence it
rests on. Two did not survive contact with the code:

- **#9's binary is false.** It asks whether the docx `light` font role is
  repurposed as `display` or retired, on the grounds that no style references
  it. True of the three bundled themes, false of the corpus: `corpus-theme.ts`
  uses `font: 'light'` in three cases, so it is a live component prop with
  golden coverage. Retiring it breaks the prop; repurposing it silently changes
  existing documents. Different axes — a font family slot versus a type role —
  so neither.
- **#10's arithmetic is backwards**, and it is the basis of a scope decision.
  There are 273 docx goldens and 64 pptx; 31 docx fixtures name a theme and
  *none* of the 113 pptx cases does. Theme-less docx resolves to `minimal`,
  which is exactly what #331 repoints — so the 26 pinning `minimal` are the ones
  that would NOT move, and unpinned #331 moves ~306 goldens, not 26. Corrected
  in place rather than left for a reader to trust.

The map's header now records that tasks 1 and 2 are done (#355), and that task 8
splits to #328b per decision 5. **Phase 1 starts at task 3.**

## Evals

**`fix(evals)`** catches a run set that straddles a rebuild, and **`feat(evals)`**
measures the judge against itself. Both from the parallel session; included here
because they landed on this branch.

## Verified

- `pnpm exec turbo test --concurrency=1` — 5,102 tests, 22 packages, green
- `pnpm lint`, `pnpm typecheck`, `pnpm docs:build`, prettier — clean

## Note on the branch name

It says `pptx-bundled-theme-guard` and carries two evals commits as well,
because two sessions pushed to it. The commits are independently scoped; the
name is just narrower than the contents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `rejudge` command to reevaluate recorded document sets without regenerating them.
  - Reports per-field agreement, Cohen’s kappa, and significant rating changes.
  - Evaluation runs now detect and warn when the product changes during execution.

- **Bug Fixes**
  - Added validation for bundled PPTX themes, including registry names and JSON compatibility.
  - Prevents invalid themes from causing failures during document compilation.

- **Documentation**
  - Documented rejudging workflows, judge reliability findings, and updated the architecture roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->