### PR TITLE
design-evals: human calibration round two (#360, #362)

### DIFF
--- a/packages/design-evals/baselines/2026-09-09-human-checkpoint-verdicts-round2.json
+++ b/packages/design-evals/baselines/2026-09-09-human-checkpoint-verdicts-round2.json
@@ -1,0 +1,505 @@
+{
+  "note": "Paolo, 2026-09-09, second blind guided review: the 24 checkpoint-before sheets (repeated from 2026-09-08-human-checkpoint-verdicts.json, a test-retest) and the 24 checkpoint-after-exhibits sheets, shuffled, then the 24 before/after-exhibits pairs with sides randomised. Same questions and chips as round one.",
+  "reviewer": "paolo",
+  "sets": {
+    "before": "2026-09-07-checkpoint-before-cold-server-4.4.0.json",
+    "after-exhibits": "2026-09-08-checkpoint-after-exhibits-cold-server-4.4.4.json"
+  },
+  "summary": {
+    "wouldShip": {
+      "before": 2,
+      "after-exhibits": 22,
+      "of": 24
+    },
+    "pairs": {
+      "after-exhibits": 24
+    },
+    "reasons": {
+      "pages": 24
+    }
+  },
+  "verdicts": [
+    {
+      "set": "after-exhibits",
+      "run": "cr-brand-repositioning#1",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:46:32.622Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-brand-repositioning#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:41.490Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-brand-repositioning#2",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:45:39.504Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-brand-repositioning#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:44:13.967Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-brand-repositioning#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:45:51.613Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-brand-repositioning#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:45:38.749Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-cost-programme-review#1",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:44:56.051Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-cost-programme-review#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:45:42.197Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-cost-programme-review#2",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:46:31.483Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-cost-programme-review#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:54.926Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-cost-programme-review#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:45:36.708Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-cost-programme-review#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:56.764Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-esg-reporting-readiness#1",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:46:43.154Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-esg-reporting-readiness#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:14.775Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-esg-reporting-readiness#2",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:46:06.406Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-esg-reporting-readiness#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:44.202Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-esg-reporting-readiness#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:45:43.080Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-esg-reporting-readiness#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:45:19.157Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-market-entry-nordics#1",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:45:03.853Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-market-entry-nordics#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:44:20.019Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-market-entry-nordics#2",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:46:52.215Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-market-entry-nordics#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:53.950Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-market-entry-nordics#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:46:17.523Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-market-entry-nordics#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:24.938Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-post-merger-integration#1",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:46:04.105Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-post-merger-integration#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:29.791Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-post-merger-integration#2",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:46:34.405Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-post-merger-integration#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:16.470Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-post-merger-integration#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:46:09.063Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-post-merger-integration#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:07.664Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-pricing-review-logistics#1",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:46:11.699Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-pricing-review-logistics#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:35.584Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-pricing-review-logistics#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:27.002Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-pricing-review-logistics#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:02.118Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-pricing-review-logistics#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:46:36.782Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-pricing-review-logistics#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:45:53.122Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-service-model-redesign#1",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:46:33.538Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-service-model-redesign#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:39.741Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-service-model-redesign#2",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:46:05.382Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-service-model-redesign#2",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:45:15.552Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-service-model-redesign#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:45:56.524Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-service-model-redesign#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:45:50.268Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-workforce-planning#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:28.529Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-workforce-planning#1",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:00.187Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-workforce-planning#2",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:45:24.471Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-workforce-planning#2",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:45:34.357Z"
+    },
+    {
+      "set": "after-exhibits",
+      "run": "cr-workforce-planning#3",
+      "wouldShip": true,
+      "reasons": [],
+      "at": "2026-09-09T05:45:09.707Z"
+    },
+    {
+      "set": "before",
+      "run": "cr-workforce-planning#3",
+      "wouldShip": false,
+      "reasons": ["pages"],
+      "at": "2026-09-09T05:46:19.308Z"
+    }
+  ],
+  "pairs": [
+    {
+      "pair": "cr-brand-repositioning#1",
+      "preferred": "after-exhibits",
+      "leftWas": "before",
+      "at": "2026-09-09T05:47:30.050Z"
+    },
+    {
+      "pair": "cr-brand-repositioning#2",
+      "preferred": "after-exhibits",
+      "leftWas": "after-exhibits",
+      "at": "2026-09-09T05:47:03.596Z"
+    },
+    {
+      "pair": "cr-brand-repositioning#3",
+      "preferred": "after-exhibits",
+      "leftWas": "after-exhibits",
+      "at": "2026-09-09T05:47:22.590Z"
+    },
+    {
+      "pair": "cr-cost-programme-review#1",
+      "preferred": "after-exhibits",
+      "leftWas": "after-exhibits",
+      "at": "2026-09-09T05:47:16.759Z"
+    },
+    {
+      "pair": "cr-cost-programme-review#2",
+      "preferred": "after-exhibits",
+      "leftWas": "after-exhibits",
+      "at": "2026-09-09T05:47:32.767Z"
+    },
+    {
+      "pair": "cr-cost-programme-review#3",
+      "preferred": "after-exhibits",
+      "leftWas": "before",
+      "at": "2026-09-09T05:47:21.071Z"
+    },
+    {
+      "pair": "cr-esg-reporting-readiness#1",
+      "preferred": "after-exhibits",
+      "leftWas": "after-exhibits",
+      "at": "2026-09-09T05:47:33.487Z"
+    },
+    {
+      "pair": "cr-esg-reporting-readiness#2",
+      "preferred": "after-exhibits",
+      "leftWas": "before",
+      "at": "2026-09-09T05:47:40.728Z"
+    },
+    {
+      "pair": "cr-esg-reporting-readiness#3",
+      "preferred": "after-exhibits",
+      "leftWas": "before",
+      "at": "2026-09-09T05:47:39.519Z"
+    },
+    {
+      "pair": "cr-market-entry-nordics#1",
+      "preferred": "after-exhibits",
+      "leftWas": "after-exhibits",
+      "at": "2026-09-09T05:47:01.428Z"
+    },
+    {
+      "pair": "cr-market-entry-nordics#2",
+      "preferred": "after-exhibits",
+      "leftWas": "after-exhibits",
+      "at": "2026-09-09T05:47:13.728Z"
+    },
+    {
+      "pair": "cr-market-entry-nordics#3",
+      "preferred": "after-exhibits",
+      "leftWas": "before",
+      "at": "2026-09-09T05:47:35.175Z"
+    },
+    {
+      "pair": "cr-post-merger-integration#1",
+      "preferred": "after-exhibits",
+      "leftWas": "before",
+      "at": "2026-09-09T05:47:17.776Z"
+    },
+    {
+      "pair": "cr-post-merger-integration#2",
+      "preferred": "after-exhibits",
+      "leftWas": "before",
+      "at": "2026-09-09T05:47:19.271Z"
+    },
+    {
+      "pair": "cr-post-merger-integration#3",
+      "preferred": "after-exhibits",
+      "leftWas": "before",
+      "at": "2026-09-09T05:47:06.806Z"
+    },
+    {
+      "pair": "cr-pricing-review-logistics#1",
+      "preferred": "after-exhibits",
+      "leftWas": "after-exhibits",
+      "at": "2026-09-09T05:47:41.884Z"
+    },
+    {
+      "pair": "cr-pricing-review-logistics#2",
+      "preferred": "after-exhibits",
+      "leftWas": "after-exhibits",
+      "at": "2026-09-09T05:47:29.056Z"
+    },
+    {
+      "pair": "cr-pricing-review-logistics#3",
+      "preferred": "after-exhibits",
+      "leftWas": "before",
+      "at": "2026-09-09T05:47:38.645Z"
+    },
+    {
+      "pair": "cr-service-model-redesign#1",
+      "preferred": "after-exhibits",
+      "leftWas": "before",
+      "at": "2026-09-09T05:47:05.750Z"
+    },
+    {
+      "pair": "cr-service-model-redesign#2",
+      "preferred": "after-exhibits",
+      "leftWas": "after-exhibits",
+      "at": "2026-09-09T05:47:37.503Z"
+    },
+    {
+      "pair": "cr-service-model-redesign#3",
+      "preferred": "after-exhibits",
+      "leftWas": "after-exhibits",
+      "at": "2026-09-09T05:47:26.348Z"
+    },
+    {
+      "pair": "cr-workforce-planning#1",
+      "preferred": "after-exhibits",
+      "leftWas": "after-exhibits",
+      "at": "2026-09-09T05:47:31.058Z"
+    },
+    {
+      "pair": "cr-workforce-planning#2",
+      "preferred": "after-exhibits",
+      "leftWas": "after-exhibits",
+      "at": "2026-09-09T05:47:34.243Z"
+    },
+    {
+      "pair": "cr-workforce-planning#3",
+      "preferred": "after-exhibits",
+      "leftWas": "before",
+      "at": "2026-09-09T05:47:12.314Z"
+    }
+  ]
+}

--- a/packages/design-evals/baselines/README.md
+++ b/packages/design-evals/baselines/README.md
@@ -9,24 +9,25 @@ guards. Their transcripts did not record tool responses, so successful artifact
 delivery cannot be verified from the scorecards alone. Preserve the original
 numbers; use fresh matched runs with the guards before making acceptance claims.
 
-| File                                                          | Mode | Server                                               | Model           | Runs                                          | Judge               |
-| ------------------------------------------------------------- | ---- | ---------------------------------------------------- | --------------- | --------------------------------------------- | ------------------- |
-| `2026-09-04-cold-server-2.0.0.json`                           | cold | 2.0.0                                                | claude-sonnet-5 | 40                                            | yes                 |
-| `2026-09-07-checkpoint-before-cold-server-4.4.0.json`         | cold | 4.4.0                                                | claude-sonnet-5 | 24 (set `client-report-checkpoint`, 8 × 3)    | yes (claude-opus-5) |
-| `2026-09-08-checkpoint-after-cold-server-4.4.2.json`          | cold | 4.4.2                                                | claude-sonnet-5 | 24 (set `client-report-checkpoint`, 8 × 3)    | yes (claude-opus-5) |
-| `2026-09-08-rejudge-checkpoint-before.json`                   | —    | —                                                    | —               | 24 rejudged, same session as the next row     | claude-opus-5       |
-| `2026-09-08-rejudge-checkpoint-after.json`                    | —    | —                                                    | —               | 24 rejudged, same session as the row above    | claude-opus-5       |
-| `2026-09-08-human-checkpoint-verdicts.json`                   | —    | —                                                    | —               | 48 absolute + 24 pairwise, Paolo, blind       | human               |
-| `2026-09-08-checkpoint-after-fill-cold-server-4.4.0.json`     | cold | 4.4.0 (jto-ops 4.4.2 + page-fill rule)               | claude-sonnet-5 | 24 (set `client-report-checkpoint`, 8 × 3)    | yes (claude-opus-5) |
-| `2026-09-08-rejudge-checkpoint-before-2.json`                 | —    | —                                                    | —               | 24 rejudged, same session as the next row     | claude-opus-5       |
-| `2026-09-08-rejudge-checkpoint-after-fill.json`               | —    | —                                                    | —               | 24 rejudged, same session as the row above    | claude-opus-5       |
-| `2026-09-08-page-fill-measure.json`                           | —    | —                                                    | —               | page fill of every delivered document, 3 sets | rendered pass       |
-| `2026-09-08-checkpoint-after-flow-cold-server-4.4.4.json`     | cold | 4.4.4 + sections flow (PR #402 build)                | claude-sonnet-5 | 24 (set `client-report-checkpoint`, 8 × 3)    | yes (claude-opus-5) |
-| `2026-09-08-rejudge-checkpoint-before-3.json`                 | —    | —                                                    | —               | 24 rejudged, same session as the next row     | claude-opus-5       |
-| `2026-09-08-rejudge-checkpoint-after-flow.json`               | —    | —                                                    | —               | 24 rejudged, same session as the row above    | claude-opus-5       |
-| `2026-09-08-checkpoint-after-exhibits-cold-server-4.4.4.json` | cold | 4.4.4 + exhibit rule, last-page rule (PR #405 build) | claude-sonnet-5 | 24 (set `client-report-checkpoint`, 8 × 3)    | yes (claude-opus-5) |
-| `2026-09-08-rejudge-checkpoint-before-4.json`                 | —    | —                                                    | —               | 24 rejudged, same session as the next row     | claude-opus-5       |
-| `2026-09-08-rejudge-checkpoint-after-exhibits.json`           | —    | —                                                    | —               | 24 rejudged, same session as the row above    | claude-opus-5       |
+| File                                                          | Mode | Server                                               | Model           | Runs                                                                 | Judge               |
+| ------------------------------------------------------------- | ---- | ---------------------------------------------------- | --------------- | -------------------------------------------------------------------- | ------------------- |
+| `2026-09-04-cold-server-2.0.0.json`                           | cold | 2.0.0                                                | claude-sonnet-5 | 40                                                                   | yes                 |
+| `2026-09-07-checkpoint-before-cold-server-4.4.0.json`         | cold | 4.4.0                                                | claude-sonnet-5 | 24 (set `client-report-checkpoint`, 8 × 3)                           | yes (claude-opus-5) |
+| `2026-09-08-checkpoint-after-cold-server-4.4.2.json`          | cold | 4.4.2                                                | claude-sonnet-5 | 24 (set `client-report-checkpoint`, 8 × 3)                           | yes (claude-opus-5) |
+| `2026-09-08-rejudge-checkpoint-before.json`                   | —    | —                                                    | —               | 24 rejudged, same session as the next row                            | claude-opus-5       |
+| `2026-09-08-rejudge-checkpoint-after.json`                    | —    | —                                                    | —               | 24 rejudged, same session as the row above                           | claude-opus-5       |
+| `2026-09-08-human-checkpoint-verdicts.json`                   | —    | —                                                    | —               | 48 absolute + 24 pairwise, Paolo, blind                              | human               |
+| `2026-09-08-checkpoint-after-fill-cold-server-4.4.0.json`     | cold | 4.4.0 (jto-ops 4.4.2 + page-fill rule)               | claude-sonnet-5 | 24 (set `client-report-checkpoint`, 8 × 3)                           | yes (claude-opus-5) |
+| `2026-09-08-rejudge-checkpoint-before-2.json`                 | —    | —                                                    | —               | 24 rejudged, same session as the next row                            | claude-opus-5       |
+| `2026-09-08-rejudge-checkpoint-after-fill.json`               | —    | —                                                    | —               | 24 rejudged, same session as the row above                           | claude-opus-5       |
+| `2026-09-08-page-fill-measure.json`                           | —    | —                                                    | —               | page fill of every delivered document, 3 sets                        | rendered pass       |
+| `2026-09-08-checkpoint-after-flow-cold-server-4.4.4.json`     | cold | 4.4.4 + sections flow (PR #402 build)                | claude-sonnet-5 | 24 (set `client-report-checkpoint`, 8 × 3)                           | yes (claude-opus-5) |
+| `2026-09-08-rejudge-checkpoint-before-3.json`                 | —    | —                                                    | —               | 24 rejudged, same session as the next row                            | claude-opus-5       |
+| `2026-09-08-rejudge-checkpoint-after-flow.json`               | —    | —                                                    | —               | 24 rejudged, same session as the row above                           | claude-opus-5       |
+| `2026-09-08-checkpoint-after-exhibits-cold-server-4.4.4.json` | cold | 4.4.4 + exhibit rule, last-page rule (PR #405 build) | claude-sonnet-5 | 24 (set `client-report-checkpoint`, 8 × 3)                           | yes (claude-opus-5) |
+| `2026-09-08-rejudge-checkpoint-before-4.json`                 | —    | —                                                    | —               | 24 rejudged, same session as the next row                            | claude-opus-5       |
+| `2026-09-08-rejudge-checkpoint-after-exhibits.json`           | —    | —                                                    | —               | 24 rejudged, same session as the row above                           | claude-opus-5       |
+| `2026-09-09-human-checkpoint-verdicts-round2.json`            | —    | —                                                    | —               | 48 absolute (before again + after-exhibits) + 24 pairs, Paolo, blind | human               |
 
 ## The client-report checkpoint "before" set
 
@@ -258,6 +259,37 @@ short of shortening the page before it. A keep-with-previous option on the
 `footnotes` block, or a fill map that places the notes before the last
 section's paragraph, is the follow-up. The cover is a design pass on the
 `cover` block.
+
+## Human calibration, round two
+
+`2026-09-09-human-checkpoint-verdicts-round2.json` is Paolo's second blind
+review, same page and questions as the first: the 24 before sheets again (a
+test-retest of his own verdicts) and the 24 sheets of the exhibit-rule set,
+shuffled together, then the 24 before/after-exhibits pairs with sides
+randomised.
+
+|                             | before | after-exhibits |
+| --------------------------- | ------ | -------------- |
+| Paolo would send, round two | 2/24   | 22/24          |
+| Paolo would send, round one | 10/24  | —              |
+| judge, own session          | 3/24   | 6/24           |
+| judge, shared sitting       | 0/24   | 8/24           |
+
+Pairwise he prefers the exhibit-rule document in 24 of 24; the shared-sitting
+judge levels imply 15 after, 8 tie, 1 before. On the 24 before documents his
+own two rounds agree 67% (kappa 0.23): ten ships became two, all in one
+direction. Read that as a contrast effect — the same sheets judged beside a
+visibly better set — as much as noise, and it is the reason both rounds keep
+the before set in the mix. Every rejection again carries the single reason
+"empty or half-blank pages"; two of the 24 new documents were held on it
+(`cr-workforce-planning#1`, a stub last page; `cr-pricing-review-logistics#2`).
+
+Against the judge on this set, shipping agreement is 62% (kappa 0.25) with the
+shared sitting and 56% (0.12) with the original: the judge ships 8 where Paolo
+ships 22. Its level still tracks him — 14 of the 15 documents it put at level
+4 he would send, 9 of 29 at level 3 — so "excellent" remains the estimate to
+read; the ship question in the rubric is now clearly stricter than the human
+it is meant to stand in for, and recalibrating it is the follow-up.
 
 ## Reading one
 


### PR DESCRIPTION
Paolo's second blind review, recorded as `baselines/2026-09-09-human-checkpoint-verdicts-round2.json` with a README section: the 24 before sheets again (test-retest) and the 24 exhibit-rule sheets, then 24 pairs.

| | before | after-exhibits |
| --- | --- | --- |
| Paolo would send | 2/24 | 22/24 |
| judge, shared sitting | 0/24 | 8/24 |

Pairs: 24 of 24 for the exhibit-rule document. Before-set test-retest against round one: 67% agreement, ten ships became two, one direction (contrast effect as much as noise). Judge ship flag vs Paolo: kappa 0.25 (shared sitting); judge level ≥4 predicts his ship at 14/15. All rejections cite empty or half-blank pages.

Refs #360, #362.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the recorded-baselines documentation with additional checkpoint, rejudge, measurement, and human-verdict records.
  - Added round-two human-calibration results, including pairwise preferences, judge agreement, shipping decisions, and remaining page-layout findings.
- **Evaluation Data**
  - Added a dated dataset covering 24 before-and-after exhibit comparisons and their recorded verdicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->