### PR TITLE
feat(themes): add shared visual foundation

### DIFF
--- a/.changeset/schema-validate-stack.md
+++ b/.changeset/schema-validate-stack.md
@@ -1,0 +1,5 @@
+---
+'@json-to-office/jto-cli': patch
+---
+
+Validate against an exported JSON Schema on a worker thread with an explicit stack size, and stop asking Ajv for `verbose` errors. The generated DOCX schema compiles to one very large validator function per recursive definition, and its stack frame no longer fit the main thread's stack: validation threw `RangeError: Maximum call stack size exceeded` instead of reporting schema errors. Error paths, messages and values are unchanged.

--- a/.changeset/shared-theme-foundation.md
+++ b/.changeset/shared-theme-foundation.md
@@ -1,0 +1,9 @@
+---
+'@json-to-office/shared': minor
+'@json-to-office/shared-docx': minor
+'@json-to-office/shared-pptx': minor
+'@json-to-office/core-docx': minor
+'@json-to-office/core-pptx': minor
+---
+
+Add shared palette, typography and canvas-spacing theme layers for DOCX and PPTX. Named roles compile into native styles, ordered chart palettes reach both chart paths, and quality checks recognize the extended colors. Fix DOCX theme font weights and support case formatting. Preserve existing theme defaults; chrome/motif recipes are schema contracts for later consumers.

--- a/docs/architecture/office-renderer-ir.md
+++ b/docs/architecture/office-renderer-ir.md
@@ -885,6 +885,20 @@ relationship or make deterministic renumbering miss a newly-added part.
 | `packages/core-docx/src/utils/packageDocument.ts`                 | Generic DOCX relationship-id, core-metadata and ZIP timestamp canonicalization                | Relationship parts and owners, `docProps/core.xml`, ZIP entry headers                      | Final DOCX pass, after every backend-specific repair                                             |
 | `packages/core-pptx/src/core/finalizePackage.ts`                  | Generic PPTX chart-id, nested-package, core-metadata and ZIP timestamp canonicalization       | Chart names and references, embedded Office packages, `docProps/core.xml`, ZIP entry dates | Final PPTX pass, after chart and PptxGenJS-specific repairs                                      |
 
+## Theme foundation golden changes (#328)
+
+`theme/font-numeric-weights` changes intentionally: DOCX theme-level weights now
+reach Word styles as synthetic family names and bold/italic flags. All other
+existing corpus digests remain unchanged. New `theme/shared-foundation` cases in
+both formats cover palette tokens, named roles, canvas scale/spacing and case.
+The DOCX case uses vermilion with additive overrides; no bundled theme is restyled.
+
+Both DOCX writers emit only one of caps/smallCaps. Package finalization now adds
+the opposite false flag, allowing `case: none` to reset an inherited case style.
+This repair also runs with deterministic output disabled. PPTX case is lowered
+to text runs in the compiler; synthetic small caps use 80% size for lowercase
+spans. Chrome/motif contracts do not render until #361.
+
 ## Source map
 
 | Concern                                             | Path                                                                                           |

--- a/docs/architecture/office-renderer-ir.md
+++ b/docs/architecture/office-renderer-ir.md
@@ -894,7 +894,8 @@ both formats cover palette tokens, named roles, canvas scale/spacing and case.
 The DOCX case uses vermilion with additive overrides; no bundled theme is restyled.
 
 Both DOCX writers emit only one of caps/smallCaps. Package finalization now adds
-the opposite false flag, allowing `case: none` to reset an inherited case style.
+the opposite false flag next to the flag already present — `CT_RPr` is an ordered
+sequence — allowing `case: none` to reset an inherited case style.
 This repair also runs with deterministic output disabled. PPTX case is lowered
 to text runs in the compiler; synthetic small caps use 80% size for lowercase
 spans. Chrome/motif contracts do not render until #361.

