### PR TITLE
Make a forgotten valued option a compile error

### DIFF
--- a/packages/design-evals/src/rejudge-cli.ts
+++ b/packages/design-evals/src/rejudge-cli.ts
@@ -7,8 +7,18 @@ import { rejudge, type RejudgedRun } from './rejudge.js';
 
 /** Options that take a value, so their value is never read as the runs dir. */
 const VALUED_OPTIONS = ['scorecard', 'judge', 'briefs'] as const;
+type ValuedOption = (typeof VALUED_OPTIONS)[number];
 
-function value(argv: readonly string[], name: string): string | undefined {
+/**
+ * `name` is narrowed to the declared list on purpose. A valued option added
+ * here and forgotten in `VALUED_OPTIONS` is exactly how the runs directory
+ * came to be read from an option's value; typing it makes that a compile
+ * error instead of a silent one.
+ */
+function value(
+  argv: readonly string[],
+  name: ValuedOption
+): string | undefined {
   const index = argv.indexOf(`--${name}`);
   if (index === -1) return undefined;
   const next = argv[index + 1];


### PR DESCRIPTION
Follow-up to #357, which merged while this was being written.

#357 fixed the rejudge CLI reading an option's *value* as its positional argument — `--scorecard out/sc.json runs/foo` resolved a runs directory of `out/sc.json`. The fix declares the valued options in one list:

```ts
const VALUED_OPTIONS = ['scorecard', 'judge', 'briefs'] as const;
```

But `value()` took a bare `string`, so an option added to the CLI and left out of that list silently reintroduces the same bug. Narrowing the parameter to the declared union turns it into a type error at the call site instead.

Verified by renaming one call to an undeclared option:

```
src/rejudge-cli.ts(90,29): error TS2345: Argument of type '"model"' is not
assignable to parameter of type '"scorecard" | "judge" | "briefs"'.
```

One file, eleven lines, no behaviour change. `typecheck` and 144 design-evals tests green on top of main.