### PR TITLE
design-evals: human calibration on the checkpoint sets (#360, #362)

### DIFF
--- a/packages/design-evals/baselines/2026-09-08-human-checkpoint-verdicts.json
+++ b/packages/design-evals/baselines/2026-09-08-human-checkpoint-verdicts.json
@@ -1,0 +1,507 @@
+{
+  "note": "Paolo, 2026-09-08, blind guided review of the 48 checkpoint contact sheets (before and after sets, shuffled) then 24 before/after pairs of the same brief and pass, sides randomised. Absolute question: would you send this to the client unchanged; reasons are one-tap chips (pages = empty or half-blank pages, prose = prose where a table or chart was owed, generic, data = chart or table wrong, other). Pairwise question: which would you rather send.",
+  "reviewer": "paolo",
+  "sets": {
+    "before": "2026-09-07-checkpoint-before-cold-server-4.4.0.json",
+    "after": "2026-09-08-checkpoint-after-cold-server-4.4.2.json"
+  },
+  "summary": {
+    "wouldShip": {
+      "before": 10,
+      "after": 8,
+      "of": 24
+    },
+    "pairs": {
+      "before": 12,
+      "tie": 6,
+      "after": 6
+    },
+    "reasons": {
+      "pages": 30
+    }
+  },
+  "verdicts": [
+    {
+      "set": "after",
+      "run": "cr-brand-repositioning#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:29:15.461Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-brand-repositioning#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:30:25.358Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-brand-repositioning#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:28:42.176Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-brand-repositioning#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:28:32.138Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-brand-repositioning#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:30:06.474Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-brand-repositioning#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:28:33.599Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-cost-programme-review#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:29:32.482Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-cost-programme-review#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:27:17.004Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-cost-programme-review#2",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:29:26.074Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-cost-programme-review#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:27:50.369Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-cost-programme-review#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:31:04.010Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-cost-programme-review#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:26:46.033Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-esg-reporting-readiness#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:30:17.324Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-esg-reporting-readiness#1",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:29:23.923Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-esg-reporting-readiness#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:29:30.903Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-esg-reporting-readiness#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:30:16.094Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-esg-reporting-readiness#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:30:13.880Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-esg-reporting-readiness#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:31:17.326Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-market-entry-nordics#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:29:07.241Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-market-entry-nordics#1",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:27:26.961Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-market-entry-nordics#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:28:05.631Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-market-entry-nordics#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:26:12.494Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-market-entry-nordics#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:29:21.251Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-market-entry-nordics#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:30:18.471Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-post-merger-integration#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:27:08.054Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-post-merger-integration#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:31:27.156Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-post-merger-integration#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:26:32.961Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-post-merger-integration#2",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:30:11.405Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-post-merger-integration#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:27:46.469Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-post-merger-integration#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:26:01.250Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-pricing-review-logistics#1",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:28:00.048Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-pricing-review-logistics#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:31:28.890Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-pricing-review-logistics#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:31:09.101Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-pricing-review-logistics#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:30:32.223Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-pricing-review-logistics#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:28:14.998Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-pricing-review-logistics#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:26:56.560Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-service-model-redesign#1",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:29:05.404Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-service-model-redesign#1",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:27:33.258Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-service-model-redesign#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:28:35.129Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-service-model-redesign#2",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:29:27.049Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-service-model-redesign#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:28:39.817Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-service-model-redesign#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:25:55.806Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-workforce-planning#1",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:30:51.699Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-workforce-planning#1",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:28:12.384Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-workforce-planning#2",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:31:12.961Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-workforce-planning#2",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:31:20.745Z"
+    },
+    {
+      "set": "after",
+      "run": "cr-workforce-planning#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-08T07:27:56.907Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-workforce-planning#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-08T07:28:26.938Z"
+    }
+  ],
+  "pairs": [
+    {
+      "pair": "cr-brand-repositioning#1",
+      "preferred": "before",
+      "leftWas": "after",
+      "at": "2026-09-08T07:32:17.623Z"
+    },
+    {
+      "pair": "cr-brand-repositioning#2",
+      "preferred": "tie",
+      "leftWas": "after",
+      "at": "2026-09-08T07:36:59.268Z"
+    },
+    {
+      "pair": "cr-brand-repositioning#3",
+      "preferred": "tie",
+      "leftWas": "after",
+      "at": "2026-09-08T07:35:08.184Z"
+    },
+    {
+      "pair": "cr-cost-programme-review#1",
+      "preferred": "before",
+      "leftWas": "before",
+      "at": "2026-09-08T07:36:33.902Z"
+    },
+    {
+      "pair": "cr-cost-programme-review#2",
+      "preferred": "after",
+      "leftWas": "after",
+      "at": "2026-09-08T07:35:22.517Z"
+    },
+    {
+      "pair": "cr-cost-programme-review#3",
+      "preferred": "before",
+      "leftWas": "before",
+      "at": "2026-09-08T07:37:02.401Z"
+    },
+    {
+      "pair": "cr-esg-reporting-readiness#1",
+      "preferred": "before",
+      "leftWas": "before",
+      "at": "2026-09-08T07:36:36.752Z"
+    },
+    {
+      "pair": "cr-esg-reporting-readiness#2",
+      "preferred": "tie",
+      "leftWas": "before",
+      "at": "2026-09-08T07:34:10.986Z"
+    },
+    {
+      "pair": "cr-esg-reporting-readiness#3",
+      "preferred": "tie",
+      "leftWas": "before",
+      "at": "2026-09-08T07:36:14.134Z"
+    },
+    {
+      "pair": "cr-market-entry-nordics#1",
+      "preferred": "tie",
+      "leftWas": "before",
+      "at": "2026-09-08T07:35:46.267Z"
+    },
+    {
+      "pair": "cr-market-entry-nordics#2",
+      "preferred": "tie",
+      "leftWas": "before",
+      "at": "2026-09-08T07:35:54.201Z"
+    },
+    {
+      "pair": "cr-market-entry-nordics#3",
+      "preferred": "after",
+      "leftWas": "before",
+      "at": "2026-09-08T07:36:26.417Z"
+    },
+    {
+      "pair": "cr-post-merger-integration#1",
+      "preferred": "after",
+      "leftWas": "after",
+      "at": "2026-09-08T07:36:10.384Z"
+    },
+    {
+      "pair": "cr-post-merger-integration#2",
+      "preferred": "before",
+      "leftWas": "before",
+      "at": "2026-09-08T07:36:23.950Z"
+    },
+    {
+      "pair": "cr-post-merger-integration#3",
+      "preferred": "after",
+      "leftWas": "before",
+      "at": "2026-09-08T07:32:26.372Z"
+    },
+    {
+      "pair": "cr-pricing-review-logistics#1",
+      "preferred": "after",
+      "leftWas": "after",
+      "at": "2026-09-08T07:36:40.484Z"
+    },
+    {
+      "pair": "cr-pricing-review-logistics#2",
+      "preferred": "before",
+      "leftWas": "after",
+      "at": "2026-09-08T07:32:05.489Z"
+    },
+    {
+      "pair": "cr-pricing-review-logistics#3",
+      "preferred": "before",
+      "leftWas": "after",
+      "at": "2026-09-08T07:35:49.817Z"
+    },
+    {
+      "pair": "cr-service-model-redesign#1",
+      "preferred": "before",
+      "leftWas": "after",
+      "at": "2026-09-08T07:35:39.901Z"
+    },
+    {
+      "pair": "cr-service-model-redesign#2",
+      "preferred": "before",
+      "leftWas": "after",
+      "at": "2026-09-08T07:32:14.106Z"
+    },
+    {
+      "pair": "cr-service-model-redesign#3",
+      "preferred": "before",
+      "leftWas": "after",
+      "at": "2026-09-08T07:31:44.916Z"
+    },
+    {
+      "pair": "cr-workforce-planning#1",
+      "preferred": "before",
+      "leftWas": "before",
+      "at": "2026-09-08T07:32:49.057Z"
+    },
+    {
+      "pair": "cr-workforce-planning#2",
+      "preferred": "before",
+      "leftWas": "before",
+      "at": "2026-09-08T07:36:05.685Z"
+    },
+    {
+      "pair": "cr-workforce-planning#3",
+      "preferred": "after",
+      "leftWas": "before",
+      "at": "2026-09-08T07:32:22.517Z"
+    }
+  ]
+}

--- a/packages/design-evals/baselines/README.md
+++ b/packages/design-evals/baselines/README.md
@@ -16,6 +16,7 @@ numbers; use fresh matched runs with the guards before making acceptance claims.
 | `2026-09-08-checkpoint-after-cold-server-4.4.2.json`  | cold | 4.4.2  | claude-sonnet-5 | 24 (set `client-report-checkpoint`, 8 × 3) | yes (claude-opus-5) |
 | `2026-09-08-rejudge-checkpoint-before.json`           | —    | —      | —               | 24 rejudged, same session as the next row  | claude-opus-5       |
 | `2026-09-08-rejudge-checkpoint-after.json`            | —    | —      | —               | 24 rejudged, same session as the row above | claude-opus-5       |
+| `2026-09-08-human-checkpoint-verdicts.json`           | —    | —      | —               | 48 absolute + 24 pairwise, Paolo, blind    | human               |
 
 ## The client-report checkpoint "before" set
 
@@ -93,6 +94,35 @@ one `W_QUALITY_RENDERED_FONT_SUBSTITUTED`, at `info`: the consulting theme's
 body face is Calibri, which this host does not have, so LibreOffice previewed
 it in Carlito. That is a fact about the render host, declared as such by the
 finding (`declared: false`), not a defect in the document.
+
+## Human calibration on the checkpoint sets
+
+`2026-09-08-human-checkpoint-verdicts.json` is Paolo's blind review of the same
+48 contact sheets the judge saw, in a guided page: one sheet at a time,
+shuffled across both sets, "would you send this to the client unchanged", then
+the 24 before/after pairs of the same brief and pass with sides randomised,
+"which would you rather send". This is the calibration #360 asked for.
+
+|                         | before | after |
+| ----------------------- | ------ | ----- |
+| Paolo would send        | 10/24  | 8/24  |
+| judge, original session | 3/24   | 2/24  |
+| judge, 09-08 session    | 2/24   | 3/24  |
+
+Pairwise, Paolo prefers the before document 12 times, the after document 6,
+and calls 6 ties; the rejudge levels imply 6, 3 and 15. Both readers agree the
+after set is not better. Every one of Paolo's 30 rejections names the same
+reason, empty or half-blank pages — the defect `rendered/page-underfilled`
+now reports.
+
+**The judge's ship flag is not Paolo's.** Agreement on shipping is 69% with
+the original session (kappa 0.22) and 60% with the rejudge (kappa 0.01): the
+judge answers "ship" for 5 of 48 where Paolo answers it for 18, and the two
+sets of five overlap Paolo's only by 4 and 2. The judge's _level_ tracks him
+better: Paolo sends 10 of the 14 documents the rejudge put at level 4 and 7 of
+the 30 at level 3. So for now read "excellent" (level ≥ 4) as the judge's
+sendability estimate and treat its `wouldShip` as advisory, as #360 item 5
+already says; recalibrating the ship question in the rubric is the follow-up.
 
 ## Reading one
 


### PR DESCRIPTION
Paolo's blind review of the 48 checkpoint contact sheets and the 24 before/after pairs, recorded as `baselines/2026-09-08-human-checkpoint-verdicts.json` with a README section.

| | before | after |
| --- | --- | --- |
| Paolo would send | 10/24 | 8/24 |
| judge, original session | 3/24 | 2/24 |

Pairs: before 12, after 6, tie 6. All 30 rejections cite empty or half-blank pages. Judge ship flag vs Paolo: kappa 0.22 (original) / 0.01 (rejudge); judge level ≥ 4 predicts Paolo's ship far better (10/14 vs 7/30). Read excellent as the sendability estimate until the rubric's ship question is recalibrated.

Refs #360, #362.