--- a/docs/guide/themes.md
+++ b/docs/guide/themes.md
@@ -56,6 +56,51 @@ The pptx `chart` and the `highcharts` component in **both** formats default thei
 A theme that fills only some of them behaves identically in both formats too: the unset slot is dropped, the palette is only as long as the theme has tokens defined, and the chart library reuses that shorter list. No warning is emitted — the fallback rule above governs a token named _explicitly_, not the implicit chart palette. Every built-in DOCX theme fills `accent4`–`accent6`, so a docx chart on a bundled theme draws from six curated series colors. See [Charts](/guide/charts#theme-palette).
 :::
 
+## Shared visual roles
+
+Add a type ladder and palette without changing a bundled theme. For example, use this root on a DOCX document:
+
+```json
+{
+  "name": "docx",
+  "props": {
+    "theme": "vermilion",
+    "themeOverrides": {
+      "palette": {
+        "rule": "#58595B",
+        "textMuted": "rule",
+        "chart": ["primary", "accent", "rule"]
+      },
+      "typography": {
+        "roles": {
+          "display": {
+            "face": "heading",
+            "weight": 300,
+            "case": "upper",
+            "color": "primary"
+          },
+          "source": { "size": 9, "color": "textMuted" }
+        },
+        "scale": { "a4": { "base": 12, "ratio": 1.25, "baselinePt": 4 } }
+      },
+      "spacing": { "canvas": { "a4": { "safeAreaIn": 0.75 } } }
+    }
+  },
+  "children": [
+    {
+      "name": "paragraph",
+      "props": { "text": "A stronger report", "themeStyle": "display" }
+    },
+    {
+      "name": "paragraph",
+      "props": { "text": "Source: field observations", "themeStyle": "source" }
+    }
+  ]
+}
+```
+
+PPTX themes accept the same layers; use `wide169` or `standard43` scales and `style: "display"` on text. A theme controls visual values only. It does not require a title, source line or any other content. Chrome and motif recipes currently store values for later rendering work. See the [shared visual reference](/reference/theme-schema#shared-visual-layers) for precedence, units and case behavior.
+
 ## Built-in themes
 
 ### DOCX themes

--- a/docs/reference/theme-schema.md
+++ b/docs/reference/theme-schema.md
@@ -2,7 +2,60 @@
 
 Precise reference for both theme file formats: the DOCX `ThemeConfig` (validated against the generated `theme.schema.json`) and the PPTX `ThemeConfig` (usually supplied inline on `props.theme`). For the conceptual guide — tokens, built-ins, cascades — see [Themes & styling](/guide/themes).
 
+## Shared visual layers
+
+These optional roots use the same schema in DOCX and PPTX. DOCX also accepts them in `props.themeOverrides`, deep-merging objects and replacing arrays. PPTX accepts them in an inline `props.theme` or a registered theme. `jto://themes/values` preserves all these values; `jto://themes` retains its list of names.
+
+Themes specify appearance. They never require content, an archetype, action titles, sources, trackers, footers or density. Blueprints and quality profiles own those expectations. A coordinate-authored document can use every theme without adding chrome.
+
+### `palette`
+
+Optional scalar keys: `rule`, `textMuted`, `onPrimary`, `surfaceInverse`, `positive`, `negative`. Values are six-digit hex (optional `#`) or references to legacy `colors` or these palette keys. Palette keys take precedence over same-named legacy colors; unknown targets and cycles fail generation.
+
+`chart` is an ordered array of 1–12 such colors. Native charts and Highcharts use it when the author provides no chart colors. Without it, the existing six-token chart palette applies. Quality checks recognize these additional colors.
+
+PPTX component color enums are unchanged: reference new roles inside themes, or use their resolved hex in component props. DOCX component colors can reference new palette names directly.
+
+### `typography`
+
+`roles` accepts `eyebrow`, `display`, `stat`, `quote`, `label`, `footer`, `tableHeader`, `tableCell`, `chartLabel`, `tracker`, `source`. Only declared roles are materialized; role names alone do not restyle existing components.
+
+| Role field                  | Meaning                                                                                                               |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `face`                      | `heading`, `body`, `mono`, `light`; defaults to body. PPTX missing mono falls back to body, missing light to heading. |
+| `weight`                    | Integer 100–900. Overrides bold; numeric weights use the existing synthetic-family mechanism.                         |
+| `size`                      | Explicit 5–200 points; wins over the canvas scale.                                                                    |
+| `lineHeight`                | Line-height multiple, 0.5–3.                                                                                          |
+| `tracking`                  | Hundredths of an em, negative for condensed tracking.                                                                 |
+| `case`                      | `none`, `upper`, `smallCaps`.                                                                                         |
+| `color`                     | Hex or theme token.                                                                                                   |
+| `spaceBefore`, `spaceAfter` | Nonnegative points.                                                                                                   |
+
+Use `themeStyle: "display"` on a DOCX paragraph or `style: "display"` on PPTX text/shape. Native `styles.<role>` fields override projected role fields, and explicit component formatting wins. DOCX `font.case` and native theme styles accept the same case values; PPTX native text styles also accept `case` and `paraSpaceBefore`.
+
+DOCX writes native caps/small-caps formatting and preserves text. PPTX writes uppercase output text; small caps are emulated by uppercasing lowercase spans at 80% of the run size. Authored JSON remains unchanged. This is not OpenType small-cap glyph selection.
+
+`scale.<canvas>` takes required `base` (5–200 pt), optional `ratio` (1–2, default 1.25) and `baselinePt` (>0–24, default 4). Derived size is `base × ratio^step`, snapped to the nearest baseline step and clamped to 5–200 pt. Steps: display 4, stat 3, quote 1, tableHeader/tableCell 0, eyebrow/label/chartLabel/tracker −1, footer/source −2. Without a canvas scale, roles use the existing body/default size.
+
+Canvas keys are `a4`, `letter`, `wide169`, `standard43`. DOCX uses `theme.page.size`: LETTER selects letter; A4, A3, LEGAL and custom dimensions use a4. PPTX selects the closest of 16:9 and 4:3 from document dimensions (default 10 × 7.5 inches); ties use standard43. There is no authored canvas identifier.
+
+### `spacing`
+
+`canvas.<canvas>` accepts nonnegative `safeAreaIn` and `gutterIn`, and integer `columns`/`rows` (1–100). DOCX maps safe area to four page margins and gutter to the page gutter, converting inches to twips; section/page overrides still apply. PPTX uses them as grid defaults; document/slide/template grid overrides win. Absolute PPTX coordinates remain absolute.
+
+`basePt` (>0) and `blockGap.tight/normal/loose` (≥0) are spacing values in points. DOCX normal-style spacing falls back to `blockGap.normal`, then `basePt`, when native normal-style spacing is absent. Its normal size similarly falls back to the selected scale base. Tight/loose gaps and DOCX grid rows/columns are reserved for semantic block consumers; they do not insert blocks or columns. PPTX block gaps are values for those later consumers, not automatic coordinate rearrangement.
+
+### `chrome` and `motif`
+
+Schema contracts only in this foundation; rendering consumers are tracked in #361. No content is inserted.
+
+`chrome` optionally contains `runningHead`, `tracker`, `actionTitle`, `keyTakeaways`, `sourceLine`, `confidentialFooter`, `logoSlot`, `cover`. Each recipe accepts `type` (a role name), `color`, `fill`, `rule: { weightPt, color }`, `padPt` and `alignment` (left/center/right). Weights/padding are nonnegative points.
+
+`motif` is a single object with required `kind` (none/rule/corner/band), optional `color`, `weightPt` and `placement`. Recipe colors are stored for later consumers. Neither schema accepts content requirements.
+
 ## DOCX theme
+
+Both formats also accept the five optional [shared visual layers](#shared-visual-layers). Existing themes need none of them.
 
 A DOCX theme is a JSON object (conventionally a `*.docx.theme.json` file). Unknown top-level properties are rejected (`additionalProperties: false`).
 
@@ -161,6 +214,8 @@ When a theme is loaded programmatically, missing optional pieces are filled from
 :::
 
 ## PPTX theme
+
+Also accepts optional `displayName`, `description`, `version` and the [shared visual layers](#shared-visual-layers). `fonts.mono` and `fonts.light` are optional family strings for type roles.
 
 A PPTX theme is a plain object, most often supplied **inline** on the presentation's `props.theme` (see [Themes & styling](/guide/themes#custom-themes)). Unknown top-level properties are rejected (`additionalProperties: false`). `jto pptx schemas` emits a PPTX `theme.schema.json` generated from this ThemeConfig schema — the format parent determines which theme schema is generated (see [JSON schemas](/reference/json-schemas)).
 

--- a/docs/reference/theme-schema.md
+++ b/docs/reference/theme-schema.md
@@ -35,7 +35,7 @@ Use `themeStyle: "display"` on a DOCX paragraph or `style: "display"` on PPTX te
 
 DOCX writes native caps/small-caps formatting and preserves text. PPTX writes uppercase output text; small caps are emulated by uppercasing lowercase spans at 80% of the run size. Authored JSON remains unchanged. This is not OpenType small-cap glyph selection.
 
-`scale.<canvas>` takes required `base` (5–200 pt), optional `ratio` (1–2, default 1.25) and `baselinePt` (>0–24, default 4). Derived size is `base × ratio^step`, snapped to the nearest baseline step and clamped to 5–200 pt. Steps: display 4, stat 3, quote 1, tableHeader/tableCell 0, eyebrow/label/chartLabel/tracker −1, footer/source −2. Without a canvas scale, roles use the existing body/default size.
+`scale.<canvas>` takes required `base` (5–200 pt), optional `ratio` (1–2, default 1.25) and `baselinePt` (>0–24, default 4). Derived size is `base × ratio^step`, snapped to the nearest multiple of `baselinePt` and clamped to 5–200 pt. A step-0 role keeps `base` exactly, unsnapped. Steps: display 4, stat 3, quote 1, tableHeader/tableCell 0, eyebrow/label/chartLabel/tracker −1, footer/source −2. Without a canvas scale, roles use the existing body/default size.
 
 Canvas keys are `a4`, `letter`, `wide169`, `standard43`. DOCX uses `theme.page.size`: LETTER selects letter; A4, A3, LEGAL and custom dimensions use a4. PPTX selects the closest of 16:9 and 4:3 from document dimensions (default 10 × 7.5 inches); ties use standard43. There is no authored canvas identifier.
 
@@ -51,7 +51,7 @@ Schema contracts only in this foundation; rendering consumers are tracked in #36
 
 `chrome` optionally contains `runningHead`, `tracker`, `actionTitle`, `keyTakeaways`, `sourceLine`, `confidentialFooter`, `logoSlot`, `cover`. Each recipe accepts `type` (a role name), `color`, `fill`, `rule: { weightPt, color }`, `padPt` and `alignment` (left/center/right). Weights/padding are nonnegative points.
 
-`motif` is a single object with required `kind` (none/rule/corner/band), optional `color`, `weightPt` and `placement`. Recipe colors are stored for later consumers. Neither schema accepts content requirements.
+`motif` is a single object with required `kind` (none/rule/corner/band), optional `color`, `weightPt` and `placement` (`top`, `bottom`, `left`, `right`, `topLeft`, `topRight`, `bottomLeft`, `bottomRight`). Recipe colors are stored for later consumers. Neither schema accepts content requirements.
 
 ## DOCX theme
 

--- a/packages/core-docx/src/__tests__/design-system.test.ts
+++ b/packages/core-docx/src/__tests__/design-system.test.ts
@@ -159,6 +159,18 @@ describe('DOCX theme foundation', () => {
       )?.[0];
       expect(explicit).toContain('<w:caps w:val="false"/>');
       expect(explicit).toMatch(/<w:smallCaps w:val="(?:false|0)"\/>/);
+      // CT_RPr is an ordered sequence: w:caps, then w:smallCaps, then the rest.
+      const runProperties = /<w:rPr\b[^>]*>[\s\S]*?<\/w:rPr>/.exec(
+        explicit ?? ''
+      )?.[0];
+      const caps = runProperties?.indexOf('<w:caps') ?? -1;
+      const smallCaps = runProperties?.indexOf('<w:smallCaps') ?? -1;
+      expect(caps).toBeGreaterThanOrEqual(0);
+      expect(smallCaps).toBeGreaterThan(caps);
+      for (const later of ['<w:strike', '<w:color', '<w:sz', '<w:spacing']) {
+        const at = runProperties?.indexOf(later) ?? -1;
+        if (at >= 0) expect(at).toBeGreaterThan(smallCaps);
+      }
       expect(explicit).toContain('Arial Black');
       expect(
         Object.keys(a.files).some((name) =>

--- a/packages/core-docx/src/__tests__/design-system.test.ts
+++ b/packages/core-docx/src/__tests__/design-system.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import JSZip from 'jszip';
+import { Value } from '@sinclair/typebox/value';
+import {
+  ThemeConfigSchema,
+  ThemeOverridesSchema,
+} from '@json-to-office/shared-docx';
+import { generateBufferFromJson } from '../core/generator';
+import { createDocumentGenerator } from '../plugin/createDocumentGenerator';
+import { vermilionTheme } from '../templates/themes';
+import { applyThemeOverrides } from '../themes/overrides';
+import { resolveDocxDesignSystem } from '../themes/design-system';
+import { prepareDocxQualityDocument } from '../quality/facts';
+
+export const foundation = {
+  palette: {
+    rule: '#123456',
+    textMuted: 'rule',
+    positive: '#337755',
+    chart: ['positive', 'rule'],
+  },
+  typography: {
+    roles: {
+      display: {
+        face: 'heading' as const,
+        weight: 300,
+        case: 'upper' as const,
+        color: 'textMuted',
+        lineHeight: 1.5,
+        tracking: 2,
+      },
+      source: { size: 9, case: 'smallCaps' as const },
+    },
+    scale: { a4: { base: 12, ratio: 1.25, baselinePt: 4 } },
+  },
+  spacing: { canvas: { a4: { safeAreaIn: 0.5, gutterIn: 0.1 } } },
+  chrome: { actionTitle: { type: 'display' as const } },
+  motif: { kind: 'rule' as const, color: 'rule' },
+};
+const document = {
+  name: 'docx',
+  props: { theme: 'vermilion', themeOverrides: foundation },
+  children: [
+    {
+      name: 'section',
+      children: [
+        {
+          name: 'paragraph',
+          props: { text: 'Mixed Case', themeStyle: 'display' },
+        },
+        {
+          name: 'paragraph',
+          props: { text: 'A source', themeStyle: 'source' },
+        },
+        {
+          name: 'paragraph',
+          props: {
+            text: 'Explicit',
+            themeStyle: 'display',
+            font: { size: 14, case: 'none', color: '#ABCDEF', fontWeight: 900 },
+          },
+        },
+      ],
+    },
+  ],
+};
+
+describe('DOCX theme foundation', () => {
+  it('exposes the extended palette to quality checks', () => {
+    const prepared = prepareDocxQualityDocument(document as never);
+    const fact = prepared.facts.find((entry) => entry.kind === 'docx/theme');
+    expect(fact).toMatchObject({
+      paletteHexes: { rule: '#123456', positive: '#337755' },
+    });
+  });
+
+  it('applies the ordered palette to native charts', async () => {
+    const input = {
+      name: 'docx',
+      renderer: 'office-open',
+      props: document.props,
+      children: [
+        {
+          name: 'chart',
+          props: {
+            type: 'bar',
+            data: [
+              { name: 'Revenue', labels: ['Q1'], values: [10] },
+              { name: 'Cost', labels: ['Q1'], values: [5] },
+            ],
+          },
+        },
+      ],
+    };
+    const zip = await JSZip.loadAsync(
+      await generateBufferFromJson(input as never)
+    );
+    const charts = await Promise.all(
+      Object.keys(zip.files)
+        .filter((path) => /word\/charts\/chart\d+\.xml$/.test(path))
+        .map((path) => zip.file(path)!.async('string'))
+    );
+    expect(charts).toHaveLength(1);
+    expect(charts[0]).toContain('337755');
+    expect(charts[0]).toContain('123456');
+  });
+  it('validates on both theme and override surfaces; preserves values', () => {
+    const theme = applyThemeOverrides(vermilionTheme, foundation);
+    expect(Value.Check(ThemeOverridesSchema, foundation)).toBe(true);
+    expect(Value.Check(ThemeConfigSchema, theme)).toBe(true);
+    const merged = applyThemeOverrides(theme, {
+      palette: { chart: ['rule'] },
+      typography: { roles: { display: { size: 32 } } },
+    });
+    expect(merged.palette).toEqual({ ...foundation.palette, chart: ['rule'] });
+    expect(merged.typography?.roles?.display).toEqual({
+      ...foundation.typography.roles.display,
+      size: 32,
+    });
+    expect(theme.typography?.roles?.display).not.toHaveProperty('size');
+    expect(resolveDocxDesignSystem(theme).styles?.display).toMatchObject({
+      size: 28,
+      fontWeight: 300,
+      case: 'upper',
+    });
+  });
+
+  for (const renderer of ['docxjs', 'office-open'] as const) {
+    it(`renders roles, spacing and explicit overrides through both ${renderer} pipelines`, async () => {
+      const input = { ...document, renderer };
+      const core = await generateBufferFromJson(
+        structuredClone(input) as never
+      );
+      const plugin = await createDocumentGenerator({}).generateBuffer(
+        structuredClone(input) as never
+      );
+      const a = await JSZip.loadAsync(core);
+      const b = await JSZip.loadAsync(plugin.buffer);
+      for (const part of ['word/document.xml', 'word/styles.xml'])
+        expect(await b.file(part)!.async('string')).toBe(
+          await a.file(part)!.async('string')
+        );
+      const styles = await a.file('word/styles.xml')!.async('string');
+      const display = styles.match(
+        /<w:style\b[^>]*w:styleId="display"[\s\S]*?<\/w:style>/
+      )?.[0];
+      expect(display).toContain('w:sz w:val="56"');
+      expect(display).toContain('Light');
+      expect(display).toContain('123456');
+      expect(display).toContain('w:caps');
+      expect(styles).toContain('w:smallCaps');
+      const xml = await a.file('word/document.xml')!.async('string');
+      expect(xml).toContain('w:pStyle w:val="display"');
+      expect(xml).toContain('w:left="720"');
+      expect(xml).toContain('w:sz w:val="28"');
+      expect(xml).toContain('ABCDEF');
+      const explicit = [...xml.matchAll(/<w:r>[\s\S]*?<\/w:r>/g)].find(
+        ([run]) => run.includes('Explicit')
+      )?.[0];
+      expect(explicit).toContain('<w:caps w:val="false"/>');
+      expect(explicit).toMatch(/<w:smallCaps w:val="(?:false|0)"\/>/);
+      expect(explicit).toContain('Arial Black');
+      expect(
+        Object.keys(a.files).some((name) =>
+          /word\/(header|footer)\d/.test(name)
+        )
+      ).toBe(false);
+    });
+  }
+});

--- a/packages/core-docx/src/__tests__/fixtures/corpus-goldens.ts
+++ b/packages/core-docx/src/__tests__/fixtures/corpus-goldens.ts
@@ -18,6 +18,8 @@
  */
 
 export const CORPUS_GOLDENS: Readonly<Record<string, string>> = {
+  'theme/shared-foundation':
+    '0cd1445e4de233d4f50d96eb52a15bd94e3d06186c1850650953ac3334a77b6f',
   'text/plain':
     'd488d552102350e37f866b6354c3f20b52fe2918e8dfd61223ae6f340b3b566b',
   'text/empty-and-whitespace':
@@ -545,7 +547,7 @@ export const CORPUS_GOLDENS: Readonly<Record<string, string>> = {
   'theme/font-registry-safe-families':
     '0687f66c26d4b671ab1ef4caa31463bf2e5452ae54a6d079916b0fea7b158219',
   'theme/font-numeric-weights':
-    '32a59d602b5e51c600f3773637a86d53ef41c563177b770c1015013f0cb3297c',
+    'f7420c8b81e661fb401aeaf5e18557e4d3e1882bd440beab8ecad90916a1f1fe',
   'theme/toc-entry-styles':
     '64815d016ab0ed929d167fd7d7d17942d2fa190eb21c99f2299e872e0d59c562',
   'theme/component-defaults-document':

--- a/packages/core-docx/src/__tests__/fixtures/corpus-goldens.ts
+++ b/packages/core-docx/src/__tests__/fixtures/corpus-goldens.ts
@@ -19,7 +19,7 @@
 
 export const CORPUS_GOLDENS: Readonly<Record<string, string>> = {
   'theme/shared-foundation':
-    '0cd1445e4de233d4f50d96eb52a15bd94e3d06186c1850650953ac3334a77b6f',
+    'd4d5649f4c5089dd7562a2e5142bdc45c2a2988ab5c7514ff5a3a4d2dc8465bb',
   'text/plain':
     'd488d552102350e37f866b6354c3f20b52fe2918e8dfd61223ae6f340b3b566b',
   'text/empty-and-whitespace':

--- a/packages/core-docx/src/__tests__/fixtures/corpus-theme.ts
+++ b/packages/core-docx/src/__tests__/fixtures/corpus-theme.ts
@@ -13,16 +13,14 @@
  * for exactly one of them names a single theme file, and one that moves for all
  * three names the theme→docx adapter.
  *
- * Two corners are deliberately absent:
+ * A deliberately absent corner:
  *
  * - A colour token that is not in the palette. `resolveColor` throws
  *   `Invalid color value: "…"` rather than degrading, so such a document is a
  *   validation failure, not a corpus case.
- * - A custom style name in `themeStyle`. `theme.styles` accepts arbitrary keys,
- *   but the docx adapter only maps the nine predefined ones
- *   (normal, heading1..6, title, subtitle) and warns-and-ignores anything else,
- *   so the extra key would not reach the package. `theme/toc-entry-styles`
- *   covers the one family of non-predefined styles that does — TOC1..TOC6.
+ * Custom theme styles, including the new type roles, compile to Word styles.
+ * `theme/shared-foundation` covers their projection; `theme/toc-entry-styles`
+ * covers the canonical TOC1..TOC6 identifiers.
  *
  * The two shipped example documents are imported rather than copied, so they
  * keep tracking `templates/documents/` as it changes. `inlineImages` swaps any
@@ -196,6 +194,46 @@ function inlineImages<T>(node: T): T {
 }
 
 export const CASES: CorpusCase[] = [
+  {
+    name: 'theme/shared-foundation',
+    document: page(
+      [
+        p({ text: 'A shared visual system', themeStyle: 'display' }),
+        p({ text: 'Source: field observations', themeStyle: 'source' }),
+        p({
+          text: 'Explicit override',
+          themeStyle: 'display',
+          font: { case: 'none', size: 12 },
+        }),
+      ],
+      {
+        theme: 'vermilion',
+        themeOverrides: {
+          palette: {
+            rule: '#123456',
+            textMuted: 'rule',
+            chart: ['rule', '#337755'],
+          },
+          typography: {
+            roles: {
+              display: {
+                face: 'heading',
+                weight: 300,
+                case: 'upper',
+                color: 'textMuted',
+                tracking: 2,
+              },
+              source: { size: 9, case: 'smallCaps' },
+            },
+            scale: { a4: { base: 12, ratio: 1.25, baselinePt: 4 } },
+          },
+          spacing: { canvas: { a4: { safeAreaIn: 0.5 } } },
+          chrome: { sourceLine: { type: 'source' } },
+          motif: { kind: 'rule', color: 'rule' },
+        },
+      }
+    ),
+  },
   // --------------------------------------------------------------------------
   // The bundled themes — one body, one case per theme
   // --------------------------------------------------------------------------

--- a/packages/core-docx/src/components/__tests__/highcharts.test.ts
+++ b/packages/core-docx/src/components/__tests__/highcharts.test.ts
@@ -645,6 +645,31 @@ describe('components/highcharts', { timeout: 30000 }, () => {
   });
 
   describe('theme palette injection', () => {
+    it('uses the ordered visual palette and preserves explicit chart colors', async () => {
+      const theme = {
+        ...devportalTheme,
+        palette: {
+          positive: '#337755',
+          rule: '#123456',
+          chart: ['positive', 'rule'],
+        },
+      };
+      const options = {
+        chart: { width: 600, height: 400 },
+        series: [{ type: 'bar', data: [1, 2] }],
+      };
+      await renderChartToImageProps({ options } as never, theme);
+      expect(JSON.parse(mockFetch.mock.calls[0][1].body).infile.colors).toEqual(
+        ['#337755', '#123456']
+      );
+      await renderChartToImageProps(
+        { options: { ...options, colors: ['#ABCDEF'] } } as never,
+        theme
+      );
+      expect(JSON.parse(mockFetch.mock.calls[1][1].body).infile.colors).toEqual(
+        ['#ABCDEF']
+      );
+    });
     const chartComponent = {
       name: 'highcharts' as const,
       props: {

--- a/packages/core-docx/src/components/highcharts.ts
+++ b/packages/core-docx/src/components/highcharts.ts
@@ -123,12 +123,14 @@ function withThemeColors(
   const options = config.options as Record<string, unknown> | undefined;
   if (!options || options.colors || !theme?.colors) return config;
   const themeColors = theme.colors as Record<string, string | undefined>;
-  const palette = DEFAULT_CHART_THEME_COLORS.map((token) => {
-    const value = themeColors[token];
-    return typeof value === 'string' && value.length > 0
-      ? toChartColor(value, theme)
-      : undefined;
-  }).filter((c): c is string => c !== undefined);
+  const palette = theme.palette?.chart
+    ? theme.palette.chart.map((value) => `#${resolveColor(value, theme)}`)
+    : DEFAULT_CHART_THEME_COLORS.map((token) => {
+        const value = themeColors[token];
+        return typeof value === 'string' && value.length > 0
+          ? toChartColor(value, theme)
+          : undefined;
+      }).filter((c): c is string => c !== undefined);
   if (palette.length === 0) return config;
   return {
     ...config,

--- a/packages/core-docx/src/components/highcharts.ts
+++ b/packages/core-docx/src/components/highcharts.ts
@@ -8,14 +8,13 @@
  */
 
 import { ThemeConfig } from '../styles';
-import { resolveColor } from '../styles/utils/colorUtils';
+import { chartPaletteValues, resolveColor } from '../styles/utils/colorUtils';
 import { isNodeEnvironment } from '../utils/environment';
 import { resolveServiceUrl, postJsonToService } from '../utils/serviceClient';
 
 // Import only the types we actually use from shared package
 import type { HighchartsProps } from '@json-to-office/shared-docx';
 import type { HighchartsServiceConfig } from '@json-to-office/shared';
-import { DEFAULT_CHART_THEME_COLORS } from '@json-to-office/shared';
 
 // Re-export HighchartsProps for backward compatibility
 export type { HighchartsProps } from '@json-to-office/shared-docx';
@@ -113,8 +112,9 @@ function toChartColor(value: string, theme: ThemeConfig): string | undefined {
  * series colors so charts follow the theme by default. accent4-6 are optional
  * in the theme schema; slots the theme leaves unset are skipped, in both
  * formats, so the palette never carries gaps or repeats and Highcharts wraps
- * the shorter list (see DEFAULT_CHART_THEME_COLORS). Explicit `colors` always
- * wins.
+ * the shorter list (see DEFAULT_CHART_THEME_COLORS). A theme declaring
+ * `palette.chart` supplies that list instead, in its own order. Explicit
+ * `colors` always wins.
  */
 function withThemeColors(
   config: HighchartsProps,
@@ -122,15 +122,10 @@ function withThemeColors(
 ): HighchartsProps {
   const options = config.options as Record<string, unknown> | undefined;
   if (!options || options.colors || !theme?.colors) return config;
-  const themeColors = theme.colors as Record<string, string | undefined>;
-  const palette = theme.palette?.chart
-    ? theme.palette.chart.map((value) => `#${resolveColor(value, theme)}`)
-    : DEFAULT_CHART_THEME_COLORS.map((token) => {
-        const value = themeColors[token];
-        return typeof value === 'string' && value.length > 0
-          ? toChartColor(value, theme)
-          : undefined;
-      }).filter((c): c is string => c !== undefined);
+  const palette = chartPaletteValues(theme).flatMap((value) => {
+    const color = toChartColor(value, theme);
+    return color ? [color] : [];
+  });
   if (palette.length === 0) return config;
   return {
     ...config,

--- a/packages/core-docx/src/core/generationContext.ts
+++ b/packages/core-docx/src/core/generationContext.ts
@@ -22,6 +22,7 @@ import type {
 import { applyExportMode } from '@json-to-office/shared';
 import { resolveBuiltInTheme } from '../styles/theme-resolver';
 import { applyThemeOverrides } from '../themes/overrides';
+import { resolveDocxDesignSystem } from '../themes/design-system';
 
 export interface ThemeContextOptions {
   customThemes?: { [key: string]: ThemeConfig };
@@ -112,6 +113,7 @@ export function resolveThemeContext(
 
   // Export-mode pre-pass: substitute (default) rewrites non-safe families to
   // safe equivalents; custom keeps refs as-is.
+  theme = resolveDocxDesignSystem(theme);
   const mode = applyExportMode({ doc: document, theme, fonts });
   for (const w of mode.warnings) {
     if (warnings) {

--- a/packages/core-docx/src/ir/compiler.ts
+++ b/packages/core-docx/src/ir/compiler.ts
@@ -22,7 +22,11 @@ import {
   FeatureRequirementCollector,
   type FeatureRequirement,
 } from '@json-to-office/shared/rendering';
-import type { GenerationWarning } from '@json-to-office/shared';
+import type {
+  GenerationWarning,
+  TypeRoleName,
+  TypeRole,
+} from '@json-to-office/shared';
 import {
   synthesizeFamilyName,
   DEFAULT_CHART_THEME_COLORS,
@@ -834,6 +838,7 @@ function compileChromeParagraph(
       italic: font.italic ?? false,
       ...(font.underline !== undefined ? { underline: font.underline } : {}),
       ...(font.fontWeight !== undefined ? { fontWeight: font.fontWeight } : {}),
+      ...(font.case !== undefined ? { case: font.case } : {}),
       ...(font.lineSpacing !== undefined
         ? { lineSpacing: font.lineSpacing }
         : {}),
@@ -3105,9 +3110,20 @@ function runFormatting(
   ctx: CompileContext
 ): DocxIrRunFormatting {
   const hasWeightRequest = font.fontWeight != null || font.bold === true;
+  const roleName = props.themeStyle as string | undefined;
+  const role = roleName
+    ? ctx.theme.typography?.roles?.[roleName as TypeRoleName]
+    : undefined;
+  const roleStyles = ctx.theme.styles as
+    | Record<string, { font?: TypeRole['face'] }>
+    | undefined;
+  const roleFamily =
+    role && roleName
+      ? resolveFontFamily(ctx.theme, roleStyles?.[roleName]?.font ?? role.face)
+      : undefined;
   const effectiveFamily =
     font.family ??
-    (hasWeightRequest ? resolveBodyFamily(ctx.theme) : undefined);
+    (hasWeightRequest ? roleFamily ?? resolveBodyFamily(ctx.theme) : undefined);
 
   const weighted = applyFontWeightAlias({
     fontFamily: effectiveFamily,
@@ -3117,7 +3133,11 @@ function runFormatting(
   });
 
   const formatting: DocxIrRunFormatting = {};
-  if (font.family || (weighted.font && weighted.font !== effectiveFamily)) {
+  if (
+    font.family ||
+    (hasWeightRequest && roleFamily) ||
+    (weighted.font && weighted.font !== effectiveFamily)
+  ) {
     formatting.fontFamily = weighted.font;
   }
   if (font.size) formatting.sizeHalfPoints = pointsToHalfPoints(font.size);
@@ -3129,6 +3149,10 @@ function runFormatting(
     formatting.underline = font.underline ? { type: 'single' } : undefined;
   }
   if (font.scale) formatting.scalePercent = font.scale;
+  if (font.case !== undefined) {
+    if (font.case === 'upper') formatting.allCaps = true;
+    else formatting.smallCaps = font.case === 'smallCaps';
+  }
   if (font.characterSpacing) {
     const { type, value } = font.characterSpacing as {
       type?: string;
@@ -3707,19 +3731,21 @@ function compileChart(
     ? props.chartColors.map((color: unknown) =>
         resolveColor(String(color), ctx.theme)
       )
-    : DEFAULT_CHART_THEME_COLORS.map((token) => {
-        const value = (
-          ctx.theme?.colors as Record<string, string | undefined>
-        )?.[token];
-        if (typeof value !== 'string' || value.length === 0) return undefined;
-        try {
-          return resolveColor(token, ctx.theme);
-        } catch {
-          // A slot reaching no colour is dropped, never handed on: Word
-          // answers an unparseable colour by drawing the series black.
-          return undefined;
-        }
-      }).filter((color): color is string => color !== undefined);
+    : ctx.theme.palette?.chart
+      ? ctx.theme.palette.chart.map((value) => resolveColor(value, ctx.theme))
+      : DEFAULT_CHART_THEME_COLORS.map((token) => {
+          const value = (
+            ctx.theme?.colors as Record<string, string | undefined>
+          )?.[token];
+          if (typeof value !== 'string' || value.length === 0) return undefined;
+          try {
+            return resolveColor(token, ctx.theme);
+          } catch {
+            // A slot reaching no colour is dropped, never handed on: Word
+            // answers an unparseable colour by drawing the series black.
+            return undefined;
+          }
+        }).filter((color): color is string => color !== undefined);
 
   const page = getPageSetup(ctx.theme);
   const contentWidthInches =

--- a/packages/core-docx/src/ir/compiler.ts
+++ b/packages/core-docx/src/ir/compiler.ts
@@ -27,15 +27,12 @@ import type {
   TypeRoleName,
   TypeRole,
 } from '@json-to-office/shared';
-import {
-  synthesizeFamilyName,
-  DEFAULT_CHART_THEME_COLORS,
-} from '@json-to-office/shared';
+import { capsFormatting, synthesizeFamilyName } from '@json-to-office/shared';
 import type { LayoutPlan, SectionLayout } from '../core/layout';
 import type { ProcessedDocument } from '../core/structure';
 import type { ComponentDefinition } from '../types';
 import type { ThemeConfig } from '../styles';
-import { resolveColor } from '../styles/utils/colorUtils';
+import { chartPaletteValues, resolveColor } from '../styles/utils/colorUtils';
 import {
   isNativeVisualProps,
   type VisualNativeProps,
@@ -3149,10 +3146,8 @@ function runFormatting(
     formatting.underline = font.underline ? { type: 'single' } : undefined;
   }
   if (font.scale) formatting.scalePercent = font.scale;
-  if (font.case !== undefined) {
-    if (font.case === 'upper') formatting.allCaps = true;
-    else formatting.smallCaps = font.case === 'smallCaps';
-  }
+  if (font.case !== undefined)
+    Object.assign(formatting, capsFormatting(font.case));
   if (font.characterSpacing) {
     const { type, value } = font.characterSpacing as {
       type?: string;
@@ -3731,21 +3726,15 @@ function compileChart(
     ? props.chartColors.map((color: unknown) =>
         resolveColor(String(color), ctx.theme)
       )
-    : ctx.theme.palette?.chart
-      ? ctx.theme.palette.chart.map((value) => resolveColor(value, ctx.theme))
-      : DEFAULT_CHART_THEME_COLORS.map((token) => {
-          const value = (
-            ctx.theme?.colors as Record<string, string | undefined>
-          )?.[token];
-          if (typeof value !== 'string' || value.length === 0) return undefined;
-          try {
-            return resolveColor(token, ctx.theme);
-          } catch {
-            // A slot reaching no colour is dropped, never handed on: Word
-            // answers an unparseable colour by drawing the series black.
-            return undefined;
-          }
-        }).filter((color): color is string => color !== undefined);
+    : chartPaletteValues(ctx.theme).flatMap((value) => {
+        try {
+          return [resolveColor(value, ctx.theme)];
+        } catch {
+          // A slot reaching no colour is dropped, never handed on: Word
+          // answers an unparseable colour by drawing the series black.
+          return [];
+        }
+      });
 
   const page = getPageSetup(ctx.theme);
   const contentWidthInches =

--- a/packages/core-docx/src/quality/facts.ts
+++ b/packages/core-docx/src/quality/facts.ts
@@ -20,6 +20,7 @@ import type {
   GenerationWarning,
 } from '@json-to-office/shared';
 import { DEFAULT_DOCX_RENDERER_ID } from '@json-to-office/shared-docx';
+import { designColors, resolveDesignColor } from '@json-to-office/shared';
 import type { ComponentDefinition, ReportComponentDefinition } from '../types';
 import type { ThemeConfig } from '../styles';
 import {
@@ -908,16 +909,29 @@ export function prepareDocxQualityDocument(
   };
 
   const paletteHexes: Record<string, string> = {};
-  for (const [token, value] of Object.entries(
-    (resolved.theme.colors ?? {}) as Record<string, unknown>
-  )) {
+  const visualColors = designColors(
+    resolved.theme.colors,
+    resolved.theme.palette
+  );
+  const entries = {
+    ...visualColors,
+    ...Object.fromEntries(
+      (resolved.theme.palette?.chart ?? []).map((value) => {
+        const hex = resolveDesignColor(value, visualColors);
+        return [hex ? `#${hex}` : value, value];
+      })
+    ),
+  };
+  for (const [token, value] of Object.entries(entries)) {
     if (typeof value !== 'string') continue;
-    const hex = normalizeHex(value);
+    const hex = normalizeHex(resolveDesignColor(value, visualColors) ?? value);
     if (hex) paletteHexes[token] = hex;
   }
-  const paletteTokens = SERIES_COLOR_TOKENS.filter(
-    (token) => paletteHexes[token] !== undefined
-  );
+  const paletteTokens =
+    resolved.theme.palette?.chart?.map(
+      (value) => `#${resolveDesignColor(value, visualColors)}`
+    ) ??
+    SERIES_COLOR_TOKENS.filter((token) => paletteHexes[token] !== undefined);
   const authoredPropsAt = (pointer: string): Rec | undefined =>
     asRecord(asRecord(nodeAtPointer(context.document, pointer))?.props);
   addFact({

--- a/packages/core-docx/src/renderers/docxjs/emit.ts
+++ b/packages/core-docx/src/renderers/docxjs/emit.ts
@@ -177,6 +177,9 @@ export function runOptions(
       : undefined;
   }
   if (formatting.strike !== undefined) options.strike = formatting.strike;
+  if (formatting.allCaps !== undefined) options.allCaps = formatting.allCaps;
+  if (formatting.smallCaps !== undefined)
+    options.smallCaps = formatting.smallCaps;
   if (formatting.scalePercent !== undefined) {
     options.scale = formatting.scalePercent;
   }

--- a/packages/core-docx/src/renderers/docxjs/index.ts
+++ b/packages/core-docx/src/renderers/docxjs/index.ts
@@ -39,6 +39,7 @@ import type {
 import type { DocxFeature } from '../../ir/features';
 import {
   canonicalizeDocxBuffer,
+  normalizeDocxCaseBuffer,
   resolveGenerationDate,
 } from '../../utils/packageDocument';
 import { fixFloatingImageIdsInBuffer } from '../../utils/fixFloatingImageIds';
@@ -111,7 +112,8 @@ export function createDocxJsRenderer(): DocxRenderer {
       const packed = (await Packer.toBuffer(document)) as Buffer;
       const fixed = fixFloatingImageIdsInBuffer(packed);
 
-      if (renderOptions?.deterministic === false) return new Uint8Array(fixed);
+      if (renderOptions?.deterministic === false)
+        return new Uint8Array(normalizeDocxCaseBuffer(fixed));
       return new Uint8Array(
         canonicalizeDocxBuffer(
           fixed,

--- a/packages/core-docx/src/renderers/office-open/index.ts
+++ b/packages/core-docx/src/renderers/office-open/index.ts
@@ -28,6 +28,7 @@ import {
 } from '../../utils/imageUtils';
 import {
   canonicalizeDocxBuffer,
+  normalizeDocxCaseBuffer,
   resolveGenerationDate,
 } from '../../utils/packageDocument';
 import type { DocxRenderOptions, DocxRenderer, DocxRendererId } from '../types';
@@ -147,7 +148,8 @@ export async function createOfficeOpenDocxRenderer(): Promise<DocxRenderer> {
         raw = zip.toBuffer();
       }
 
-      if (options?.deterministic === false) return new Uint8Array(raw);
+      if (options?.deterministic === false)
+        return new Uint8Array(normalizeDocxCaseBuffer(raw));
       // The backend stamps ZIP entries with the wall clock, so the same
       // document rendered twice differs. Pinning those is a property of an
       // OOXML package rather than of this backend, which is why the same pass

--- a/packages/core-docx/src/styles/themeToStyles.ts
+++ b/packages/core-docx/src/styles/themeToStyles.ts
@@ -8,6 +8,7 @@
  */
 
 import { getTheme } from '../templates/themes';
+import { synthesizeFamilyName } from '@json-to-office/shared';
 
 /**
  * A right tab at the text-measure edge, which is where a TOC page number sits.
@@ -81,6 +82,8 @@ interface ThemeBorders {
 
 // Style properties for various text elements
 interface StyleProperties {
+  fontWeight?: number;
+  case?: 'none' | 'upper' | 'smallCaps';
   font?: 'heading' | 'body' | 'mono' | 'light';
   size?: number;
   color?: string;
@@ -113,48 +116,15 @@ interface StyleProperties {
 }
 
 /**
- * Type-safe style name union
- */
-type StyleName =
-  | 'normal'
-  | 'heading1'
-  | 'heading2'
-  | 'heading3'
-  | 'heading4'
-  | 'heading5'
-  | 'heading6'
-  | 'title'
-  | 'subtitle';
-
-/**
- * Type guard to check if a style name is valid
- */
-function isValidStyleName(name: string): name is StyleName {
-  return [
-    'normal',
-    'heading1',
-    'heading2',
-    'heading3',
-    'heading4',
-    'heading5',
-    'heading6',
-    'title',
-    'subtitle',
-  ].includes(name);
-}
-
-/**
  * Type-safe style getter with proper error handling
  */
 function getStyleSafe(
   theme: ThemeConfig,
   styleName: string
 ): StyleProperties | undefined {
-  if (!isValidStyleName(styleName)) {
-    console.warn(`Invalid style name: ${styleName}`);
-    return undefined;
-  }
-  return theme.styles?.[styleName] as StyleProperties | undefined;
+  return theme.styles && Object.hasOwn(theme.styles, styleName)
+    ? (theme.styles as Record<string, StyleProperties | undefined>)[styleName]
+    : undefined;
 }
 
 /**
@@ -260,8 +230,16 @@ function convertRunProperties(
   defaultColor?: string,
   defaultSize?: number
 ): DocxIrRunFormatting {
+  const weighted =
+    merged.fontWeight !== undefined
+      ? synthesizeFamilyName(
+          merged.family || 'Arial',
+          merged.fontWeight,
+          merged.italic === true
+        )
+      : undefined;
   return {
-    fontFamily: merged.family || 'Arial',
+    fontFamily: weighted?.family ?? merged.family ?? 'Arial',
     sizeHalfPoints: (merged.size || defaultSize || 11) * 2,
     color: {
       hex: resolveColor(
@@ -271,6 +249,11 @@ function convertRunProperties(
     },
     ...(merged.bold !== undefined && { bold: merged.bold }),
     ...(merged.italic !== undefined && { italic: merged.italic }),
+    ...(weighted && { bold: weighted.bold, italic: weighted.italic }),
+    ...(merged.case !== undefined &&
+      (merged.case === 'upper'
+        ? { allCaps: true }
+        : { smallCaps: merged.case === 'smallCaps' })),
     ...(merged.underline !== undefined &&
       merged.underline && { underline: { type: 'single' } }),
     ...(merged.characterSpacing && {
@@ -397,12 +380,25 @@ function fallbackRun(
   defaultColor: string,
   defaultSize: number
 ): DocxIrRunFormatting {
+  const weighted =
+    fontProps.fontWeight !== undefined
+      ? synthesizeFamilyName(
+          fontProps.family || 'Arial',
+          fontProps.fontWeight,
+          fontProps.italic === true
+        )
+      : undefined;
   return {
-    fontFamily: fontProps.family || 'Arial',
+    fontFamily: weighted?.family ?? fontProps.family ?? 'Arial',
     sizeHalfPoints: (fontProps.size || defaultSize) * 2,
     color: { hex: resolveColor(fontProps.color || defaultColor, theme) },
     ...(fontProps.bold !== undefined && { bold: fontProps.bold }),
     ...(fontProps.italic !== undefined && { italic: fontProps.italic }),
+    ...(weighted && { bold: weighted.bold, italic: weighted.italic }),
+    ...(fontProps.case !== undefined &&
+      (fontProps.case === 'upper'
+        ? { allCaps: true }
+        : { smallCaps: fontProps.case === 'smallCaps' })),
     ...(fontProps.underline !== undefined &&
       fontProps.underline && { underline: { type: 'single' } }),
   };
@@ -448,6 +444,8 @@ export function createDocumentStyles(
           size: normalStyle?.size,
           color: normalStyle?.color,
           bold: normalStyle?.bold,
+          fontWeight: normalStyle?.fontWeight,
+          case: normalStyle?.case,
           italic: normalStyle?.italic,
           underline: normalStyle?.underline,
           characterSpacing: normalStyle?.characterSpacing,
@@ -496,6 +494,8 @@ export function createDocumentStyles(
             size: headingStyle.size,
             color: headingStyle.color,
             bold: headingStyle.bold,
+            fontWeight: headingStyle.fontWeight,
+            case: headingStyle.case,
             italic: headingStyle.italic,
             underline: headingStyle.underline,
             characterSpacing: headingStyle.characterSpacing,
@@ -566,6 +566,8 @@ export function createDocumentStyles(
             size: headingStyle.size,
             color: headingStyle.color,
             bold: headingStyle.bold,
+            fontWeight: headingStyle.fontWeight,
+            case: headingStyle.case,
             italic: headingStyle.italic,
             underline: headingStyle.underline,
             characterSpacing: headingStyle.characterSpacing,
@@ -634,6 +636,8 @@ export function createDocumentStyles(
           size: titleStyle.size,
           color: titleStyle.color,
           bold: titleStyle.bold,
+          fontWeight: titleStyle.fontWeight,
+          case: titleStyle.case,
           italic: titleStyle.italic,
           underline: titleStyle.underline,
           characterSpacing: titleStyle.characterSpacing,
@@ -695,6 +699,8 @@ export function createDocumentStyles(
           size: subtitleStyle.size,
           color: subtitleStyle.color,
           bold: subtitleStyle.bold,
+          fontWeight: subtitleStyle.fontWeight,
+          case: subtitleStyle.case,
           italic: subtitleStyle.italic,
           underline: subtitleStyle.underline,
           characterSpacing: subtitleStyle.characterSpacing,
@@ -852,6 +858,8 @@ export function createDocumentStyles(
             size: customStyle.size,
             color: customStyle.color,
             bold: customStyle.bold,
+            fontWeight: customStyle.fontWeight,
+            case: customStyle.case,
             italic: customStyle.italic,
             underline: customStyle.underline,
             characterSpacing: customStyle.characterSpacing,

--- a/packages/core-docx/src/styles/themeToStyles.ts
+++ b/packages/core-docx/src/styles/themeToStyles.ts
@@ -8,7 +8,7 @@
  */
 
 import { getTheme } from '../templates/themes';
-import { synthesizeFamilyName } from '@json-to-office/shared';
+import { capsFormatting, synthesizeFamilyName } from '@json-to-office/shared';
 
 /**
  * A right tab at the text-measure edge, which is where a TOC page number sits.
@@ -222,6 +222,24 @@ function resolveSpacing(spacing?: { before?: number; after?: number }): {
 }
 
 /**
+ * A numeric weight reaches Word as a synthetic family plus bold/italic flags;
+ * both the merged-style and the fallback run path need the same translation.
+ */
+function weightedFamily(props: {
+  fontWeight?: number;
+  family?: string;
+  italic?: boolean;
+}) {
+  return props.fontWeight === undefined
+    ? undefined
+    : synthesizeFamilyName(
+        props.family || 'Arial',
+        props.fontWeight,
+        props.italic === true
+      );
+}
+
+/**
  * Convert merged style properties to docx run properties
  */
 function convertRunProperties(
@@ -230,14 +248,7 @@ function convertRunProperties(
   defaultColor?: string,
   defaultSize?: number
 ): DocxIrRunFormatting {
-  const weighted =
-    merged.fontWeight !== undefined
-      ? synthesizeFamilyName(
-          merged.family || 'Arial',
-          merged.fontWeight,
-          merged.italic === true
-        )
-      : undefined;
+  const weighted = weightedFamily(merged);
   return {
     fontFamily: weighted?.family ?? merged.family ?? 'Arial',
     sizeHalfPoints: (merged.size || defaultSize || 11) * 2,
@@ -250,10 +261,7 @@ function convertRunProperties(
     ...(merged.bold !== undefined && { bold: merged.bold }),
     ...(merged.italic !== undefined && { italic: merged.italic }),
     ...(weighted && { bold: weighted.bold, italic: weighted.italic }),
-    ...(merged.case !== undefined &&
-      (merged.case === 'upper'
-        ? { allCaps: true }
-        : { smallCaps: merged.case === 'smallCaps' })),
+    ...(merged.case !== undefined && capsFormatting(merged.case)),
     ...(merged.underline !== undefined &&
       merged.underline && { underline: { type: 'single' } }),
     ...(merged.characterSpacing && {
@@ -380,14 +388,7 @@ function fallbackRun(
   defaultColor: string,
   defaultSize: number
 ): DocxIrRunFormatting {
-  const weighted =
-    fontProps.fontWeight !== undefined
-      ? synthesizeFamilyName(
-          fontProps.family || 'Arial',
-          fontProps.fontWeight,
-          fontProps.italic === true
-        )
-      : undefined;
+  const weighted = weightedFamily(fontProps);
   return {
     fontFamily: weighted?.family ?? fontProps.family ?? 'Arial',
     sizeHalfPoints: (fontProps.size || defaultSize) * 2,
@@ -395,10 +396,7 @@ function fallbackRun(
     ...(fontProps.bold !== undefined && { bold: fontProps.bold }),
     ...(fontProps.italic !== undefined && { italic: fontProps.italic }),
     ...(weighted && { bold: weighted.bold, italic: weighted.italic }),
-    ...(fontProps.case !== undefined &&
-      (fontProps.case === 'upper'
-        ? { allCaps: true }
-        : { smallCaps: fontProps.case === 'smallCaps' })),
+    ...(fontProps.case !== undefined && capsFormatting(fontProps.case)),
     ...(fontProps.underline !== undefined &&
       fontProps.underline && { underline: { type: 'single' } }),
   };

--- a/packages/core-docx/src/styles/utils/colorUtils.ts
+++ b/packages/core-docx/src/styles/utils/colorUtils.ts
@@ -1,5 +1,6 @@
 import { ThemeConfig } from '../index';
 import { getThemeColors } from '../../themes/defaults';
+import { resolveDesignColor } from '@json-to-office/shared';
 
 export type ColorName = keyof ReturnType<typeof getThemeColors>;
 
@@ -16,7 +17,12 @@ export type ValidColorName =
   | 'borderPrimary'
   | 'borderSecondary'
   | 'backgroundPrimary'
-  | 'backgroundSecondary';
+  | 'backgroundSecondary'
+  | 'rule'
+  | 'onPrimary'
+  | 'surfaceInverse'
+  | 'positive'
+  | 'negative';
 
 // Type for color value that can be either a hex string or a color name
 export type ColorValue = string; // Can be hex color or color name
@@ -49,8 +55,11 @@ export function resolveColor(
   const colors = getThemeColors(theme);
   const resolvedColor = colors[colorValue as ColorName];
   if (typeof resolvedColor === 'string') {
-    // Recursively resolve in case the theme color is also a reference
-    return resolveColor(resolvedColor, theme);
+    const hex = resolveDesignColor(colorValue, colors);
+    if (hex) return hex.toUpperCase();
+    throw new Error(
+      `Unresolvable theme color: "${colorValue}" (missing reference or cycle).`
+    );
   }
 
   // Bare 6-digit hex, e.g. "F0FDF4". HexColorSchema admits it through the

--- a/packages/core-docx/src/styles/utils/colorUtils.ts
+++ b/packages/core-docx/src/styles/utils/colorUtils.ts
@@ -1,6 +1,9 @@
 import { ThemeConfig } from '../index';
 import { getThemeColors } from '../../themes/defaults';
-import { resolveDesignColor } from '@json-to-office/shared';
+import {
+  DEFAULT_CHART_THEME_COLORS,
+  resolveDesignColor,
+} from '@json-to-office/shared';
 
 export type ColorName = keyof ReturnType<typeof getThemeColors>;
 
@@ -108,4 +111,24 @@ export function isValidColorName(
 export function getAvailableColorNames(theme: ThemeConfig): string[] {
   const colors = getThemeColors(theme);
   return Object.keys(colors).filter((name) => isValidColorName(name, theme));
+}
+
+/**
+ * The values an implicit DOCX chart palette is built from, in palette order.
+ *
+ * `palette.chart` wins outright when the theme declares it; otherwise the
+ * legacy series tokens contribute the value they store, skipping slots the
+ * theme leaves unset (see DEFAULT_CHART_THEME_COLORS). Each caller resolves
+ * these with its own policy — the native chart compiler throws on an
+ * unresolvable value, the Highcharts component drops it — so only the choice
+ * of source lives here, and it lives here once.
+ */
+export function chartPaletteValues(theme: ThemeConfig): string[] {
+  const explicit = theme.palette?.chart;
+  if (explicit) return [...explicit];
+  const colors = getThemeColors(theme) as Record<string, string | undefined>;
+  return DEFAULT_CHART_THEME_COLORS.flatMap((token) => {
+    const value = colors[token];
+    return typeof value === 'string' && value.length > 0 ? [value] : [];
+  });
 }

--- a/packages/core-docx/src/styles/utils/styleHelpers.ts
+++ b/packages/core-docx/src/styles/utils/styleHelpers.ts
@@ -93,6 +93,8 @@ export function resolveFontSize(
  * Font properties that can be defined in font definitions
  */
 export interface FontProperties {
+  fontWeight?: number;
+  case?: 'none' | 'upper' | 'smallCaps';
   family?: string;
   size?: number;
   color?: string;
@@ -141,6 +143,8 @@ export function resolveFontProperties(
     size: fontDef.size,
     color: fontDef.color,
     bold: fontDef.bold,
+    fontWeight: fontDef.fontWeight,
+    case: fontDef.case,
     italic: fontDef.italic,
     underline: fontDef.underline,
     alignment: fontDef.alignment,

--- a/packages/core-docx/src/themes/__tests__/theme-round-trip.test.ts
+++ b/packages/core-docx/src/themes/__tests__/theme-round-trip.test.ts
@@ -26,6 +26,11 @@ const COMPLETE: ThemeConfigJson = {
   displayName: 'Round Trip',
   description: 'Every root key the schema allows.',
   version: '1.0.0',
+  palette: { rule: '#123456', chart: ['rule', 'primary'] },
+  typography: { roles: { display: { size: 32 } }, scale: { a4: { base: 12 } } },
+  spacing: { basePt: 4, canvas: { a4: { safeAreaIn: 0.75 } } },
+  chrome: { sourceLine: { type: 'source' } },
+  motif: { kind: 'rule' },
   colors: {
     primary: '#2B302B',
     secondary: '#4A5B4E',
@@ -96,9 +101,9 @@ describe('ensureThemeDefaults keeps what the schema allows', () => {
     // must not need this function edited to survive.
     const result = ensureThemeDefaults({
       ...COMPLETE,
-      typography: { roles: { eyebrow: { size: 8 } } },
+      futureVisualLayer: { token: 8 },
     } as ThemeConfigJson) as Record<string, unknown>;
-    expect(result.typography).toEqual({ roles: { eyebrow: { size: 8 } } });
+    expect(result.futureVisualLayer).toEqual({ token: 8 });
   });
 
   it('keeps a font role it has never heard of', () => {

--- a/packages/core-docx/src/themes/defaults.ts
+++ b/packages/core-docx/src/themes/defaults.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ThemeConfigJson } from '@json-to-office/shared-docx';
+import { designColors } from '@json-to-office/shared';
 
 /**
  * Default colors for themes
@@ -200,10 +201,13 @@ export function isCompleteTheme(theme: unknown): theme is ThemeConfigJson {
  * Safe getter for theme colors with defaults
  */
 export function getThemeColors(theme: Partial<ThemeConfigJson>) {
-  return {
-    ...DEFAULT_COLORS,
-    ...(theme.colors || {}),
-  };
+  return designColors(
+    {
+      ...DEFAULT_COLORS,
+      ...(theme.colors || {}),
+    },
+    theme.palette
+  );
 }
 
 /**

--- a/packages/core-docx/src/themes/design-system.ts
+++ b/packages/core-docx/src/themes/design-system.ts
@@ -1,0 +1,68 @@
+import {
+  designCanvas,
+  resolveTypeRoles,
+  validateDesignColors,
+} from '@json-to-office/shared';
+import { getThemeColors } from './defaults';
+import type { ThemeConfig } from '../styles';
+
+/** Materialize visual tokens before either pipeline reads style/layout defaults. */
+export function resolveDocxDesignSystem(theme: ThemeConfig): ThemeConfig {
+  validateDesignColors(theme, getThemeColors(theme));
+  if (!theme.typography && !theme.spacing) return theme;
+  const canvas = designCanvas('docx', theme.page.size);
+  const roles = resolveTypeRoles(theme, canvas, theme.fonts.body.size ?? 11);
+  const styles: Record<string, object> = { ...theme.styles };
+  for (const [name, role] of Object.entries(roles)) {
+    const spacing = {
+      ...(role.spaceBefore !== undefined && { before: role.spaceBefore }),
+      ...(role.spaceAfter !== undefined && { after: role.spaceAfter }),
+    };
+    styles[name] = {
+      font: role.face ?? 'body',
+      size: role.size,
+      ...(role.weight !== undefined && { fontWeight: role.weight }),
+      ...(role.color !== undefined && { color: role.color }),
+      ...(role.case !== undefined && { case: role.case }),
+      ...(role.lineHeight !== undefined && {
+        lineSpacing: { type: 'multiple', value: role.lineHeight },
+      }),
+      ...(role.tracking !== undefined && {
+        characterSpacing: {
+          type: role.tracking < 0 ? 'condensed' : 'expanded',
+          value: (Math.abs(role.tracking) * role.size) / 5,
+        },
+      }),
+      ...(Object.keys(spacing).length && { spacing }),
+      ...styles[name],
+    };
+  }
+  const gap = theme.spacing?.blockGap?.normal ?? theme.spacing?.basePt;
+  const scale = theme.typography?.scale?.[canvas];
+  if (scale || gap !== undefined) {
+    styles.normal = {
+      ...(scale && { size: scale.base }),
+      ...(gap !== undefined && { spacing: { after: gap } }),
+      ...styles.normal,
+    };
+  }
+  const space = theme.spacing?.canvas?.[canvas];
+  const safe = space?.safeAreaIn;
+  return {
+    ...theme,
+    styles,
+    page: {
+      ...theme.page,
+      margins: {
+        ...theme.page.margins,
+        ...(safe !== undefined && {
+          top: safe * 1440,
+          bottom: safe * 1440,
+          left: safe * 1440,
+          right: safe * 1440,
+        }),
+        ...(space?.gutterIn !== undefined && { gutter: space.gutterIn * 1440 }),
+      },
+    },
+  };
+}

--- a/packages/core-docx/src/themes/overrides.ts
+++ b/packages/core-docx/src/themes/overrides.ts
@@ -4,8 +4,9 @@
  */
 
 import type { ThemeConfig } from '../styles';
+import { mergeWithDefaults, type DesignSystem } from '@json-to-office/shared';
 
-export interface ThemeOverrides {
+export interface ThemeOverrides extends DesignSystem {
   colors?: Partial<ThemeConfig['colors']>;
   fonts?: Partial<ThemeConfig['fonts']>;
   styles?: ThemeConfig['styles'];
@@ -39,6 +40,16 @@ export function applyThemeOverrides(
 
   return {
     ...theme,
+    ...Object.fromEntries(
+      ['palette', 'typography', 'spacing', 'chrome', 'motif'].flatMap(
+        (name) => {
+          const key = name as keyof DesignSystem;
+          return overrides[key] === undefined
+            ? []
+            : [[key, mergeWithDefaults(overrides[key], theme[key] ?? {})]];
+        }
+      )
+    ),
     colors: { ...theme.colors, ...(overrides.colors ?? {}) },
     fonts,
     ...(Object.keys(styles).length > 0 && { styles }),

--- a/packages/core-docx/src/utils/normalizeTextCase.ts
+++ b/packages/core-docx/src/utils/normalizeTextCase.ts
@@ -1,0 +1,47 @@
+/**
+ * Case is a run property with two mutually exclusive OOXML flags, `w:caps` and
+ * `w:smallCaps`, and both DOCX writers emit only the one that is true (docx.js
+ * `RunProperties` writes `w:smallCaps` *or* `w:caps`, never both). A run that
+ * turns case off, or swaps one kind for the other, therefore inherits the flag
+ * it did not state from its style. This pass states the opposite flag as false.
+ *
+ * `CT_RPr` is an ordered sequence — `w:caps` precedes `w:smallCaps`, and both
+ * precede `w:strike`, `w:color`, `w:sz` — so the added flag goes next to the
+ * flag already present, never at the end of the property bag.
+ */
+import type AdmZip from 'adm-zip';
+
+const WORD_XML = /^word\/.*\.xml$/;
+const ANY_CASE_FLAG = /<w:(?:caps|smallCaps)\b/;
+const RUN_PROPERTIES = /<w:rPr\b[^>]*>[\s\S]*?<\/w:rPr>/g;
+const CASE_FLAG = /<w:(caps|smallCaps)\b[^>]*(?:\/>|>[\s\S]*?<\/w:\1>)/;
+
+/** Add the missing case flag to every run that states exactly one of them. */
+export function normalizeTextCase(zip: AdmZip): boolean {
+  let changed = false;
+  for (const entry of zip.getEntries()) {
+    if (!WORD_XML.test(entry.entryName)) continue;
+    const xml = entry.getData().toString('utf8');
+    if (!ANY_CASE_FLAG.test(xml)) continue;
+    const normalized = xml.replace(RUN_PROPERTIES, completeCaseFlags);
+    if (normalized === xml) continue;
+    zip.updateFile(entry, Buffer.from(normalized, 'utf8'));
+    changed = true;
+  }
+  return changed;
+}
+
+function completeCaseFlags(runProperties: string): string {
+  const flag = CASE_FLAG.exec(runProperties);
+  if (!flag) return runProperties;
+  const isCaps = flag[1] === 'caps';
+  const opposite = `<w:${isCaps ? 'smallCaps' : 'caps'} w:val="false"/>`;
+  // Already complete: the other flag is stated somewhere in this bag.
+  if (runProperties.includes(`<w:${isCaps ? 'smallCaps' : 'caps'}`)) {
+    return runProperties;
+  }
+  return runProperties.replace(
+    flag[0],
+    isCaps ? `${flag[0]}${opposite}` : `${opposite}${flag[0]}`
+  );
+}

--- a/packages/core-docx/src/utils/packageDocument.ts
+++ b/packages/core-docx/src/utils/packageDocument.ts
@@ -140,6 +140,7 @@ export function canonicalizeDocxBuffer(
   generatedAt: Date = DEFAULT_GENERATION_DATE
 ): Buffer {
   const zip = new AdmZip(buffer);
+  normalizeTextCase(zip);
   canonicalizeRelationshipIds(zip);
 
   const isoTimestamp = generatedAt.toISOString();
@@ -169,4 +170,40 @@ export function canonicalizeDocxBuffer(
   }
 
   return zip.toBuffer();
+}
+
+/** Case semantics also apply when timestamp normalization is disabled. */
+export function normalizeDocxCaseBuffer(buffer: Buffer): Buffer {
+  const zip = new AdmZip(buffer);
+  return normalizeTextCase(zip) ? zip.toBuffer() : buffer;
+}
+
+function normalizeTextCase(zip: AdmZip): boolean {
+  let changed = false;
+  for (const entry of zip.getEntries()) {
+    // Both writers emit only one caps flag. State the opposite flag as false
+    // so case changes (including `none`) can override an inherited style.
+    if (/^word\/.*\.xml$/.test(entry.entryName)) {
+      const xml = entry.getData().toString('utf8');
+      if (/<w:(?:caps|smallCaps)\b/.test(xml)) {
+        const normalized = xml.replace(
+          /<w:rPr\b[^>]*>[\s\S]*?<\/w:rPr>/g,
+          (run) => {
+            const caps = /<w:caps\b/.test(run);
+            const small = /<w:smallCaps\b/.test(run);
+            if (caps === small) return run;
+            return run.replace(
+              '</w:rPr>',
+              `<w:${caps ? 'smallCaps' : 'caps'} w:val="false"/></w:rPr>`
+            );
+          }
+        );
+        if (normalized !== xml) {
+          zip.updateFile(entry, Buffer.from(normalized, 'utf8'));
+          changed = true;
+        }
+      }
+    }
+  }
+  return changed;
 }

--- a/packages/core-docx/src/utils/packageDocument.ts
+++ b/packages/core-docx/src/utils/packageDocument.ts
@@ -1,4 +1,5 @@
 import AdmZip from 'adm-zip';
+import { normalizeTextCase } from './normalizeTextCase';
 
 export interface DocumentPackageOptions {
   /** Normalize volatile OOXML metadata and ZIP timestamps. Defaults to true. */
@@ -176,34 +177,4 @@ export function canonicalizeDocxBuffer(
 export function normalizeDocxCaseBuffer(buffer: Buffer): Buffer {
   const zip = new AdmZip(buffer);
   return normalizeTextCase(zip) ? zip.toBuffer() : buffer;
-}
-
-function normalizeTextCase(zip: AdmZip): boolean {
-  let changed = false;
-  for (const entry of zip.getEntries()) {
-    // Both writers emit only one caps flag. State the opposite flag as false
-    // so case changes (including `none`) can override an inherited style.
-    if (/^word\/.*\.xml$/.test(entry.entryName)) {
-      const xml = entry.getData().toString('utf8');
-      if (/<w:(?:caps|smallCaps)\b/.test(xml)) {
-        const normalized = xml.replace(
-          /<w:rPr\b[^>]*>[\s\S]*?<\/w:rPr>/g,
-          (run) => {
-            const caps = /<w:caps\b/.test(run);
-            const small = /<w:smallCaps\b/.test(run);
-            if (caps === small) return run;
-            return run.replace(
-              '</w:rPr>',
-              `<w:${caps ? 'smallCaps' : 'caps'} w:val="false"/></w:rPr>`
-            );
-          }
-        );
-        if (normalized !== xml) {
-          zip.updateFile(entry, Buffer.from(normalized, 'utf8'));
-          changed = true;
-        }
-      }
-    }
-  }
-  return changed;
 }

--- a/packages/core-pptx/src/__tests__/design-system.test.ts
+++ b/packages/core-pptx/src/__tests__/design-system.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import JSZip from 'jszip';
+import { Value } from '@sinclair/typebox/value';
+import { ThemeConfigSchema } from '@json-to-office/shared-pptx';
+import { generateBufferFromJson } from '../core/generator';
+import { createPresentationGenerator } from '../plugin/createPresentationGenerator';
+import { DEFAULT_PPTX_THEME } from '../themes';
+import { designGrid, resolvePptxDesignSystem } from '../themes/design-system';
+import { definedChartColorTokens, resolveColor } from '../utils/color';
+import { preparePptxQualityDocument } from '../quality/facts';
+
+const theme = {
+  ...DEFAULT_PPTX_THEME,
+  palette: {
+    rule: '#123456',
+    positive: '#337755',
+    chart: ['positive', 'rule'],
+  },
+  typography: {
+    roles: {
+      display: {
+        face: 'heading' as const,
+        weight: 300,
+        case: 'upper' as const,
+        color: 'rule',
+      },
+      source: { size: 10, case: 'smallCaps' as const },
+    },
+    scale: {
+      wide169: { base: 16, ratio: 1.25, baselinePt: 4 },
+      standard43: { base: 12 },
+    },
+  },
+  spacing: {
+    canvas: {
+      wide169: { safeAreaIn: 0.5, gutterIn: 0.2, columns: 6, rows: 4 },
+    },
+  },
+  chrome: { actionTitle: { type: 'display' as const } },
+  motif: { kind: 'rule' as const },
+};
+
+describe('PPTX theme foundation', () => {
+  it('exposes extended colors as legal component literals to quality fixes', () => {
+    const prepared = preparePptxQualityDocument({
+      name: 'pptx',
+      props: { theme },
+      children: [],
+    } as never);
+    const fact = prepared.facts.find((entry) => entry.kind === 'pptx/theme');
+    expect(fact).toMatchObject({
+      paletteHexes: { '#123456': '#123456', '#337755': '#337755' },
+    });
+  });
+  it('validates inline values and derives font/grid/chart defaults', () => {
+    expect(Value.Check(ThemeConfigSchema, theme)).toBe(true);
+    expect(resolvePptxDesignSystem(theme, 16, 9).styles?.display).toMatchObject(
+      { fontSize: 40, fontColor: '123456', fontWeight: 300 }
+    );
+    expect(designGrid(theme, 16, 9)).toEqual({
+      margin: 0.5,
+      gutter: 0.2,
+      columns: 6,
+      rows: 4,
+    });
+    expect(
+      definedChartColorTokens(theme).map((color) => resolveColor(color, theme))
+    ).toEqual(['337755', '123456']);
+    expect(theme.styles).not.toHaveProperty('display');
+  });
+
+  for (const renderer of ['pptxgenjs', 'office-open'] as const) {
+    it(`renders roles through both ${renderer} pipelines without required chrome`, async () => {
+      const input = {
+        name: 'pptx',
+        renderer,
+        props: { theme, slideWidth: 16, slideHeight: 9 },
+        children: [
+          {
+            name: 'slide',
+            children: [
+              {
+                name: 'text',
+                props: {
+                  text: 'Mixed Case',
+                  style: 'display',
+                  x: 1,
+                  y: 1,
+                  w: 8,
+                  h: 1,
+                },
+              },
+              {
+                name: 'text',
+                props: {
+                  text: 'A source',
+                  style: 'source',
+                  x: 1,
+                  y: 3,
+                  w: 8,
+                  h: 1,
+                },
+              },
+              {
+                name: 'text',
+                props: {
+                  text: 'Explicit',
+                  style: 'display',
+                  fontSize: 14,
+                  color: '#ABCDEF',
+                  x: 1,
+                  y: 5,
+                  w: 8,
+                  h: 1,
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const core = await generateBufferFromJson(
+        structuredClone(input) as never
+      );
+      const plugin = await createPresentationGenerator({}).generateBuffer(
+        structuredClone(input) as never
+      );
+      const a = await JSZip.loadAsync(core as Buffer);
+      const b = await JSZip.loadAsync(plugin.buffer);
+      const xml = await a.file('ppt/slides/slide1.xml')!.async('string');
+      expect(await b.file('ppt/slides/slide1.xml')!.async('string')).toBe(xml);
+      expect(xml).toContain('MIXED CASE');
+      expect(xml).toContain('sz="4000"');
+      expect(xml).toContain('123456');
+      expect(xml).toContain('Light');
+      expect(xml).toContain('sz="1400"');
+      expect(xml).toContain('ABCDEF');
+      expect(xml).toContain('sz="800"');
+      expect((xml.match(/<p:sp>/g) ?? []).length).toBe(3);
+    });
+  }
+});

--- a/packages/core-pptx/src/__tests__/fixtures/corpus-goldens.ts
+++ b/packages/core-pptx/src/__tests__/fixtures/corpus-goldens.ts
@@ -18,6 +18,8 @@
  */
 
 export const CORPUS_GOLDENS: Readonly<Record<string, string>> = {
+  'theme/shared-foundation':
+    '7af49a5ffbaf84ea7bed36d868a83cd4c9549dd89eaba2f6e970160883f63c17',
   'text/plain':
     '856c8d0ade8513d243155580bde179eefbbed559428189dd37637ece728cab74',
   'text/styled':

--- a/packages/core-pptx/src/__tests__/fixtures/corpus.ts
+++ b/packages/core-pptx/src/__tests__/fixtures/corpus.ts
@@ -11,6 +11,7 @@
  */
 
 import type { PresentationComponentDefinition } from '../../types';
+import { DEFAULT_PPTX_THEME } from '../../themes';
 
 /** A 1x1 transparent PNG. */
 export const PNG_1PX =
@@ -47,6 +48,65 @@ const SERIES = [
 import { CASES as REGRESSIONS } from './corpus-regressions';
 
 export const CORPUS: CorpusCase[] = [
+  {
+    name: 'theme/shared-foundation',
+    document: deck(
+      [
+        slide([
+          {
+            name: 'text',
+            props: {
+              text: 'A shared visual system',
+              style: 'display',
+              grid: { column: 1, row: 1, columnSpan: 4 },
+            },
+          },
+          {
+            name: 'text',
+            props: {
+              text: 'Source: observations',
+              style: 'source',
+              x: 1,
+              y: 3,
+              w: 5,
+              h: 1,
+            },
+          },
+          {
+            name: 'chart',
+            props: { type: 'bar', x: 1, y: 4, w: 6, h: 3, data: SERIES },
+          },
+        ]),
+      ],
+      {
+        slideWidth: 16,
+        slideHeight: 9,
+        theme: {
+          ...DEFAULT_PPTX_THEME,
+          palette: { rule: '#123456', chart: ['rule', '#337755'] },
+          typography: {
+            roles: {
+              display: {
+                face: 'heading',
+                weight: 300,
+                case: 'upper',
+                color: 'rule',
+              },
+              source: { size: 10, case: 'smallCaps' },
+            },
+            scale: { wide169: { base: 16, ratio: 1.25, baselinePt: 4 } },
+          },
+          spacing: {
+            canvas: {
+              wide169: { safeAreaIn: 0.5, gutterIn: 0.2, columns: 6, rows: 4 },
+            },
+          },
+          chrome: { sourceLine: { type: 'source' } },
+          motif: { kind: 'rule' },
+        },
+      }
+    ),
+  },
   {
     name: 'text/plain',
     document: deck([slide([{ name: 'text', props: { text: 'Hello' } }])]),

--- a/packages/core-pptx/src/core/generationContext.ts
+++ b/packages/core-pptx/src/core/generationContext.ts
@@ -25,6 +25,7 @@ import type {
 import type { FontRuntimeOpts } from '@json-to-office/shared';
 import { applyExportMode } from '@json-to-office/shared';
 import { getPptxTheme } from '../themes/defaults';
+import { resolvePptxDesignSystem } from '../themes/design-system';
 
 export interface ThemeContextOptions {
   customThemes?: Record<string, PptxThemeConfig>;
@@ -106,6 +107,11 @@ export function resolveThemeContext(
 
   // Export-mode pre-pass: substitute rewrites non-safe families in place;
   // custom leaves refs untouched and resolution short-circuits to empty.
+  theme = resolvePptxDesignSystem(
+    theme,
+    document.props.slideWidth,
+    document.props.slideHeight
+  );
   const mode = applyExportMode({ doc: document, theme, fonts });
   document = mode.doc;
   theme = mode.theme;

--- a/packages/core-pptx/src/core/structure.ts
+++ b/packages/core-pptx/src/core/structure.ts
@@ -74,6 +74,10 @@ export function processPresentation(
       : options?.customThemes?.[props.theme ?? 'default'] ??
         getPptxTheme(props.theme ?? 'default'));
 
+  // Idempotent, and deliberately repeated: the generation prologue already
+  // resolved the theme it hands over, while a direct caller reaches this with a
+  // raw theme. Re-resolving projects the same roles onto styles that already
+  // carry them, because a style key present in `styles` wins over the role.
   const baseTheme = resolvePptxDesignSystem(
     selectedTheme,
     props.slideWidth,

--- a/packages/core-pptx/src/core/structure.ts
+++ b/packages/core-pptx/src/core/structure.ts
@@ -19,6 +19,7 @@ import {
   mergeGridConfigs,
 } from './grid';
 import { getPptxTheme } from '../themes';
+import { resolvePptxDesignSystem, designGrid } from '../themes/design-system';
 import type { GenerationOptions } from './generator';
 import { resolveComponentTree } from '../utils/resolveComponentTree';
 import {
@@ -58,19 +59,33 @@ export function processPresentation(
   document: PresentationComponentDefinition,
   options?: GenerationOptions
 ): ProcessedPresentation {
-  const { props, children = [] } = document;
+  let { props } = document;
+  const { children = [] } = document;
 
   // The generation prologue hands the resolved theme over directly — after
   // the export-mode pre-pass, so a name lookup here would resurrect
   // pre-substitute font families. The `props.theme` resolution below (a name,
   // or an inline theme config object embedded in the document itself —
   // self-contained documents-as-data) is the fallback for direct callers.
-  const baseTheme =
+  const selectedTheme =
     options?.theme ??
     (typeof props.theme === 'object' && props.theme !== null
       ? (props.theme as PptxThemeConfig)
       : options?.customThemes?.[props.theme ?? 'default'] ??
         getPptxTheme(props.theme ?? 'default'));
+
+  const baseTheme = resolvePptxDesignSystem(
+    selectedTheme,
+    props.slideWidth,
+    props.slideHeight
+  );
+  const tokenGrid = designGrid(
+    baseTheme,
+    props.slideWidth ?? 10,
+    props.slideHeight ?? 7.5
+  );
+  if (tokenGrid)
+    props = { ...props, grid: mergeGridConfigs(tokenGrid, props.grid) };
 
   // Merge presentation-level componentDefaults on top of theme-level ones
   const presDefaults = props.componentDefaults;

--- a/packages/core-pptx/src/ir/__tests__/compiler.test.ts
+++ b/packages/core-pptx/src/ir/__tests__/compiler.test.ts
@@ -8,6 +8,7 @@ import type {
   PptxIrTextBoxElement,
 } from '../types';
 import { assertValidPptxIr } from '../validation';
+import { DEFAULT_PPTX_THEME } from '../../themes';
 
 const PNG_1PX =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
@@ -527,6 +528,31 @@ describe('PptxIR feature requirements', () => {
         ])
       )
     ).toContain('rich-text');
+  });
+
+  it('reads the authored runs, not the case lowering', async () => {
+    // Small caps splits one authored run into several so the lowercase spans can
+    // shrink; that device must not report the deck as rich text.
+    const { ir, required } = await compile(
+      deck(
+        [
+          slide([
+            { name: 'text', props: { text: 'Mixed Case', style: 'source' } },
+          ]),
+        ],
+        {
+          theme: {
+            ...DEFAULT_PPTX_THEME,
+            typography: { roles: { source: { case: 'smallCaps' } } },
+          },
+        }
+      )
+    );
+    const text = ir.slides[0].elements[0] as PptxIrTextBoxElement;
+    expect(text.runs.length).toBeGreaterThan(1);
+    const features = new Set(required.map((r) => r.feature));
+    expect(features).toContain('text');
+    expect(features).not.toContain('rich-text');
   });
 
   it('records the fill kind actually used', async () => {

--- a/packages/core-pptx/src/ir/compiler.ts
+++ b/packages/core-pptx/src/ir/compiler.ts
@@ -638,9 +638,11 @@ function compileText(
         },
       ];
 
-  runs = applyTextCase(runs, named.style?.case);
   ctx.features.require('text', path);
+  // Feature gates read the authored runs: the case lowering below can split one
+  // authored run into several, which is a rendering device, not rich text.
   if (runs.length > 1) ctx.features.require('rich-text', path);
+  runs = applyTextCase(runs, named.style?.case);
   if (cascade.language) ctx.features.require('proofing-language', path);
   if (hyperlink) ctx.features.require('text-hyperlinks', path);
 
@@ -699,7 +701,14 @@ function namedStyle(
   };
 }
 
-/** PPTX backends lack a shared caps primitive. Lower case to explicit runs. */
+/**
+ * PPTX backends lack a shared caps primitive. Lower case to explicit runs.
+ *
+ * A small-caps run splits per lowercase span, so a run carrying its own
+ * hyperlink hands the same link to every piece — the fan-out the office-open
+ * backend already performs for an element-level link over rich runs. Splitting
+ * is what makes the 80% size possible; a link is at worst repeated, never lost.
+ */
 function applyTextCase(
   runs: PptxIrTextRun[],
   textCase: 'none' | 'upper' | 'smallCaps' | undefined
@@ -1130,11 +1139,12 @@ function compileShape(
           compileTextSegment(segment, cascade, ctx)
         )
       : [{ text: props.text as string, ...baseRunFormatting(cascade) }];
-    runs = applyTextCase(runs, named.style?.case);
     style = textBodyStyle(props, named, cascade);
     requireBulletFeatures(style.bullet, path, ctx);
     ctx.features.require('text', path);
+    // Gate on the authored runs, before the case lowering can split them.
     if (runs.length > 1) ctx.features.require('rich-text', path);
+    runs = applyTextCase(runs, named.style?.case);
   }
 
   const hyperlink = compileHyperlink(props.hyperlink, 'shape', ctx, path);

--- a/packages/core-pptx/src/ir/compiler.ts
+++ b/packages/core-pptx/src/ir/compiler.ts
@@ -623,7 +623,7 @@ function compileText(
   const hyperlink = compileHyperlink(props.hyperlink, 'text', ctx, path);
   // The link belongs to the text box, not to each run: attaching it per run
   // emits one identical external relationship per run.
-  const runs: PptxIrTextRun[] = runProps
+  let runs: PptxIrTextRun[] = runProps
     ? runProps.map((run) =>
         compileRichRun(run, cascade, undefined, scope.slideCtx, ctx)
       )
@@ -638,6 +638,7 @@ function compileText(
         },
       ];
 
+  runs = applyTextCase(runs, named.style?.case);
   ctx.features.require('text', path);
   if (runs.length > 1) ctx.features.require('rich-text', path);
   if (cascade.language) ctx.features.require('proofing-language', path);
@@ -696,6 +697,28 @@ function namedStyle(
     style: name ? pickStyle(theme, name) : undefined,
     isHeading: name !== undefined && /^(title|heading)/.test(name),
   };
+}
+
+/** PPTX backends lack a shared caps primitive. Lower case to explicit runs. */
+function applyTextCase(
+  runs: PptxIrTextRun[],
+  textCase: 'none' | 'upper' | 'smallCaps' | undefined
+): PptxIrTextRun[] {
+  if (!textCase || textCase === 'none') return runs;
+  return runs.flatMap((run) => {
+    if (textCase === 'upper') return [{ ...run, text: run.text.toUpperCase() }];
+    const pieces = run.text.match(/\p{Ll}+|[^\p{Ll}]+/gu) ?? [''];
+    return pieces.map((text, index) => ({
+      ...run,
+      text: text.toUpperCase(),
+      fontSize: /^\p{Ll}/u.test(text) ? run.fontSize * 0.8 : run.fontSize,
+      ...(index > 0 && { spaceBeforePoints: undefined }),
+      ...(index < pieces.length - 1 && {
+        breakAfter: undefined,
+        spaceAfterPoints: undefined,
+      }),
+    }));
+  });
 }
 
 function pickStyle(theme: PptxThemeConfig, name: StyleName) {
@@ -920,8 +943,8 @@ function textBodyStyle(
       : lineSpacing !== undefined
         ? { lineSpacingPoints: lineSpacing }
         : {}),
-    ...(props.paraSpaceBefore !== undefined
-      ? { spaceBeforePoints: props.paraSpaceBefore }
+    ...((props.paraSpaceBefore ?? style?.paraSpaceBefore) !== undefined
+      ? { spaceBeforePoints: props.paraSpaceBefore ?? style?.paraSpaceBefore }
       : {}),
     ...(spaceAfter !== undefined ? { spaceAfterPoints: spaceAfter } : {}),
     ...(props.bullet !== undefined
@@ -1107,6 +1130,7 @@ function compileShape(
           compileTextSegment(segment, cascade, ctx)
         )
       : [{ text: props.text as string, ...baseRunFormatting(cascade) }];
+    runs = applyTextCase(runs, named.style?.case);
     style = textBodyStyle(props, named, cascade);
     requireBulletFeatures(style.bullet, path, ctx);
     ctx.features.require('text', path);

--- a/packages/core-pptx/src/quality/facts.ts
+++ b/packages/core-pptx/src/quality/facts.ts
@@ -17,7 +17,11 @@ import {
   type TableInfoDesign,
 } from '@json-to-office/quality';
 import type { FontRuntimeOpts, ServicesConfig } from '@json-to-office/shared';
-import { DEFAULT_PPTX_RENDERER_ID } from '@json-to-office/shared-pptx';
+import {
+  DEFAULT_PPTX_RENDERER_ID,
+  SEMANTIC_COLOR_NAMES,
+} from '@json-to-office/shared-pptx';
+import { designColors } from '@json-to-office/shared';
 import type {
   GridConfig,
   GridPosition,
@@ -1202,12 +1206,32 @@ export function preparePptxQualityDocument(
   const ctx = themeContext(processed.theme);
 
   const paletteHexes: Record<string, string> = {};
-  for (const [token, value] of Object.entries(processed.theme.colors ?? {})) {
+  const visualColors = designColors(
+    processed.theme.colors,
+    processed.theme.palette
+  );
+  const entries = {
+    ...visualColors,
+    ...Object.fromEntries(
+      (processed.theme.palette?.chart ?? []).map((value) => [
+        `#${resolveColor(value, processed.theme)}`,
+        value,
+      ])
+    ),
+  };
+  for (const [token, value] of Object.entries(entries)) {
     if (typeof value !== 'string') continue;
     // Through `resolveColor` so a slot naming another slot lands on the colour
     // it actually paints, not on the token name it stores.
     const hex = normalizeHex(resolveColor(value, processed.theme));
-    if (hex) paletteHexes[token] = hex;
+    // New palette roles are theme-only, outside the component color enum.
+    // Quality fixes must offer a legal literal for those colors.
+    if (hex)
+      paletteHexes[
+        (SEMANTIC_COLOR_NAMES as readonly string[]).includes(token)
+          ? token
+          : hex
+      ] = hex;
   }
   addFact({
     id: 'pptx:theme',
@@ -1240,9 +1264,11 @@ export function preparePptxQualityDocument(
   );
   const analyzedTextPaths = new Set<string>();
   const analyzedContentPaths = new Set<string>();
-  const paletteTokens = SERIES_COLOR_TOKENS.filter(
-    (token) => paletteHexes[token] !== undefined
-  );
+  const paletteTokens =
+    processed.theme.palette?.chart?.map(
+      (value) => `#${resolveColor(value, processed.theme)}`
+    ) ??
+    SERIES_COLOR_TOKENS.filter((token) => paletteHexes[token] !== undefined);
   const authoredPropsAt = (pointer: string): Rec | undefined =>
     authoredPropsAtPointer(document, pointer);
 

--- a/packages/core-pptx/src/themes/design-system.ts
+++ b/packages/core-pptx/src/themes/design-system.ts
@@ -1,0 +1,61 @@
+import {
+  designCanvas,
+  resolveTypeRoles,
+  validateDesignColors,
+} from '@json-to-office/shared';
+import type { PptxThemeConfig, GridConfig } from '../types';
+import { resolveColor } from '../utils/color';
+
+export function resolvePptxDesignSystem(
+  theme: PptxThemeConfig,
+  width = 10,
+  height = 7.5
+): PptxThemeConfig {
+  validateDesignColors(theme, theme.colors);
+  if (!theme.typography) return theme;
+  const canvas = designCanvas('pptx', { width, height });
+  const roles = resolveTypeRoles(theme, canvas, theme.defaults.fontSize);
+  const styles = { ...theme.styles };
+  for (const [name, role] of Object.entries(roles)) {
+    const key = name as keyof typeof styles;
+    styles[key] = {
+      fontFace:
+        theme.fonts[role.face ?? 'body'] ??
+        (role.face === 'light' ? theme.fonts.heading : theme.fonts.body),
+      fontSize: role.size,
+      ...(role.weight !== undefined && { fontWeight: role.weight }),
+      ...(role.color !== undefined && {
+        fontColor: resolveColor(role.color, theme),
+      }),
+      ...(role.case !== undefined && { case: role.case }),
+      ...(role.lineHeight !== undefined && {
+        lineSpacing: role.lineHeight * role.size,
+      }),
+      ...(role.tracking !== undefined && {
+        charSpacing: (role.tracking * role.size) / 100,
+      }),
+      ...(role.spaceBefore !== undefined && {
+        paraSpaceBefore: role.spaceBefore,
+      }),
+      ...(role.spaceAfter !== undefined && { paraSpaceAfter: role.spaceAfter }),
+      ...styles[key],
+    };
+  }
+  return { ...theme, styles };
+}
+
+export function designGrid(
+  theme: PptxThemeConfig,
+  width: number,
+  height: number
+): GridConfig | undefined {
+  const space =
+    theme.spacing?.canvas?.[designCanvas('pptx', { width, height })];
+  if (!space) return undefined;
+  return {
+    ...(space.safeAreaIn !== undefined && { margin: space.safeAreaIn }),
+    ...(space.gutterIn !== undefined && { gutter: space.gutterIn }),
+    ...(space.columns !== undefined && { columns: space.columns }),
+    ...(space.rows !== undefined && { rows: space.rows }),
+  };
+}

--- a/packages/core-pptx/src/types.ts
+++ b/packages/core-pptx/src/types.ts
@@ -10,6 +10,7 @@ import type {
   GradientFill,
   PptxComponentDefaults,
   PptxRendererId,
+  ThemeConfigJson,
 } from '@json-to-office/shared-pptx';
 
 export interface PptxComponentInput {
@@ -133,59 +134,12 @@ export interface GridPosition {
   rowSpan?: number;
 }
 
-export interface TextStyle {
-  fontSize?: number;
-  fontFace?: string;
-  fontColor?: string;
-  bold?: boolean;
-  /**
-   * Per-style weight (100–900). Overrides `bold` when set — renderer picks
-   * the closest embedded variant via CSS font-matching and emits the run
-   * under a synthetic family alias (e.g. "Inter Light" for weight 300).
-   */
-  fontWeight?: number;
-  italic?: boolean;
-  align?: string;
-  lineSpacing?: number;
-  charSpacing?: number;
-  paraSpaceAfter?: number;
-}
+export type TextStyle = NonNullable<
+  NonNullable<ThemeConfigJson['styles']>['body']
+>;
+export type StyleName = keyof NonNullable<ThemeConfigJson['styles']>;
 
-export type StyleName =
-  | 'title'
-  | 'subtitle'
-  | 'heading1'
-  | 'heading2'
-  | 'heading3'
-  | 'body'
-  | 'caption';
-
-export interface PptxThemeConfig {
-  name: string;
-  colors: {
-    primary: string;
-    secondary: string;
-    accent: string;
-    background: string;
-    text: string;
-    text2?: string;
-    background2?: string;
-    accent4?: string;
-    accent5?: string;
-    accent6?: string;
-  };
-  fonts: {
-    heading: string;
-    body: string;
-  };
-  fontRegistry?: FontRegistryDefinition;
-  defaults: {
-    fontSize: number;
-    fontColor: string;
-  };
-  styles?: Partial<Record<StyleName, TextStyle>>;
-  componentDefaults?: PptxComponentDefaults;
-}
+export type PptxThemeConfig = ThemeConfigJson;
 
 export interface PlaceholderDefinition {
   name: string;

--- a/packages/core-pptx/src/utils/color.ts
+++ b/packages/core-pptx/src/utils/color.ts
@@ -6,7 +6,11 @@
 
 import type { PptxThemeConfig, PipelineWarning } from '../types';
 import { SEMANTIC_COLOR_NAMES } from '@json-to-office/shared-pptx';
-import { DEFAULT_CHART_THEME_COLORS } from '@json-to-office/shared';
+import {
+  DEFAULT_CHART_THEME_COLORS,
+  designColors,
+  resolveDesignColor,
+} from '@json-to-office/shared';
 import { warn, W } from './warn';
 
 // Build identity entries from the shared source of truth, then add aliases
@@ -74,6 +78,7 @@ function chainToHex(
  * fallback + warning.
  */
 export function definedChartColorTokens(theme: PptxThemeConfig): string[] {
+  if (theme.palette?.chart) return theme.palette.chart;
   const colors = theme?.colors as
     | Record<string, string | undefined>
     | undefined;
@@ -95,6 +100,13 @@ export function resolveColor(
   theme: PptxThemeConfig,
   warnings?: PipelineWarning[]
 ): string {
+  if (theme.palette) {
+    const hex = resolveDesignColor(
+      color,
+      designColors(theme.colors, theme.palette)
+    );
+    if (hex) return hex;
+  }
   const themeKey = SEMANTIC_TO_THEME_KEY[color];
   if (themeKey) {
     const resolved = theme.colors[themeKey];

--- a/packages/jto-cli/src/services/__tests__/json-validator.test.ts
+++ b/packages/jto-cli/src/services/__tests__/json-validator.test.ts
@@ -45,9 +45,10 @@ describe('JsonValidator custom schemas', () => {
     });
 
     expect(result).toMatchObject({ valid: true, type: 'custom' });
-    // Compiling a schema this size on a worker thread costs seconds, not
-    // milliseconds; the budget matches its siblings below.
-  }, 60_000);
+    // Compiling a schema this size costs seconds locally and the better part of
+    // a minute on a two-core runner, so this carries the same budget as the
+    // heaviest case below rather than a tighter one.
+  }, 180_000);
 
   it('compiles the deepest branch a document can actually reach', async () => {
     // Ajv compiles lazily, so an empty document proves nothing about the parts
@@ -101,7 +102,7 @@ describe('JsonValidator custom schemas', () => {
     });
 
     expect(result).toMatchObject({ valid: true, type: 'custom' });
-  }, 60_000);
+  }, 180_000);
 
   it('applies the document\u2019s own renderer rules inside a section header', async () => {
     // A section header reaches components through the recursive component

--- a/packages/jto-cli/src/services/__tests__/json-validator.test.ts
+++ b/packages/jto-cli/src/services/__tests__/json-validator.test.ts
@@ -45,7 +45,9 @@ describe('JsonValidator custom schemas', () => {
     });
 
     expect(result).toMatchObject({ valid: true, type: 'custom' });
-  });
+    // Compiling a schema this size on a worker thread costs seconds, not
+    // milliseconds; the budget matches its siblings below.
+  }, 60_000);
 
   it('compiles the deepest branch a document can actually reach', async () => {
     // Ajv compiles lazily, so an empty document proves nothing about the parts

--- a/packages/jto-cli/src/services/json-validator.ts
+++ b/packages/jto-cli/src/services/json-validator.ts
@@ -319,45 +319,24 @@ export class JsonValidator {
     strict?: boolean
   ): Promise<ValidateFileResult> {
     try {
-      const schemaContent = readFileSync(resolve(schemaPath), 'utf-8');
-      const schema = JSON.parse(schemaContent);
-
-      // Ajv bundles draft-07 under its canonical http URI. Accept the https
-      // spelling emitted by older json-to-office schema generators too.
-      if (schema.$schema === 'https://json-schema.org/draft-07/schema#') {
-        schema.$schema = 'http://json-schema.org/draft-07/schema#';
-      }
-
-      const Ajv = (await import('ajv')).default;
-      const addFormats = (await import('ajv-formats')).default;
-
-      const ajv = new Ajv({
-        allErrors: true,
-        verbose: true,
-        strict: strict ?? false,
-        // Renderer profiles make the DOCX schema substantially larger. Keep
-        // recursive refs as functions instead of inlining them into one giant
-        // validator, which overflows Ajv 8.12's compile stack.
-        inlineRefs: false,
-      });
-      addFormats(ajv);
-
-      const validate = ajv.compile(schema);
-      const valid = validate(jsonData);
-
-      const errors: ValidationError[] =
-        validate.errors?.map((error) => ({
-          path: error.instancePath || 'root',
-          message: error.message || 'Validation error',
-          code: error.keyword || 'validation_error',
-          value: error.data,
-        })) || [];
+      const { valid, errors } = await compileAndValidate(
+        resolve(schemaPath),
+        jsonData,
+        strict ?? false
+      );
 
       return {
         file: filePath,
-        valid: valid as boolean,
+        valid,
         type: 'custom',
-        errors: valid ? undefined : errors,
+        errors: valid
+          ? undefined
+          : errors.map((error) => ({
+              path: error.instancePath || 'root',
+              message: error.message || 'Validation error',
+              code: error.keyword || 'validation_error',
+              value: valueAtPointer(jsonData, error.instancePath),
+            })),
       };
     } catch (error: any) {
       return {
@@ -452,3 +431,128 @@ export class JsonValidator {
     return JSON.stringify(results, null, 2);
   }
 }
+
+interface SchemaErrorReport {
+  instancePath: string;
+  message?: string;
+  keyword?: string;
+}
+
+/**
+ * The value an Ajv error points at, read back from its `instancePath`.
+ *
+ * Ajv can hand this over itself under `verbose`, but only by embedding the
+ * subschema and the failing data at every error site in the validator it
+ * generates — which is exactly what this path cannot afford (see below).
+ */
+function valueAtPointer(data: unknown, pointer: string): unknown {
+  if (!pointer) return data;
+  let current: unknown = data;
+  for (const raw of pointer.slice(1).split('/')) {
+    if (current === null || typeof current !== 'object') return undefined;
+    const key = raw.replace(/~1/g, '/').replace(/~0/g, '~');
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+/**
+ * Compile an exported schema and validate one document against it, on a worker
+ * thread.
+ *
+ * The generated schemas are large — the DOCX document schema is several
+ * megabytes, most of it one recursive `ComponentDefinition` — and Ajv turns
+ * each recursive definition into a single generated function. A stack frame for
+ * a function that size, entered once per nesting level of the document, does
+ * not fit the ~1MB stack Node gives the main thread: validation threw
+ * `RangeError: Maximum call stack size exceeded` before it could report a
+ * single schema error, on documents the runtime validator accepts. A worker
+ * thread's stack is sized explicitly, so the ceiling is a number here rather
+ * than a property of the host.
+ *
+ * Ajv resolves from this module, not from the worker's cwd: the worker source
+ * is evaluated without a filename and could not find `ajv` on its own.
+ */
+async function compileAndValidate(
+  schemaPath: string,
+  data: unknown,
+  strict: boolean
+): Promise<{ valid: boolean; errors: SchemaErrorReport[] }> {
+  const { Worker } = await import('node:worker_threads');
+  const { default: Module } = await import('node:module');
+  const { pathToFileURL } = await import('node:url');
+  const require = Module.createRequire(import.meta.url);
+
+  return new Promise((resolvePromise, reject) => {
+    const worker = new Worker(SCHEMA_WORKER_SOURCE, {
+      eval: true,
+      workerData: {
+        ajvUrl: pathToFileURL(require.resolve('ajv')).href,
+        formatsUrl: pathToFileURL(require.resolve('ajv-formats')).href,
+        schemaPath,
+        data,
+        strict,
+      },
+      // 16MB carries the current schemas with room to grow; the default 4MB
+      // clears them today by a margin thin enough to break on the next
+      // component added.
+      resourceLimits: { stackSizeMb: 16 },
+    });
+    worker.once('message', (message) => {
+      void worker.terminate();
+      if (message.error) reject(new Error(message.error));
+      else resolvePromise({ valid: message.valid, errors: message.errors });
+    });
+    worker.once('error', reject);
+    worker.once('exit', (code) => {
+      if (code !== 0) reject(new Error(`Schema worker exited with ${code}`));
+    });
+  });
+}
+
+/**
+ * CommonJS on purpose: `eval`-ed worker source has no module context of its
+ * own, so it reaches Ajv through the file URLs the parent resolved.
+ */
+const SCHEMA_WORKER_SOURCE = `
+const { parentPort, workerData } = require('node:worker_threads');
+const { readFileSync } = require('node:fs');
+
+(async () => {
+  const ajvModule = await import(workerData.ajvUrl);
+  const formatsModule = await import(workerData.formatsUrl);
+  const Ajv = ajvModule.default?.default ?? ajvModule.default ?? ajvModule;
+  const addFormats =
+    formatsModule.default?.default ?? formatsModule.default ?? formatsModule;
+
+  const schema = JSON.parse(readFileSync(workerData.schemaPath, 'utf-8'));
+  // Ajv bundles draft-07 under its canonical http URI. Accept the https
+  // spelling emitted by older json-to-office schema generators too.
+  if (schema.$schema === 'https://json-schema.org/draft-07/schema#') {
+    schema.$schema = 'http://json-schema.org/draft-07/schema#';
+  }
+
+  const ajv = new Ajv({
+    allErrors: true,
+    strict: workerData.strict,
+    // Renderer profiles make the DOCX schema substantially larger. Keep
+    // recursive refs as functions instead of inlining them into one giant
+    // validator, which overflows Ajv 8.12's compile stack.
+    inlineRefs: false,
+  });
+  addFormats(ajv);
+
+  const validate = ajv.compile(schema);
+  const valid = validate(workerData.data);
+  parentPort.postMessage({
+    valid,
+    errors: (validate.errors ?? []).map((error) => ({
+      instancePath: error.instancePath,
+      message: error.message,
+      keyword: error.keyword,
+    })),
+  });
+})().catch((error) => {
+  parentPort.postMessage({ error: error?.message ?? String(error) });
+});
+`;

--- a/packages/mcp-server/src/__tests__/resources.test.ts
+++ b/packages/mcp-server/src/__tests__/resources.test.ts
@@ -153,6 +153,29 @@ describe('discovery resources', () => {
     }
   });
 
+  it('preserves extended visual values without changing theme-name discovery', async () => {
+    const extended = {
+      name: 'extended',
+      palette: { chart: ['#123456'] },
+      typography: { roles: { display: { size: 32 } } },
+      spacing: { basePt: 4 },
+      chrome: { sourceLine: { type: 'source' } },
+      motif: { kind: 'rule' },
+    };
+    const detailed = vi
+      .spyOn(deps.getAdapter('docx'), 'getBuiltinThemeValues')
+      .mockResolvedValue({ extended });
+    try {
+      const values = await readJson(RESOURCE_URIS.themeValues);
+      expect(
+        values.formats.find((entry: any) => entry.format === 'docx').themes
+          .extended
+      ).toEqual(extended);
+    } finally {
+      detailed.mockRestore();
+    }
+  });
+
   it('serves starter documents that validate', async () => {
     const { starters } = await readJson(RESOURCE_URIS.templates);
     expect(starters.length).toBeGreaterThanOrEqual(4);

--- a/packages/shared-docx/src/index.ts
+++ b/packages/shared-docx/src/index.ts
@@ -95,6 +95,7 @@ export type {
 
 export {
   ThemeConfigSchema,
+  ThemeOverridesSchema,
   isValidThemeConfig,
   createMinimalTheme,
 } from './schemas/theme';

--- a/packages/shared-docx/src/schemas/font.ts
+++ b/packages/shared-docx/src/schemas/font.ts
@@ -4,7 +4,7 @@
  */
 
 import { Type } from '@sinclair/typebox';
-import { FontFamilyNameSchema } from '@json-to-office/shared';
+import { FontFamilyNameSchema, TextCaseSchema } from '@json-to-office/shared';
 
 // ----------------------------------------------------------------------------
 // Shared Color Schema
@@ -71,6 +71,7 @@ export const NoProofWordsSchema = Type.Array(Type.String({ minLength: 1 }), {
  */
 export const TextFormattingPropertiesSchema = Type.Object(
   {
+    case: Type.Optional(TextCaseSchema),
     size: Type.Optional(Type.Number({ minimum: 8, maximum: 120 })),
     color: Type.Optional(HexColorSchema),
     bold: Type.Optional(Type.Boolean()),

--- a/packages/shared-docx/src/schemas/theme.ts
+++ b/packages/shared-docx/src/schemas/theme.ts
@@ -4,7 +4,10 @@
  */
 
 import { Type, Static } from '@sinclair/typebox';
-import { FontRegistrySchema } from '@json-to-office/shared';
+import {
+  FontRegistrySchema,
+  DesignSystemProperties,
+} from '@json-to-office/shared';
 import {
   FontDefinitionSchema,
   TextFormattingPropertiesSchema,
@@ -417,6 +420,7 @@ export const ThemeColorsSchema = Type.Object(
 
 export const ThemeOverridesSchema = Type.Object(
   {
+    ...DesignSystemProperties,
     colors: Type.Optional(Type.Partial(ThemeColorsSchema)),
     fonts: Type.Optional(Type.Partial(FontsSchema)),
     styles: Type.Optional(StyleDefinitionsSchema),
@@ -430,36 +434,13 @@ export const ThemeOverridesSchema = Type.Object(
 
 export const ThemeConfigSchema = Type.Object(
   {
+    ...DesignSystemProperties,
     $schema: Type.Optional(Type.String()),
     name: Type.String(),
     displayName: Type.String(),
     description: Type.String(),
     version: Type.String(),
-    colors: Type.Object(
-      {
-        primary: HexColorSchema,
-        secondary: HexColorSchema,
-        accent: HexColorSchema,
-        text: HexColorSchema,
-        background: HexColorSchema,
-        border: HexColorSchema,
-        // Additional semantic color names
-        textPrimary: HexColorSchema,
-        textSecondary: HexColorSchema,
-        textMuted: HexColorSchema,
-        borderPrimary: HexColorSchema,
-        borderSecondary: HexColorSchema,
-        backgroundPrimary: HexColorSchema,
-        backgroundSecondary: HexColorSchema,
-        // Extra chart-series slots, named to match the PPTX theme so both
-        // formats share one palette vocabulary. Optional: the bundled DOCX
-        // themes leave them unset and charts skip the empty slots.
-        accent4: Type.Optional(HexColorSchema),
-        accent5: Type.Optional(HexColorSchema),
-        accent6: Type.Optional(HexColorSchema),
-      },
-      { additionalProperties: false }
-    ),
+    colors: ThemeColorsSchema,
     fonts: FontsSchema,
     fontRegistry: Type.Optional(FontRegistrySchema),
     page: PageSchema,

--- a/packages/shared-pptx/src/schemas/theme.ts
+++ b/packages/shared-pptx/src/schemas/theme.ts
@@ -7,6 +7,8 @@ import { Value } from '@sinclair/typebox/value';
 import {
   FontFamilyNameSchema,
   FontRegistrySchema,
+  DesignSystemProperties,
+  TextCaseSchema,
 } from '@json-to-office/shared';
 import {
   ColorValueSchema,
@@ -98,6 +100,8 @@ export const TextStyleSchema = Type.Object(
     lineSpacing: Type.Optional(Type.Number()),
     charSpacing: Type.Optional(Type.Number()),
     paraSpaceAfter: Type.Optional(Type.Number()),
+    paraSpaceBefore: Type.Optional(Type.Number()),
+    case: Type.Optional(TextCaseSchema),
   },
   { additionalProperties: false, description: 'Text style preset' }
 );
@@ -108,6 +112,10 @@ export type TextStyle = Static<typeof TextStyleSchema>;
 
 export const ThemeConfigSchema = Type.Object(
   {
+    ...DesignSystemProperties,
+    displayName: Type.Optional(Type.String()),
+    description: Type.Optional(Type.String()),
+    version: Type.Optional(Type.String()),
     name: Type.String({ description: 'Theme name' }),
     colors: Type.Object(
       {
@@ -131,6 +139,8 @@ export const ThemeConfigSchema = Type.Object(
       {
         heading: FontFamilyNameSchema,
         body: FontFamilyNameSchema,
+        mono: Type.Optional(FontFamilyNameSchema),
+        light: Type.Optional(FontFamilyNameSchema),
       },
       { additionalProperties: false, description: 'Font families' }
     ),
@@ -147,7 +157,7 @@ export const ThemeConfigSchema = Type.Object(
         Type.Object(
           Object.fromEntries(
             STYLE_NAMES.map((n) => [n, TextStyleSchema])
-          ) as Record<string, typeof TextStyleSchema>
+          ) as Record<(typeof STYLE_NAMES)[number], typeof TextStyleSchema>
         ),
         { additionalProperties: false, description: 'Named text style presets' }
       )

--- a/packages/shared/src/__tests__/design-system.test.ts
+++ b/packages/shared/src/__tests__/design-system.test.ts
@@ -36,13 +36,15 @@ describe('shared visual theme contract', () => {
     expect(designCanvas('pptx', { width: 10, height: 10 })).toBe('standard43');
     const theme = {
       typography: {
-        roles: { display: {}, source: { size: 9 } },
-        scale: { a4: { base: 12, ratio: 1.25, baselinePt: 4 } },
+        roles: { display: {}, source: { size: 9 }, tableCell: {} },
+        scale: { a4: { base: 11, ratio: 1.25, baselinePt: 4 } },
       },
     };
+    // A step-0 role keeps the authored base rather than snapping to 12.
     expect(resolveTypeRoles(theme, 'a4', 11)).toEqual({
       display: { size: 28 },
       source: { size: 9 },
+      tableCell: { size: 11 },
     });
     expect(resolveTypeRoles(theme, 'letter', 11).display?.size).toBe(11);
   });

--- a/packages/shared/src/__tests__/design-system.test.ts
+++ b/packages/shared/src/__tests__/design-system.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+import {
+  DesignSystemSchema,
+  designCanvas,
+  resolveTypeRoles,
+  validateDesignColors,
+} from '../theme/design-system';
+
+describe('shared visual theme contract', () => {
+  it('is additive, strict, and contains no content requirements', () => {
+    expect(Value.Check(DesignSystemSchema, {})).toBe(true);
+    for (const invalid of [
+      { palette: { chart: [] } },
+      { palette: { rule: '#xyz' } },
+      { typography: { roles: { display: { weight: 1000 } } } },
+      { typography: { roles: { typo: {} } } },
+      { spacing: { canvas: { a4: { gutterIn: -1 } } } },
+      { chrome: { actionTitle: { required: true } } },
+      { motif: { kind: 'rule', minCount: 1 } },
+    ])
+      expect(Value.Check(DesignSystemSchema, invalid)).toBe(false);
+    const walk = (schema: Record<string, any>) => {
+      for (const [key, child] of Object.entries(schema.properties ?? {})) {
+        expect(key).not.toMatch(/^(required|must|min|max|archetype|density)/i);
+        walk(child as Record<string, any>);
+      }
+    };
+    walk(DesignSystemSchema);
+  });
+
+  it('derives canvas sizes deterministically; explicit role sizes win', () => {
+    expect(designCanvas('docx', 'LETTER')).toBe('letter');
+    expect(designCanvas('docx', 'LEGAL')).toBe('a4');
+    expect(designCanvas('pptx', { width: 16, height: 9 })).toBe('wide169');
+    expect(designCanvas('pptx', { width: 10, height: 10 })).toBe('standard43');
+    const theme = {
+      typography: {
+        roles: { display: {}, source: { size: 9 } },
+        scale: { a4: { base: 12, ratio: 1.25, baselinePt: 4 } },
+      },
+    };
+    expect(resolveTypeRoles(theme, 'a4', 11)).toEqual({
+      display: { size: 28 },
+      source: { size: 9 },
+    });
+    expect(resolveTypeRoles(theme, 'letter', 11).display?.size).toBe(11);
+  });
+
+  it('rejects cycles and missing palette targets without recursion', () => {
+    expect(() =>
+      validateDesignColors(
+        { palette: { rule: 'textMuted', textMuted: 'rule' } },
+        {}
+      )
+    ).toThrow(/cycle/);
+    expect(() =>
+      validateDesignColors({ palette: { chart: ['missing'] } }, {})
+    ).toThrow(/palette.chart\[0\]/);
+    expect(() =>
+      validateDesignColors(
+        { palette: { chart: ['positive'], positive: 'primary' } },
+        { primary: '#123456' }
+      )
+    ).not.toThrow();
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -175,6 +175,7 @@ export {
 
 // Cross-format theme constants
 export { DEFAULT_CHART_THEME_COLORS } from './theme/chart-palette';
+export * from './theme/design-system';
 
 // Deep merge utilities
 export { mergeWithDefaults } from './utils/deepMerge';

--- a/packages/shared/src/schemas/slide-content/theme.ts
+++ b/packages/shared/src/schemas/slide-content/theme.ts
@@ -3,6 +3,7 @@
  */
 
 import { Type } from '@sinclair/typebox';
+import { TYPE_ROLES } from '../../theme/design-system';
 
 const HexColorSchema = Type.String({
   pattern: '^#?[0-9A-Fa-f]{6}$',
@@ -50,6 +51,7 @@ export const STYLE_NAMES = [
   'heading3',
   'body',
   'caption',
+  ...TYPE_ROLES,
 ] as const;
 
 export const StyleNameSchema = Type.Union(

--- a/packages/shared/src/theme/chart-palette.ts
+++ b/packages/shared/src/theme/chart-palette.ts
@@ -17,8 +17,9 @@
  * is a preference-ordered pool of candidate colors, not fixed per-series slots,
  * so keeping a color the theme did define beats dropping or duplicating one.
  *
- * A slot may also hold another token's name (`"accent4": "primary"`) — both
- * theme schemas allow it — and both formats walk that reference to hex before
+ * DOCX legacy slots and both formats' new `palette` roles may name another
+ * token. Legacy PPTX `colors` slots accept hex only at validation, though
+ * both runtime resolvers walk references to hex before
  * using it, so a chained slot lands on the same color in a deck as in a
  * document. A slot whose value reaches no hex (`"accent4": "nonsense"`, or a
  * reference cycle) is dropped from the implicit palette in both formats rather

--- a/packages/shared/src/theme/design-system.ts
+++ b/packages/shared/src/theme/design-system.ts
@@ -207,7 +207,18 @@ export const MotifSchema = Type.Object(
     ]),
     color: Type.Optional(ColorTokenSchema),
     weightPt: Type.Optional(Type.Number({ minimum: 0 })),
-    placement: Type.Optional(Type.String()),
+    placement: Type.Optional(
+      Type.Union([
+        Type.Literal('top'),
+        Type.Literal('bottom'),
+        Type.Literal('left'),
+        Type.Literal('right'),
+        Type.Literal('topLeft'),
+        Type.Literal('topRight'),
+        Type.Literal('bottomLeft'),
+        Type.Literal('bottomRight'),
+      ])
+    ),
   },
   {
     additionalProperties: false,
@@ -251,6 +262,44 @@ export const ROLE_SCALE_STEPS: Record<TypeRoleName, number> = {
   footer: -2,
   source: -2,
 };
+type Scale = Static<typeof ScaleSchema>;
+
+/**
+ * `base × ratio^step`, snapped to the nearest baseline multiple and clamped to
+ * the schema's 5-200pt window. A step-0 role keeps `base` exactly: snapping a
+ * role that asked for no scaling would silently retune the authored base size.
+ */
+function scaledSize(scale: Scale, step: number): number {
+  if (step === 0) return scale.base;
+  const baseline = scale.baselinePt ?? 4;
+  const exact = scale.base * (scale.ratio ?? 1.25) ** step;
+  return Math.max(5, Math.min(200, Math.round(exact / baseline) * baseline));
+}
+
+/** The palette minus its ordered chart array, which no scalar resolver reads. */
+function paletteScalars(
+  palette?: DesignSystem['palette']
+): Record<string, string | undefined> {
+  const scalars: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(palette ?? {})) {
+    if (typeof value === 'string') scalars[key] = value;
+  }
+  return scalars;
+}
+
+/**
+ * Case as DOCX run flags. Word inherits case from the style, so a run that
+ * asks for `none` must state the flag it turns off rather than omit it.
+ */
+export function capsFormatting(textCase: 'none' | 'upper' | 'smallCaps'): {
+  allCaps?: boolean;
+  smallCaps?: boolean;
+} {
+  return textCase === 'upper'
+    ? { allCaps: true }
+    : { smallCaps: textCase === 'smallCaps' };
+}
+
 export function resolveTypeRoles(
   system: DesignSystem,
   canvas: DesignCanvas,
@@ -261,20 +310,11 @@ export function resolveTypeRoles(
   for (const name of TYPE_ROLES) {
     const role = system.typography?.roles?.[name];
     if (!role) continue;
-    const step = scale?.baselinePt ?? 4;
-    const derived = scale
-      ? Math.max(
-          5,
-          Math.min(
-            200,
-            Math.round(
-              (scale.base * (scale.ratio ?? 1.25) ** ROLE_SCALE_STEPS[name]) /
-                step
-            ) * step
-          )
-        )
-      : base;
-    roles[name] = { ...role, size: role.size ?? derived };
+    roles[name] = {
+      ...role,
+      size:
+        role.size ?? (scale ? scaledSize(scale, ROLE_SCALE_STEPS[name]) : base),
+    };
   }
   return roles;
 }
@@ -284,9 +324,7 @@ export function designColors(
   colors: Record<string, string | undefined>,
   palette?: DesignSystem['palette']
 ): Record<string, string | undefined> {
-  const { chart: _chart, ...scalars } = palette ?? {};
-  void _chart;
-  return { ...colors, ...scalars };
+  return { ...colors, ...paletteScalars(palette) };
 }
 export function resolveDesignColor(
   value: string,

--- a/packages/shared/src/theme/design-system.ts
+++ b/packages/shared/src/theme/design-system.ts
@@ -1,0 +1,334 @@
+import { Type, type Static } from '@sinclair/typebox';
+
+/** Visual values only. Profiles and blueprints own required content. */
+export const TYPE_ROLES = [
+  'eyebrow',
+  'display',
+  'stat',
+  'quote',
+  'label',
+  'footer',
+  'tableHeader',
+  'tableCell',
+  'chartLabel',
+  'tracker',
+  'source',
+] as const;
+export const TypeRoleNameSchema = Type.Union(
+  TYPE_ROLES.map((name) => Type.Literal(name))
+);
+export type TypeRoleName = (typeof TYPE_ROLES)[number];
+export const CANVASES = ['a4', 'letter', 'wide169', 'standard43'] as const;
+export type DesignCanvas = (typeof CANVASES)[number];
+export const TextCaseSchema = Type.Union([
+  Type.Literal('none'),
+  Type.Literal('upper'),
+  Type.Literal('smallCaps'),
+]);
+const ColorTokenSchema = Type.String({
+  pattern: '^(#?[0-9A-Fa-f]{6}|[a-zA-Z][a-zA-Z0-9]*)$',
+  description:
+    'Six-digit hex or a theme color/palette token. References must resolve without cycles.',
+});
+export const PaletteSchema = Type.Object(
+  {
+    rule: Type.Optional(ColorTokenSchema),
+    textMuted: Type.Optional(ColorTokenSchema),
+    onPrimary: Type.Optional(ColorTokenSchema),
+    surfaceInverse: Type.Optional(ColorTokenSchema),
+    positive: Type.Optional(ColorTokenSchema),
+    negative: Type.Optional(ColorTokenSchema),
+    chart: Type.Optional(
+      Type.Array(ColorTokenSchema, { minItems: 1, maxItems: 12 })
+    ),
+  },
+  { additionalProperties: false }
+);
+
+export const TypeRoleSchema = Type.Object(
+  {
+    face: Type.Optional(
+      Type.Union([
+        Type.Literal('heading'),
+        Type.Literal('body'),
+        Type.Literal('mono'),
+        Type.Literal('light'),
+      ])
+    ),
+    weight: Type.Optional(Type.Integer({ minimum: 100, maximum: 900 })),
+    size: Type.Optional(
+      Type.Number({
+        minimum: 5,
+        maximum: 200,
+        description:
+          'Explicit size in points; takes precedence over the canvas scale.',
+      })
+    ),
+    lineHeight: Type.Optional(Type.Number({ minimum: 0.5, maximum: 3 })),
+    tracking: Type.Optional(
+      Type.Number({ description: 'Tracking in hundredths of an em.' })
+    ),
+    case: Type.Optional(TextCaseSchema),
+    color: Type.Optional(ColorTokenSchema),
+    spaceBefore: Type.Optional(Type.Number({ minimum: 0 })),
+    spaceAfter: Type.Optional(Type.Number({ minimum: 0 })),
+  },
+  { additionalProperties: false }
+);
+// Explicit properties preserve literal keys in Static<> (Object.fromEntries does not).
+export const TypeRolesSchema = Type.Object(
+  {
+    eyebrow: Type.Optional(TypeRoleSchema),
+    display: Type.Optional(TypeRoleSchema),
+    stat: Type.Optional(TypeRoleSchema),
+    quote: Type.Optional(TypeRoleSchema),
+    label: Type.Optional(TypeRoleSchema),
+    footer: Type.Optional(TypeRoleSchema),
+    tableHeader: Type.Optional(TypeRoleSchema),
+    tableCell: Type.Optional(TypeRoleSchema),
+    chartLabel: Type.Optional(TypeRoleSchema),
+    tracker: Type.Optional(TypeRoleSchema),
+    source: Type.Optional(TypeRoleSchema),
+  },
+  { additionalProperties: false }
+);
+const ScaleSchema = Type.Object(
+  {
+    base: Type.Number({ minimum: 5, maximum: 200 }),
+    ratio: Type.Optional(Type.Number({ minimum: 1, maximum: 2 })),
+    baselinePt: Type.Optional(
+      Type.Number({ exclusiveMinimum: 0, maximum: 24 })
+    ),
+  },
+  { additionalProperties: false }
+);
+export const TypographySchema = Type.Object(
+  {
+    roles: Type.Optional(TypeRolesSchema),
+    scale: Type.Optional(
+      Type.Object(
+        {
+          a4: Type.Optional(ScaleSchema),
+          letter: Type.Optional(ScaleSchema),
+          wide169: Type.Optional(ScaleSchema),
+          standard43: Type.Optional(ScaleSchema),
+        },
+        { additionalProperties: false }
+      )
+    ),
+  },
+  { additionalProperties: false }
+);
+const CanvasSpacingSchema = Type.Object(
+  {
+    safeAreaIn: Type.Optional(Type.Number({ minimum: 0 })),
+    gutterIn: Type.Optional(Type.Number({ minimum: 0 })),
+    columns: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+    rows: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+  },
+  { additionalProperties: false }
+);
+export const DesignSpacingSchema = Type.Object(
+  {
+    basePt: Type.Optional(Type.Number({ exclusiveMinimum: 0 })),
+    blockGap: Type.Optional(
+      Type.Object(
+        {
+          tight: Type.Optional(Type.Number({ minimum: 0 })),
+          normal: Type.Optional(Type.Number({ minimum: 0 })),
+          loose: Type.Optional(Type.Number({ minimum: 0 })),
+        },
+        { additionalProperties: false }
+      )
+    ),
+    canvas: Type.Optional(
+      Type.Object(
+        {
+          a4: Type.Optional(CanvasSpacingSchema),
+          letter: Type.Optional(CanvasSpacingSchema),
+          wide169: Type.Optional(CanvasSpacingSchema),
+          standard43: Type.Optional(CanvasSpacingSchema),
+        },
+        { additionalProperties: false }
+      )
+    ),
+  },
+  { additionalProperties: false }
+);
+const RecipeSchema = Type.Object(
+  {
+    type: Type.Optional(TypeRoleNameSchema),
+    color: Type.Optional(ColorTokenSchema),
+    fill: Type.Optional(ColorTokenSchema),
+    rule: Type.Optional(
+      Type.Object(
+        {
+          weightPt: Type.Optional(Type.Number({ minimum: 0 })),
+          color: Type.Optional(ColorTokenSchema),
+        },
+        { additionalProperties: false }
+      )
+    ),
+    padPt: Type.Optional(Type.Number({ minimum: 0 })),
+    alignment: Type.Optional(
+      Type.Union([
+        Type.Literal('left'),
+        Type.Literal('center'),
+        Type.Literal('right'),
+      ])
+    ),
+  },
+  { additionalProperties: false }
+);
+export const ChromeSchema = Type.Object(
+  {
+    runningHead: Type.Optional(RecipeSchema),
+    tracker: Type.Optional(RecipeSchema),
+    actionTitle: Type.Optional(RecipeSchema),
+    keyTakeaways: Type.Optional(RecipeSchema),
+    sourceLine: Type.Optional(RecipeSchema),
+    confidentialFooter: Type.Optional(RecipeSchema),
+    logoSlot: Type.Optional(RecipeSchema),
+    cover: Type.Optional(RecipeSchema),
+  },
+  {
+    additionalProperties: false,
+    description:
+      'Visual recipes; consumers land in #361. No automatic content or presence requirements.',
+  }
+);
+export const MotifSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal('none'),
+      Type.Literal('rule'),
+      Type.Literal('corner'),
+      Type.Literal('band'),
+    ]),
+    color: Type.Optional(ColorTokenSchema),
+    weightPt: Type.Optional(Type.Number({ minimum: 0 })),
+    placement: Type.Optional(Type.String()),
+  },
+  {
+    additionalProperties: false,
+    description: 'At most one motif. Rendering consumers land in #361.',
+  }
+);
+export const DesignSystemProperties = {
+  palette: Type.Optional(PaletteSchema),
+  typography: Type.Optional(TypographySchema),
+  spacing: Type.Optional(DesignSpacingSchema),
+  chrome: Type.Optional(ChromeSchema),
+  motif: Type.Optional(MotifSchema),
+};
+export const DesignSystemSchema = Type.Object(DesignSystemProperties, {
+  additionalProperties: false,
+});
+export type DesignSystem = Static<typeof DesignSystemSchema>;
+export type TypeRole = Static<typeof TypeRoleSchema>;
+
+/** Custom paper uses A4; custom slides use the closest supported aspect ratio. */
+export function designCanvas(
+  format: 'docx' | 'pptx',
+  size?: string | { width: number; height: number }
+): DesignCanvas {
+  if (format === 'docx') return size === 'LETTER' ? 'letter' : 'a4';
+  const ratio = typeof size === 'object' ? size.width / size.height : 4 / 3;
+  return Math.abs(ratio - 16 / 9) < Math.abs(ratio - 4 / 3)
+    ? 'wide169'
+    : 'standard43';
+}
+export const ROLE_SCALE_STEPS: Record<TypeRoleName, number> = {
+  display: 4,
+  stat: 3,
+  quote: 1,
+  tableHeader: 0,
+  tableCell: 0,
+  label: -1,
+  eyebrow: -1,
+  chartLabel: -1,
+  tracker: -1,
+  footer: -2,
+  source: -2,
+};
+export function resolveTypeRoles(
+  system: DesignSystem,
+  canvas: DesignCanvas,
+  base: number
+): Partial<Record<TypeRoleName, TypeRole & { size: number }>> {
+  const scale = system.typography?.scale?.[canvas];
+  const roles: Partial<Record<TypeRoleName, TypeRole & { size: number }>> = {};
+  for (const name of TYPE_ROLES) {
+    const role = system.typography?.roles?.[name];
+    if (!role) continue;
+    const step = scale?.baselinePt ?? 4;
+    const derived = scale
+      ? Math.max(
+          5,
+          Math.min(
+            200,
+            Math.round(
+              (scale.base * (scale.ratio ?? 1.25) ** ROLE_SCALE_STEPS[name]) /
+                step
+            ) * step
+          )
+        )
+      : base;
+    roles[name] = { ...role, size: role.size ?? derived };
+  }
+  return roles;
+}
+
+/** Exclude ordered chart arrays from the scalar resolver. Palette overrides legacy tokens. */
+export function designColors(
+  colors: Record<string, string | undefined>,
+  palette?: DesignSystem['palette']
+): Record<string, string | undefined> {
+  const { chart: _chart, ...scalars } = palette ?? {};
+  void _chart;
+  return { ...colors, ...scalars };
+}
+export function resolveDesignColor(
+  value: string,
+  colors: Record<string, string | undefined>
+): string | undefined {
+  const seen = new Set<string>();
+  let current: string | undefined = value;
+  while (current !== undefined && !seen.has(current)) {
+    // Token lookup first, consistent with legacy resolvers.
+    if (!current.startsWith('#') && Object.hasOwn(colors, current)) {
+      seen.add(current);
+      current = colors[current];
+    } else {
+      return /^#?[0-9a-f]{6}$/i.test(current)
+        ? current.replace(/^#/, '')
+        : undefined;
+    }
+  }
+  return undefined;
+}
+
+/** Reject dangling/cyclic new tokens before they can become invalid OOXML. */
+export function validateDesignColors(
+  system: DesignSystem,
+  colors: Record<string, string | undefined>
+): void {
+  const resolved = designColors(colors, system.palette);
+  const entries = Object.entries(system.palette ?? {}).flatMap(
+    ([key, value]) =>
+      Array.isArray(value)
+        ? value.map((entry, i) => [`palette.${key}[${i}]`, entry])
+        : [[`palette.${key}`, value]]
+  );
+  for (const [name, role] of Object.entries(system.typography?.roles ?? {})) {
+    if (role.color)
+      entries.push([`typography.roles.${name}.color`, role.color]);
+  }
+  for (const [path, value] of entries) {
+    if (value && !resolveDesignColor(value, resolved)) {
+      throw new Error(
+        `Unresolvable theme color at ${path}: "${value}" (unknown token or cycle)`
+      );
+    }
+  }
+}


### PR DESCRIPTION
Themes can now declare shared palette, typography and canvas-spacing values. DOCX and PPTX project named roles into rendered styles, use ordered chart palettes, and expose the extra colors to quality checks. DOCX theme weights now render correctly; both formats support case formatting.

The change is opt-in: bundled themes keep their appearance, and coordinate-authored documents gain no required content. New corpus cases prove the foundation, using vermilion overrides for DOCX. One existing golden changes intentionally for the DOCX numeric-weight fix. Chrome/motif recipes are schema contracts only; rendering remains in #361. PPTX small caps use uppercase runs at 80% size, documented alongside units and precedence.

## Review fixes

- **`w:rPr` child order.** `CT_RPr` is an ordered sequence, so the case repair now inserts the opposite `w:caps`/`w:smallCaps` flag next to the flag already present instead of appending it after `color`/`sz`. The pass moved out of the ZIP canonicalizer into `utils/normalizeTextCase.ts` — semantic run rewriting is not package canonicalization — and the `theme/shared-foundation` golden moves with it. A test pins the ordering in both DOCX backends.
- **Step-0 type roles.** A role with scale step 0 (`tableHeader`, `tableCell`) keeps the authored `base` exactly; previously `base: 11` snapped to 12. Only scaled steps snap to `baselinePt`. Reference doc updated.
- **PPTX rich-text gate.** The gate reads the authored runs, before small-caps lowering splits one run into several — a rendering device, not rich text. Regression test asserts the split still happens and `rich-text` is not required.
- **One chart-palette source in DOCX.** `chartPaletteValues(theme)` in `colorUtils` holds the `palette.chart` vs legacy-slot choice once; the native chart compiler and the Highcharts component both read it and keep their own resolution policy.
- **Shared translations.** `capsFormatting` (case → run flags) and a local `weightedFamily` replace the three- and two-site copies in the compiler and `themeToStyles`.
- **`motif.placement`** is an enum (`top`/`bottom`/`left`/`right` plus the four corners) rather than an unconstrained string, and `designColors` names its palette-scalar filter instead of discarding `chart` with a `void`.
- Documented why `resolvePptxDesignSystem` runs in both the prologue and `processPresentation`, and why a small-caps run's pieces each carry its hyperlink.

Not changed: `getStyleSafe` dropping `isValidStyleName` was flagged as newly compiling arbitrary `theme.styles` keys into Word styles — those keys already compiled through the `|| styleValue` fallback; what changed is that they now honor `baseStyle` inheritance and stop warning.

## Schema-validation ceiling

Conformance failed on the growth alone: the exported DOCX schema gained 3.4%, and Ajv compiles each recursive definition into a single generated function whose stack frame no longer fit the main thread's stack — validation threw `RangeError: Maximum call stack size exceeded` before reporting any schema error, on documents the runtime validator accepts. `jto-cli` now compiles on a worker thread with a stated 16MB stack and no longer asks Ajv for `verbose` errors (which inline every subschema into the generated code); the failing value is read back from `instancePath`, so reported paths, messages and values are unchanged. The two overflow-guard tests carry the 180s budget their heaviest sibling already had — that compile costs ~4s locally and most of a minute on a two-core runner.

Validation: build/schema generation, lint, typecheck, formatting, docs build, renderer-doc checks, and shipped-asset validation pass. Output tests cover both generation pipelines and all four backends; MCP discovery preserves extended values. The full suite passes serially (`turbo test --concurrency=1`, 22/22 tasks); under default concurrency the application package still hits its local 5-second plugin-loading timeout on one discovery test and passes all 595 with `--maxWorkers=2 --minWorkers=1` (timeout unchanged).

Closes #328.
