### PR TITLE
feat(pptx): consulting-deck blueprint and pptx scaffolding (#342)

### DIFF
--- a/.changeset/consulting-deck-blueprint.md
+++ b/.changeset/consulting-deck-blueprint.md
@@ -1,0 +1,8 @@
+---
+'@json-to-office/shared': minor
+'@json-to-office/core-pptx': minor
+'@json-to-office/core-docx': minor
+'@json-to-office/mcp-server': minor
+---
+
+The `consulting-deck` blueprint and PPTX scaffolding (#342). `core-pptx` exports `PPTX_BLUEPRINTS`, `pptxBlueprint` and `instantiatePptxBlueprint`; the blueprint's two variants (data-heavy: cover, KPI row, three action-charts, a two-column table, a statement; narrative: cover, a statement, two two-column chart slides, an action-chart, a two-column table, a statement) invoke the five deck blocks of `consulting-deck-blocks.pptx.json` and are judged by the `consulting-deck` profile. What instantiating means — carrying the invoked definitions and their dependencies, listing every `{{…}}` marker with its slot budget — now lives in `shared` (`instantiateBlueprint`, `registerBlueprints`, `slotAt`, `valueAt`); each core keeps only the shape of its root, so a deck's metadata sits under `props` and a document's under `props.metadata`. `jto_scaffold` takes `format: "pptx"`: brief facts fill the deck's `title`, `author` and `company` and the cover's slots; each `##` of an outline fills the next content slide's title (an action title or a statement's assertion, never the cover's) and its paragraphs the slide's `text`, `support` or `takeaway` slots. `jto_discover` and `jto://blueprints` list the deck blueprint beside the report ones.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,17 @@ jobs:
       # without Base, Draw, Math and their dependency trees.
       - name: Install LibreOffice and poppler
         run: |
-          sudo apt-get update
+          # The runner image ships third-party apt sources (Chrome, Edge) we
+          # never install from; when one of them serves a bad index,
+          # `apt-get update` exits 100 and the job dies before any code runs.
+          # Drop them, and retry the update against the Ubuntu mirrors.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list \
+            /etc/apt/sources.list.d/microsoft-edge*.list
+          for attempt in 1 2 3; do
+            sudo apt-get update && break
+            echo "apt-get update failed (attempt $attempt); retrying"
+            sleep 10
+          done
           # Liberation and Carlito are metric-compatible with Arial and
           # Calibri: with them the house theme renders at its design widths,
           # without them every "design font" case is a DejaVu case.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,8 +269,8 @@ jobs:
           # never install from; when one of them serves a bad index,
           # `apt-get update` exits 100 and the job dies before any code runs.
           # Drop them, and retry the update against the Ubuntu mirrors.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list \
-            /etc/apt/sources.list.d/microsoft-edge*.list
+          sudo rm -f /etc/apt/sources.list.d/google-chrome* \
+            /etc/apt/sources.list.d/microsoft-edge*
           for attempt in 1 2 3; do
             sudo apt-get update && break
             echo "apt-get update failed (attempt $attempt); retrying"

--- a/docs/reference/blueprints.md
+++ b/docs/reference/blueprints.md
@@ -44,6 +44,17 @@ The report variants invoke `cover`, `running-head`, `section-opener`, `key-takea
 
 The `technical-report` profile differs from `client-report` in what it owes a figure: a `source` wherever a block declares one, never a `takeaway` — the caption is the block's own requirement — and one more text size, for the contents list and the sub-headings.
 
+## `consulting-deck`
+
+A decision deck for a client readout, on the `consulting` theme and judged by the `consulting-deck` profile: every slide invokes one of the five deck blocks of `consulting-deck-blocks.pptx.json`, so a scaffold has no coordinates of its own. A deck's metadata (`title`, `author`, `company`) sits under `props`, not `props.metadata`, and the scaffold is drawn for the wide 16:9 canvas the blocks were designed on; any canvas lays out.
+
+| Variant      | Structure                                                                                                                                         | Slides |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `data-heavy` | Cover; a KPI row; three action-charts with their takeaway and source; a two-column slide with bullets beside a table; a closing statement         | 6–9    |
+| `narrative`  | Cover; the position as a statement; two two-column slides that argue it beside a chart; one action-chart; a two-column table; a closing statement | 6–8    |
+
+The chart slots hold a `chart` component whose series, labels and axis title are markers and whose `chartColors` name the theme's series; the table content right-aligns its numeric columns per cell, since a slot that may hold a table cannot carry chart props and a block cannot know which columns are numbers. The `consulting-deck` profile is what asks every action-chart for its takeaway and source and bounds the action titles at two lines; the theme only paints them.
+
 ## Instantiating one
 
 ```ts
@@ -51,6 +62,7 @@ import {
   docxBlueprint,
   instantiateDocxBlueprint,
 } from '@json-to-office/core-docx';
+// The PPTX core exports the same pair: pptxBlueprint, instantiatePptxBlueprint.
 import { readBlockDefinitions } from '@json-to-office/shared';
 
 const blueprint = docxBlueprint('client-report')!;
@@ -75,7 +87,7 @@ Patch every pointer with content and the document is generation-ready; leave one
 
 ## Scaffolding through MCP
 
-`jto_scaffold` wraps the same call in a workspace: it takes a blueprint id, an optional variant and theme, the facts of the brief and a markdown outline, and answers with a handle at revision 1, the fill map above with every pointer resolving at that revision, and how many markers the brief and outline already wrote. The agent fills the rest by pointer with `jto_workspace_patch` and never holds the document.
+`jto_scaffold` wraps the same call in a workspace, in either format: it takes a blueprint id, an optional variant and theme, the facts of the brief and a markdown outline, and answers with a handle at revision 1, the fill map above with every pointer resolving at that revision, and how many markers the brief and outline already wrote. The agent fills the rest by pointer with `jto_workspace_patch` and never holds the document.
 
 The brief and the outline are mapped by one rule each:
 
@@ -83,8 +95,8 @@ The brief and the outline are mapped by one rule each:
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `brief.<key>`           | `props.metadata.<key>` (`client` also fills `company`) and the `<key>` slot of the cover, the running head and the memo header (`title` also fills the memo's `subject`) — never a body block, where `title` means the section's |
 | `# Heading`             | The title, unless the brief gave one                                                                                                                                                                                             |
-| `## Heading`, in order  | The next section opener's `title`                                                                                                                                                                                                |
+| `## Heading`, in order  | The next section opener's `title`; on a deck, the next content slide's title — an action title, or a statement's assertion — never the cover's                                                                                   |
 | `### Heading`, in order | The next level-2 `heading` marker between that opener and the following one                                                                                                                                                      |
-| Paragraphs under a `##` | The body text markers between that opener and the following one, in order; a blank line separates paragraphs                                                                                                                     |
+| Paragraphs under a `##` | The body text markers between that opener and the following one, in order; on a deck, that slide's `text`, `support` or `takeaway` slots; a blank line separates paragraphs                                                      |
 
 A brief key that matches nothing comes back as `W_BRIEF_UNUSED`; a section, sub-heading or paragraph the variant has no room for, text before the first `##`, a second `#` and any heading deeper than `###` come back as `W_OUTLINE_UNMAPPED`. Nothing is dropped silently. `jto_validate` on the handle reports the markers as advisory findings with `generationReady: false` and, once they are gone, `generationReady: true`; `jto_generate` refuses in between, naming every remaining marker by pointer. `jto://blueprints` serves the plans in full and `jto_discover` their summaries.

--- a/packages/core-docx/src/blueprints/index.ts
+++ b/packages/core-docx/src/blueprints/index.ts
@@ -7,22 +7,20 @@
  * directory is scanned for any other `*.docx.blueprint.json` beside it, so
  * adding a blueprint is a file. Each is validated against the shared
  * blueprint schema when this module loads, so a malformed one fails at import
- * rather than at scaffold time. `instantiate` copies
- * a variant's children, writes the recommended theme and the archetype's
- * quality profile onto the root, brings the block definitions the children
- * invoke — and the definitions those depend on — from the playground
- * template the blueprint names, and lists every `{{…}}` scaffold marker as a
- * fill-map entry: where it is, what kind of slot holds it, its budget and the
- * guidance the marker text carries. Nothing here composes or styles.
+ * rather than at scaffold time. What instantiating means — copying a variant,
+ * carrying the definitions it invokes and their dependencies, listing every
+ * `{{…}}` marker with its slot budget and guidance — is shared with the PPTX
+ * core; this module only says what a document's root looks like: metadata
+ * under `props.metadata`. Nothing here composes or styles.
  */
 import {
-  blockDependencies,
-  validateBlueprint,
+  instantiateBlueprint,
+  registerBlueprints,
+  valueAt,
   type Blueprint,
   type BlueprintFillEntry,
-  type BlueprintVariant,
-  type BlockSlot,
-  type JsonBlockDefinition,
+  type InstantiateBlueprintOptions,
+  type InstantiatedBlueprint,
 } from '@json-to-office/shared';
 import { collectPlaceholders } from '@json-to-office/quality';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
@@ -30,28 +28,6 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import clientReport from '../templates/blueprints/client-report.docx.blueprint.json';
 import technicalReport from '../templates/blueprints/technical-report.docx.blueprint.json';
-
-function register(...candidates: unknown[]): Record<string, Blueprint> {
-  const registry: Record<string, Blueprint> = {};
-  for (const candidate of candidates) {
-    const issues = validateBlueprint(candidate);
-    if (issues.length > 0)
-      throw new Error(
-        `Invalid bundled blueprint: ${issues
-          .map((issue) => `${issue.path}: ${issue.message}`)
-          .join('; ')}`
-      );
-    const blueprint = candidate as Blueprint;
-    if (blueprint.format !== 'docx')
-      throw new Error(`Blueprint ${blueprint.id} is not a DOCX blueprint.`);
-    if (registry[blueprint.id])
-      throw new Error(
-        `Two bundled blueprints share the id "${blueprint.id}"; the later one would silently replace the earlier.`
-      );
-    registry[blueprint.id] = blueprint;
-  }
-  return registry;
-}
 
 /**
  * Blueprint files beside this module — `src/templates/blueprints` when run
@@ -79,177 +55,35 @@ function scanned(known: Readonly<Record<string, unknown>>): unknown[] {
     });
 }
 
-const bundled = register(clientReport, technicalReport);
+const bundled = registerBlueprints('docx', [clientReport, technicalReport]);
 
 /** Every bundled DOCX blueprint, by id. */
 export const DOCX_BLUEPRINTS: Readonly<Record<string, Blueprint>> = {
   ...bundled,
-  ...register(...scanned(bundled)),
+  ...registerBlueprints('docx', scanned(bundled)),
 };
 
 export function docxBlueprint(id: string): Blueprint | undefined {
   return DOCX_BLUEPRINTS[id];
 }
 
-export type { BlueprintFillEntry };
-
-export interface InstantiateBlueprintOptions {
-  /** A variant id from `blueprint.variants`; the first when omitted. */
-  variant?: string;
-  /** Overrides the blueprint's recommended theme. */
-  theme?: string;
-  /**
-   * The block definitions the variant invokes — the `props.blocks` of the
-   * playground template the blueprint names. The scaffold carries the ones it
-   * uses, plus their dependencies; nothing is looked up at render time.
-   */
-  definitions: Readonly<Record<string, JsonBlockDefinition>>;
-  /** Metadata values that replace the variant's marked ones. */
-  metadata?: Readonly<Record<string, string>>;
-}
-
-export interface InstantiatedBlueprint {
-  document: Record<string, unknown>;
-  fillMap: BlueprintFillEntry[];
-  variant: string;
-}
-
-const MARKER = /^\{\{\s*([\s\S]*?)\s*\}\}$/;
+export type {
+  BlueprintFillEntry,
+  InstantiateBlueprintOptions,
+  InstantiatedBlueprint,
+};
+export { valueAt };
 
 export function instantiateDocxBlueprint(
   blueprint: Blueprint,
   options: InstantiateBlueprintOptions
 ): InstantiatedBlueprint {
-  if (blueprint.format !== 'docx')
-    throw new Error(
-      `Blueprint ${blueprint.id} is a ${blueprint.format} blueprint; this instantiates DOCX ones.`
-    );
-  const variantId = options.variant ?? Object.keys(blueprint.variants)[0];
-  const variant: BlueprintVariant | undefined = blueprint.variants[variantId];
-  if (!variant)
-    throw new Error(
-      `Blueprint ${blueprint.id} has no variant "${variantId}"; it has ${Object.keys(
-        blueprint.variants
-      ).join(', ')}.`
-    );
-  const children = structuredClone(variant.children) as unknown[];
-  const blocks = definitionsFor(children, options.definitions, blueprint);
-  const document: Record<string, unknown> = {
-    name: 'docx',
-    props: {
-      theme: options.theme ?? blueprint.theme,
-      qualityProfile: blueprint.profile,
-      ...(Object.keys(blocks).length > 0 && { blocks }),
-      metadata: { ...variant.metadata, ...options.metadata },
-    },
-    children,
-  };
-  return { document, fillMap: fillMap(document, blocks), variant: variantId };
-}
-
-/** The definitions the children invoke, dependencies first, from `available`. */
-function definitionsFor(
-  children: unknown[],
-  available: Readonly<Record<string, JsonBlockDefinition>>,
-  blueprint: Blueprint
-): Record<string, JsonBlockDefinition> {
-  const refs = new Set<string>();
-  const visit = (node: unknown): void => {
-    if (Array.isArray(node)) return node.forEach(visit);
-    if (!node || typeof node !== 'object') return;
-    const record = node as Record<string, unknown>;
-    const props = record.props as Record<string, unknown> | undefined;
-    if (record.name === 'block' && typeof props?.ref === 'string')
-      refs.add(props.ref);
-    Object.values(record).forEach(visit);
-  };
-  visit(children);
-  const result: Record<string, JsonBlockDefinition> = {};
-  for (const ref of refs) {
-    if (!available[ref])
-      throw new Error(
-        `Blueprint ${blueprint.id} invokes "${ref}", which ${blueprint.definitions} does not define.`
-      );
-    for (const name of [...blockDependencies(available, ref), ref])
-      result[name] ??= structuredClone(available[name]);
-  }
-  return result;
-}
-
-function fillMap(
-  document: unknown,
-  blocks: Readonly<Record<string, JsonBlockDefinition>>
-): BlueprintFillEntry[] {
-  return collectPlaceholders(document)
-    .filter((occurrence) => occurrence.match.kind === 'scaffold-marker')
-    .map((occurrence) => {
-      const guidance = occurrence.text.match(MARKER)?.[1] ?? occurrence.text;
-      const base = { path: occurrence.path, marker: occurrence.text, guidance };
-      if (occurrence.path.startsWith('/props/metadata/'))
-        return { ...base, kind: 'metadata' as const };
-      const slot = slotAt(document, occurrence.path, blocks);
-      return slot
-        ? { ...base, kind: 'slot' as const, ...slot }
-        : { ...base, kind: 'text' as const };
-    });
-}
-
-/** The declared slot a pointer inside an invocation's `slots` lands in. */
-function slotAt(
-  document: unknown,
-  pointer: string,
-  blocks: Readonly<Record<string, JsonBlockDefinition>>
-):
-  | Omit<BlueprintFillEntry, 'path' | 'marker' | 'guidance' | 'kind'>
-  | undefined {
-  const at = pointer.lastIndexOf('/props/slots/');
-  if (at < 0) return undefined;
-  const invocation = valueAt(document, pointer.slice(0, at)) as
-    | { props?: { ref?: unknown } }
-    | undefined;
-  const ref = invocation?.props?.ref;
-  if (typeof ref !== 'string' || !blocks[ref]) return undefined;
-  const segments = pointer
-    .slice(at + '/props/slots/'.length)
-    .split('/')
-    .map(unescape);
-  let slot: BlockSlot | undefined = blocks[ref].slots[segments[0]];
-  const names = [segments[0]];
-  for (const segment of segments.slice(1)) {
-    if (!slot) break;
-    if (slot.type === 'array' && /^\d+$/.test(segment)) slot = slot.items;
-    else if (slot.type === 'object') {
-      slot = slot.properties?.[segment];
-      names.push(segment);
-    } else if (slot.type === 'component')
-      break; // content inside the slot
-    else slot = undefined;
-  }
-  if (!slot) return undefined;
-  return {
-    block: ref,
-    slot: names.join('.'),
-    type: slot.type,
-    ...(slot.maxWords !== undefined && { maxWords: slot.maxWords }),
-    ...(slot.maxLength !== undefined && { maxLength: slot.maxLength }),
-    ...(slot.oneLine !== undefined && { oneLine: slot.oneLine }),
-    ...(slot.required !== undefined && { required: slot.required }),
-  };
-}
-
-function unescape(segment: string): string {
-  return segment.replace(/~1/g, '/').replace(/~0/g, '~');
-}
-
-/** The value a JSON pointer names, or undefined. */
-export function valueAt(root: unknown, pointer: string): unknown {
-  if (pointer === '') return root;
-  let current: unknown = root;
-  for (const segment of pointer.split('/').slice(1).map(unescape)) {
-    if (Array.isArray(current)) current = current[Number(segment)];
-    else if (current && typeof current === 'object')
-      current = (current as Record<string, unknown>)[segment];
-    else return undefined;
-  }
-  return current;
+  return instantiateBlueprint(blueprint, options, {
+    format: 'docx',
+    metadataPointer: '/props/metadata',
+    markers: (document) =>
+      collectPlaceholders(document).filter(
+        (occurrence) => occurrence.match.kind === 'scaffold-marker'
+      ),
+  });
 }

--- a/packages/core-pptx/src/blueprints/__tests__/consulting-deck.test.ts
+++ b/packages/core-pptx/src/blueprints/__tests__/consulting-deck.test.ts
@@ -1,0 +1,229 @@
+/**
+ * The `consulting-deck` blueprint: two structural variants of the same
+ * archetype instantiated from the deck template's definitions, judged by the
+ * `consulting-deck` profile without anyone naming it, rendered warning-clean
+ * while every slot still carries its marker, and fillable through the fill
+ * map alone. A deck's metadata sits under `props`, not `props.metadata`. A
+ * theme swap changes the look and nothing the profile asks; a profile swap
+ * changes what is asked and nothing the theme paints.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { validatePresentationDocument } from '@json-to-office/shared-pptx';
+import { QUALITY_CODES } from '@json-to-office/quality';
+import {
+  readBlockDefinitions,
+  validateBlueprint,
+  valueAt,
+  type BlueprintFillEntry,
+} from '@json-to-office/shared';
+import {
+  PPTX_BLUEPRINTS,
+  instantiatePptxBlueprint,
+  pptxBlueprint,
+} from '../index';
+import { generateBufferWithWarnings } from '../../core/generator';
+import { analyzePptxQuality } from '../../quality/preflight';
+import { pptxThemes } from '../../themes';
+
+const TEMPLATE = JSON.parse(
+  readFileSync(
+    new URL(
+      '../../../../jto/src/client/public/templates/consulting-deck-blocks.pptx.json',
+      import.meta.url
+    ),
+    'utf8'
+  )
+);
+const blueprint = pptxBlueprint('consulting-deck')!;
+const definitions = readBlockDefinitions(TEMPLATE);
+const VARIANTS = Object.keys(blueprint.variants);
+const THEMES = Object.keys(pptxThemes);
+const codes = (doc: unknown, options = {}) =>
+  analyzePptxQuality(doc, options).diagnostics.map((finding) => finding.code);
+
+/** Plausible content for a marker: numbers stay numbers, text stays short. */
+const content = (entry: BlueprintFillEntry): string => {
+  if (/^[+\d]/.test(entry.guidance)) return '4.2';
+  if (entry.guidance === 'unit') return '%';
+  if (entry.guidance.startsWith('Source'))
+    return 'Source: operating review, 2026.';
+  if (entry.guidance.startsWith('Month')) return 'September 2026';
+  if (entry.guidance.startsWith('Tracker')) return 'Summary';
+  return entry.guidance.replace(/^[^:]*:\s*/, '').split(',')[0];
+};
+const set = (root: unknown, pointer: string, value: unknown): void => {
+  const segments = pointer.split('/').slice(1);
+  const parent = valueAt(root, `/${segments.slice(0, -1).join('/')}`) as
+    | Record<string, unknown>
+    | unknown[];
+  const last = segments[segments.length - 1];
+  if (Array.isArray(parent)) parent[Number(last)] = value;
+  else parent[last] = value;
+};
+const filled = (variant: string, theme?: string) => {
+  const { document, fillMap } = instantiatePptxBlueprint(blueprint, {
+    variant,
+    ...(theme && { theme }),
+    definitions,
+  });
+  for (const entry of fillMap) set(document, entry.path, content(entry));
+  return { document, fillMap };
+};
+
+describe('the consulting-deck blueprint', () => {
+  it('is a registered, schema-valid plan with a data-heavy and a narrative variant', () => {
+    expect(Object.keys(PPTX_BLUEPRINTS)).toEqual(['consulting-deck']);
+    expect(validateBlueprint(blueprint)).toEqual([]);
+    expect(VARIANTS).toEqual(['data-heavy', 'narrative']);
+    expect(blueprint).toMatchObject({
+      format: 'pptx',
+      theme: 'consulting',
+      profile: 'consulting-deck',
+      definitions: 'consulting-deck-blocks.pptx.json',
+      numbering: 'none',
+      toc: false,
+    });
+  });
+
+  describe.each(VARIANTS)('the %s variant', (variant) => {
+    it('instantiates a valid deck on the wide canvas, metadata under props, carrying every definition it invokes', () => {
+      const { document, fillMap } = instantiatePptxBlueprint(blueprint, {
+        variant,
+        definitions,
+      });
+      expect(validatePresentationDocument(document).errors).toEqual([]);
+      const props = document.props as Record<string, unknown>;
+      expect(props).toMatchObject({
+        theme: 'consulting',
+        qualityProfile: 'consulting-deck',
+        slideWidth: 13.333,
+        slideHeight: 7.5,
+        title: '{{Title: as on the cover}}',
+      });
+      expect(props.metadata).toBeUndefined();
+      expect(Object.keys(props.blocks as object)).toEqual(
+        expect.arrayContaining([
+          'cover',
+          'action-chart',
+          'two-column',
+          'statement',
+        ])
+      );
+      expect((document.children as unknown[]).length).toBe(7);
+      for (const entry of fillMap)
+        expect(valueAt(document, entry.path), entry.path).toBe(entry.marker);
+      expect(
+        fillMap.find((entry) => entry.path === '/props/title')
+      ).toMatchObject({ kind: 'metadata' });
+      expect(
+        fillMap.filter((entry) => entry.kind === 'metadata').map((e) => e.path)
+      ).toEqual(['/props/title', '/props/author', '/props/company']);
+      const title = fillMap.find(
+        (entry) => entry.block === 'cover' && entry.slot === 'title'
+      );
+      expect(title).toMatchObject({
+        kind: 'slot',
+        maxWords: 16,
+        required: true,
+      });
+      // A marker inside the chart's own data reports the component slot.
+      const inChart = fillMap.filter(
+        (entry) => entry.block === 'action-chart' && entry.slot === 'chart'
+      );
+      expect(inChart.length).toBeGreaterThanOrEqual(4);
+      expect(inChart[0]).toMatchObject({ kind: 'slot', type: 'component' });
+      // A deck has no ordinary text markers: every marker is a slot or metadata.
+      expect(fillMap.filter((entry) => entry.kind === 'text')).toEqual([]);
+    });
+
+    it('is judged by its own profile without arguments, reports only draft markers, and renders warning-clean', async () => {
+      const { document } = instantiatePptxBlueprint(blueprint, {
+        variant,
+        definitions,
+      });
+      const analysis = analyzePptxQuality(document);
+      expect(analysis.profileId).toBe('consulting-deck');
+      expect(analysis.blocked).toBe(false);
+      // The markers are advisory; the only other thing the deck reports is
+      // the info-level tight box every action title carries on the template.
+      expect(
+        new Set(
+          analysis.diagnostics
+            .filter(
+              (d) => d.severity !== 'info' || d.code !== 'W_QUALITY_TEXT_TIGHT'
+            )
+            .map((d) => d.code)
+        )
+      ).toEqual(new Set([QUALITY_CODES.SCAFFOLD_MARKER]));
+      const { warnings } = await generateBufferWithWarnings(document as never);
+      expect(warnings).toEqual([]);
+    });
+
+    it('is generation-ready once every fill-map pointer is patched', async () => {
+      const { document } = filled(variant);
+      expect(validatePresentationDocument(document).errors).toEqual([]);
+      expect(
+        analyzePptxQuality(document)
+          .diagnostics.filter((finding) => finding.severity !== 'info')
+          .map((f) => `${f.code} ${f.path}`)
+      ).toEqual([]);
+      const { warnings } = await generateBufferWithWarnings(document as never);
+      expect(warnings).toEqual([]);
+    });
+
+    it.each(THEMES)(
+      'asks the same of the deck on the %s theme, markers filled and one source blanked',
+      async (theme) => {
+        const blanked = (on: string | undefined) => {
+          const { document, fillMap } = filled(variant, on);
+          const source = fillMap.find(
+            (entry) => entry.block === 'action-chart' && entry.slot === 'source'
+          )!;
+          set(document, source.path, '');
+          return document;
+        };
+        const document = blanked(theme);
+        expect((document.props as { theme: string }).theme).toBe(theme);
+        expect(validatePresentationDocument(document).errors).toEqual([]);
+        const found = codes(document);
+        expect(found).toContain(QUALITY_CODES.CHROME_MISSING);
+        expect(found).toEqual(codes(blanked(undefined)));
+        const { warnings } = await generateBufferWithWarnings(
+          document as never
+        );
+        expect(warnings).toEqual([]);
+      }
+    );
+
+    it('owes the takeaway and the source to the profile, not the theme', () => {
+      const { document, fillMap } = filled(variant);
+      const takeaway = fillMap.find(
+        (entry) => entry.block === 'action-chart' && entry.slot === 'takeaway'
+      )!;
+      set(document, takeaway.path, '');
+      expect(codes(document)).toContain(QUALITY_CODES.CHROME_MISSING);
+      expect(
+        codes(document, {
+          profile: { id: 'technical-presentation', formats: ['pptx'] },
+        })
+      ).not.toContain(QUALITY_CODES.CHROME_MISSING);
+    });
+  });
+
+  it('refuses a blueprint of another format, a variant it lacks and a definition the template lacks', () => {
+    expect(() =>
+      instantiatePptxBlueprint(
+        { ...blueprint, format: 'docx' },
+        { definitions }
+      )
+    ).toThrow(/is a docx blueprint/);
+    expect(() =>
+      instantiatePptxBlueprint(blueprint, { variant: 'memo', definitions })
+    ).toThrow(/no variant "memo"/);
+    const { cover: _cover, ...without } = definitions; // eslint-disable-line @typescript-eslint/no-unused-vars
+    expect(() =>
+      instantiatePptxBlueprint(blueprint, { definitions: without })
+    ).toThrow(/invokes "cover"/);
+  });
+});

--- a/packages/core-pptx/src/blueprints/index.ts
+++ b/packages/core-pptx/src/blueprints/index.ts
@@ -1,0 +1,87 @@
+/**
+ * PPTX blueprints: deck archetypes as data, and the one operation that turns
+ * one into a deck.
+ *
+ * The registry is the JSON files under `templates/blueprints`: the bundled
+ * ones are imported so a stale or missing `dist` cannot lose them, and the
+ * directory is scanned for any other `*.pptx.blueprint.json` beside it, so
+ * adding a blueprint is a file. What instantiating means is shared with the
+ * DOCX core; this module only says what a deck's root looks like: the
+ * metadata a deck carries (`title`, `author`, `company`) sits directly under
+ * `props`, beside the canvas the blueprint's blocks were drawn for.
+ */
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  instantiateBlueprint,
+  registerBlueprints,
+  type Blueprint,
+  type BlueprintFillEntry,
+  type InstantiateBlueprintOptions,
+  type InstantiatedBlueprint,
+} from '@json-to-office/shared';
+import { collectPlaceholders } from '@json-to-office/quality';
+import consultingDeck from '../templates/blueprints/consulting-deck.pptx.blueprint.json';
+
+/**
+ * Blueprint files beside this module — `src/templates/blueprints` from source,
+ * `dist/templates/blueprints` from the built package — that the static import
+ * above does not already carry.
+ */
+function scanned(known: Readonly<Record<string, unknown>>): unknown[] {
+  let here: string;
+  try {
+    here = dirname(fileURLToPath(import.meta.url));
+  } catch {
+    return [];
+  }
+  const directory = [
+    join(here, '../templates/blueprints'),
+    join(here, 'templates/blueprints'),
+  ].find((path) => existsSync(path));
+  if (!directory) return [];
+  return readdirSync(directory)
+    .filter((file) => file.endsWith('.pptx.blueprint.json'))
+    .map((file) => JSON.parse(readFileSync(join(directory, file), 'utf8')))
+    .filter((candidate) => {
+      const id = (candidate as { id?: unknown } | null)?.id;
+      return !(typeof id === 'string' && id in known);
+    });
+}
+
+const bundled = registerBlueprints('pptx', [consultingDeck]);
+
+/** Every bundled PPTX blueprint, by id. */
+export const PPTX_BLUEPRINTS: Readonly<Record<string, Blueprint>> = {
+  ...bundled,
+  ...registerBlueprints('pptx', scanned(bundled)),
+};
+
+export function pptxBlueprint(id: string): Blueprint | undefined {
+  return PPTX_BLUEPRINTS[id];
+}
+
+export type {
+  BlueprintFillEntry,
+  InstantiateBlueprintOptions,
+  InstantiatedBlueprint,
+};
+
+/** The wide canvas every bundled deck block is drawn for; any canvas lays out. */
+const CANVAS = { slideWidth: 13.333, slideHeight: 7.5 } as const;
+
+export function instantiatePptxBlueprint(
+  blueprint: Blueprint,
+  options: InstantiateBlueprintOptions
+): InstantiatedBlueprint {
+  return instantiateBlueprint(blueprint, options, {
+    format: 'pptx',
+    props: CANVAS,
+    metadataPointer: '/props',
+    markers: (document) =>
+      collectPlaceholders(document).filter(
+        (occurrence) => occurrence.match.kind === 'scaffold-marker'
+      ),
+  });
+}

--- a/packages/core-pptx/src/index.ts
+++ b/packages/core-pptx/src/index.ts
@@ -63,6 +63,18 @@ export {
   pptxThemes,
 } from './themes';
 
+// Blueprints: deck archetypes as data (#342)
+export {
+  PPTX_BLUEPRINTS,
+  pptxBlueprint,
+  instantiatePptxBlueprint,
+} from './blueprints';
+export type {
+  BlueprintFillEntry,
+  InstantiateBlueprintOptions,
+  InstantiatedBlueprint,
+} from './blueprints';
+
 // Design-quality analysis (#216)
 export { analyzePptxQuality } from './quality/preflight';
 export type {

--- a/packages/core-pptx/src/templates/blueprints/consulting-deck.pptx.blueprint.json
+++ b/packages/core-pptx/src/templates/blueprints/consulting-deck.pptx.blueprint.json
@@ -1,0 +1,560 @@
+{
+  "id": "consulting-deck",
+  "format": "pptx",
+  "title": "Consulting deck",
+  "description": "A decision deck for a client readout: a cover, the quarter in numbers, one action-chart per finding with its takeaway and source, a two-column slide for the evidence that is a table or a list, a closing statement; every slide invokes one of the five consulting blocks on the house theme.",
+  "whenToUse": "A client readout, a board update or a steering-committee deck: one message per slide, a chart or table that carries it, a source under it. Not for a talk track or a training deck.",
+  "theme": "consulting",
+  "profile": "consulting-deck",
+  "definitions": "consulting-deck-blocks.pptx.json",
+  "numbering": "none",
+  "toc": false,
+  "variants": {
+    "data-heavy": {
+      "description": "Evidence-led: cover, a KPI row, three action-charts, a two-column table slide, a closing statement.",
+      "whenToUse": "The brief comes with numbers the audience will check: performance, finance, operations.",
+      "pages": {
+        "min": 6,
+        "max": 9
+      },
+      "metadata": {
+        "title": "{{Title: as on the cover}}",
+        "author": "{{Author or team}}",
+        "company": "{{Client name}}"
+      },
+      "children": [
+        {
+          "name": "slide",
+          "children": [
+            {
+              "name": "block",
+              "props": {
+                "ref": "cover",
+                "slots": {
+                  "title": "{{Title: the deck's conclusion in one sentence}}",
+                  "subtitle": "{{Subtitle: what the deck answers, for whom}}",
+                  "client": "{{Client name}}",
+                  "date": "{{Month YYYY}}",
+                  "confidentiality": "{{Confidentiality: Confidential, or For internal use}}"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "slide",
+          "children": [
+            {
+              "name": "block",
+              "props": {
+                "ref": "kpi-row",
+                "slots": {
+                  "title": "{{Action title: the claim this slide proves, with its number, two lines at most}}",
+                  "tracker": "{{Tracker: the section, one or two words}}",
+                  "items": [
+                    {
+                      "value": "{{0.0}}",
+                      "unit": "{{unit}}",
+                      "label": "{{What it measures}}",
+                      "delta": "{{+0.0}}"
+                    },
+                    {
+                      "value": "{{0.0}}",
+                      "unit": "{{unit}}",
+                      "label": "{{What it measures}}",
+                      "delta": "{{+0.0}}"
+                    },
+                    {
+                      "value": "{{0.0}}",
+                      "unit": "{{unit}}",
+                      "label": "{{What it measures}}",
+                      "delta": "{{+0.0}}"
+                    }
+                  ],
+                  "source": "{{Source: system or document, date}}"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "slide",
+          "children": [
+            {
+              "name": "block",
+              "props": {
+                "ref": "action-chart",
+                "slots": {
+                  "title": "{{Action title: the claim this slide proves, with its number, two lines at most}}",
+                  "tracker": "{{Tracker: the section, one or two words}}",
+                  "chart": {
+                    "name": "chart",
+                    "props": {
+                      "type": "bar",
+                      "valAxisTitle": "{{Measure (unit)}}",
+                      "data": [
+                        {
+                          "name": "{{Series name}}",
+                          "labels": [
+                            "{{Period 1}}",
+                            "{{Period 2}}",
+                            "{{Period 3}}"
+                          ],
+                          "values": [0, 0, 0]
+                        }
+                      ],
+                      "chartColors": [
+                        "accent",
+                        "secondary",
+                        "accent4",
+                        "accent6",
+                        "accent5"
+                      ]
+                    }
+                  },
+                  "takeaway": "{{Takeaway: what the reader should conclude, one or two sentences}}",
+                  "source": "{{Source: system or document, date}}"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "slide",
+          "children": [
+            {
+              "name": "block",
+              "props": {
+                "ref": "action-chart",
+                "slots": {
+                  "title": "{{Action title: the claim this slide proves, with its number, two lines at most}}",
+                  "tracker": "{{Tracker: the section, one or two words}}",
+                  "chart": {
+                    "name": "chart",
+                    "props": {
+                      "type": "bar",
+                      "valAxisTitle": "{{Measure (unit)}}",
+                      "data": [
+                        {
+                          "name": "{{Series name}}",
+                          "labels": [
+                            "{{Period 1}}",
+                            "{{Period 2}}",
+                            "{{Period 3}}"
+                          ],
+                          "values": [0, 0, 0]
+                        }
+                      ],
+                      "chartColors": [
+                        "accent",
+                        "secondary",
+                        "accent4",
+                        "accent6",
+                        "accent5"
+                      ]
+                    }
+                  },
+                  "takeaway": "{{Takeaway: what the reader should conclude, one or two sentences}}",
+                  "source": "{{Source: system or document, date}}"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "slide",
+          "children": [
+            {
+              "name": "block",
+              "props": {
+                "ref": "action-chart",
+                "slots": {
+                  "title": "{{Action title: the claim this slide proves, with its number, two lines at most}}",
+                  "tracker": "{{Tracker: the section, one or two words}}",
+                  "chart": {
+                    "name": "chart",
+                    "props": {
+                      "type": "bar",
+                      "valAxisTitle": "{{Measure (unit)}}",
+                      "data": [
+                        {
+                          "name": "{{Series name}}",
+                          "labels": [
+                            "{{Period 1}}",
+                            "{{Period 2}}",
+                            "{{Period 3}}"
+                          ],
+                          "values": [0, 0, 0]
+                        }
+                      ],
+                      "chartColors": [
+                        "accent",
+                        "secondary",
+                        "accent4",
+                        "accent6",
+                        "accent5"
+                      ]
+                    }
+                  },
+                  "takeaway": "{{Takeaway: what the reader should conclude, one or two sentences}}",
+                  "source": "{{Source: system or document, date}}"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "slide",
+          "children": [
+            {
+              "name": "block",
+              "props": {
+                "ref": "two-column",
+                "slots": {
+                  "title": "{{Action title: the claim this slide proves, with its number, two lines at most}}",
+                  "tracker": "{{Tracker: the section, one or two words}}",
+                  "bullets": [
+                    "{{Bullet 1: one claim, ten words}}",
+                    "{{Bullet 2: one claim, ten words}}",
+                    "{{Bullet 3: one claim, ten words}}"
+                  ],
+                  "content": {
+                    "name": "table",
+                    "props": {
+                      "rows": [
+                        [
+                          "{{Row label}}",
+                          {
+                            "text": "{{Column (unit)}}",
+                            "align": "right"
+                          },
+                          {
+                            "text": "{{Column (unit)}}",
+                            "align": "right"
+                          }
+                        ],
+                        [
+                          "{{Row 1}}",
+                          {
+                            "text": "{{0.0}}",
+                            "align": "right"
+                          },
+                          {
+                            "text": "{{0.0}}",
+                            "align": "right"
+                          }
+                        ],
+                        [
+                          "{{Row 2}}",
+                          {
+                            "text": "{{0.0}}",
+                            "align": "right"
+                          },
+                          {
+                            "text": "{{0.0}}",
+                            "align": "right"
+                          }
+                        ],
+                        [
+                          "{{Row 3}}",
+                          {
+                            "text": "{{0.0}}",
+                            "align": "right"
+                          },
+                          {
+                            "text": "{{0.0}}",
+                            "align": "right"
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  "source": "{{Source: system or document, date}}"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "slide",
+          "children": [
+            {
+              "name": "block",
+              "props": {
+                "ref": "statement",
+                "slots": {
+                  "tracker": "{{Tracker: the section, one or two words}}",
+                  "assertion": "{{Assertion: what to do next, in one sentence}}",
+                  "support": "{{Support: what backs the assertion, under thirty words}}"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "narrative": {
+      "description": "Argument-led: cover, the position as a statement, two two-column slides that argue it beside a chart, one action-chart, a two-column table, a closing statement.",
+      "whenToUse": "The brief is a position or a recommendation with few numbers; the audience follows an argument.",
+      "pages": {
+        "min": 6,
+        "max": 8
+      },
+      "metadata": {
+        "title": "{{Title: as on the cover}}",
+        "author": "{{Author or team}}",
+        "company": "{{Client name}}"
+      },
+      "children": [
+        {
+          "name": "slide",
+          "children": [
+            {
+              "name": "block",
+              "props": {
+                "ref": "cover",
+                "slots": {
+                  "title": "{{Title: the deck's conclusion in one sentence}}",
+                  "subtitle": "{{Subtitle: what the deck answers, for whom}}",
+                  "client": "{{Client name}}",
+                  "date": "{{Month YYYY}}",
+                  "confidentiality": "{{Confidentiality: Confidential, or For internal use}}"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "slide",
+          "children": [
+            {
+              "name": "block",
+              "props": {
+                "ref": "statement",
+                "slots": {
+                  "tracker": "{{Tracker: the section, one or two words}}",
+                  "assertion": "{{Assertion: the position, in one sentence}}",
+                  "support": "{{Support: what backs the assertion, under thirty words}}"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "slide",
+          "children": [
+            {
+              "name": "block",
+              "props": {
+                "ref": "two-column",
+                "slots": {
+                  "title": "{{Action title: the claim this slide proves, with its number, two lines at most}}",
+                  "tracker": "{{Tracker: the section, one or two words}}",
+                  "text": "{{Body: the argument this slide makes, under fifty words}}",
+                  "content": {
+                    "name": "chart",
+                    "props": {
+                      "type": "bar",
+                      "valAxisTitle": "{{Measure (unit)}}",
+                      "data": [
+                        {
+                          "name": "{{Series name}}",
+                          "labels": [
+                            "{{Period 1}}",
+                            "{{Period 2}}",
+                            "{{Period 3}}"
+                          ],
+                          "values": [0, 0, 0]
+                        }
+                      ],
+                      "chartColors": [
+                        "accent",
+                        "secondary",
+                        "accent4",
+                        "accent6",
+                        "accent5"
+                      ]
+                    }
+                  },
+                  "source": "{{Source: system or document, date}}"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "slide",
+          "children": [
+            {
+              "name": "block",
+              "props": {
+                "ref": "two-column",
+                "slots": {
+                  "title": "{{Action title: the claim this slide proves, with its number, two lines at most}}",
+                  "tracker": "{{Tracker: the section, one or two words}}",
+                  "text": "{{Body: the argument this slide makes, under fifty words}}",
+                  "content": {
+                    "name": "chart",
+                    "props": {
+                      "type": "bar",
+                      "valAxisTitle": "{{Measure (unit)}}",
+                      "data": [
+                        {
+                          "name": "{{Series name}}",
+                          "labels": [
+                            "{{Period 1}}",
+                            "{{Period 2}}",
+                            "{{Period 3}}"
+                          ],
+                          "values": [0, 0, 0]
+                        }
+                      ],
+                      "chartColors": [
+                        "accent",
+                        "secondary",
+                        "accent4",
+                        "accent6",
+                        "accent5"
+                      ]
+                    }
+                  },
+                  "source": "{{Source: system or document, date}}"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "slide",
+          "children": [
+            {
+              "name": "block",
+              "props": {
+                "ref": "action-chart",
+                "slots": {
+                  "title": "{{Action title: the claim this slide proves, with its number, two lines at most}}",
+                  "tracker": "{{Tracker: the section, one or two words}}",
+                  "chart": {
+                    "name": "chart",
+                    "props": {
+                      "type": "bar",
+                      "valAxisTitle": "{{Measure (unit)}}",
+                      "data": [
+                        {
+                          "name": "{{Series name}}",
+                          "labels": [
+                            "{{Period 1}}",
+                            "{{Period 2}}",
+                            "{{Period 3}}"
+                          ],
+                          "values": [0, 0, 0]
+                        }
+                      ],
+                      "chartColors": [
+                        "accent",
+                        "secondary",
+                        "accent4",
+                        "accent6",
+                        "accent5"
+                      ]
+                    }
+                  },
+                  "takeaway": "{{Takeaway: what the reader should conclude, one or two sentences}}",
+                  "source": "{{Source: system or document, date}}"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "slide",
+          "children": [
+            {
+              "name": "block",
+              "props": {
+                "ref": "two-column",
+                "slots": {
+                  "title": "{{Action title: the claim this slide proves, with its number, two lines at most}}",
+                  "tracker": "{{Tracker: the section, one or two words}}",
+                  "bullets": [
+                    "{{Bullet 1: one claim, ten words}}",
+                    "{{Bullet 2: one claim, ten words}}",
+                    "{{Bullet 3: one claim, ten words}}"
+                  ],
+                  "content": {
+                    "name": "table",
+                    "props": {
+                      "rows": [
+                        [
+                          "{{Row label}}",
+                          {
+                            "text": "{{Column (unit)}}",
+                            "align": "right"
+                          },
+                          {
+                            "text": "{{Column (unit)}}",
+                            "align": "right"
+                          }
+                        ],
+                        [
+                          "{{Row 1}}",
+                          {
+                            "text": "{{0.0}}",
+                            "align": "right"
+                          },
+                          {
+                            "text": "{{0.0}}",
+                            "align": "right"
+                          }
+                        ],
+                        [
+                          "{{Row 2}}",
+                          {
+                            "text": "{{0.0}}",
+                            "align": "right"
+                          },
+                          {
+                            "text": "{{0.0}}",
+                            "align": "right"
+                          }
+                        ],
+                        [
+                          "{{Row 3}}",
+                          {
+                            "text": "{{0.0}}",
+                            "align": "right"
+                          },
+                          {
+                            "text": "{{0.0}}",
+                            "align": "right"
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  "source": "{{Source: system or document, date}}"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "slide",
+          "children": [
+            {
+              "name": "block",
+              "props": {
+                "ref": "statement",
+                "slots": {
+                  "tracker": "{{Tracker: the section, one or two words}}",
+                  "assertion": "{{Assertion: what to do next, in one sentence}}",
+                  "support": "{{Support: what backs the assertion, under thirty words}}"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/packages/mcp-server/src/__tests__/discover.test.ts
+++ b/packages/mcp-server/src/__tests__/discover.test.ts
@@ -202,12 +202,14 @@ describe('jto_discover', () => {
     // The DOCX document schema is over 3 MB. Whatever else changes here, this
     // tool must never start shipping schemas. The ceiling grew from 32 KB to
     // 36 KB when the blueprint summaries joined the gallery and block
-    // references, and to 44 KB with the technical-report blueprint and the
+    // references, to 44 KB with the technical-report blueprint and the
     // twelfth template, whose eleven block references (ten shared by name
     // with the client-report template, one new) are each listed under their
-    // own template; a full blueprint plan would blow it, and belongs to the
-    // scaffold, never to discovery.
-    expect(JSON.stringify(result).length).toBeLessThan(44 * 1024);
+    // own template, and to 48 KB with the consulting-deck blueprint and the
+    // four deck blocks beside action-chart (45 KB measured, three bytes over
+    // the old ceiling on CI); a full blueprint plan would blow it, and
+    // belongs to the scaffold, never to discovery.
+    expect(JSON.stringify(result).length).toBeLessThan(48 * 1024);
     expect(JSON.stringify(result)).not.toContain('"$schema"');
   });
 

--- a/packages/mcp-server/src/__tests__/scaffold.test.ts
+++ b/packages/mcp-server/src/__tests__/scaffold.test.ts
@@ -178,7 +178,7 @@ describe('what a scaffold is', () => {
     });
   });
 
-  it('refuses an unknown blueprint, an unknown variant and a format without blueprints, naming what exists', async () => {
+  it('refuses an unknown blueprint, an unknown variant and a blueprint of the other format, naming what exists', async () => {
     const unknown = await call('jto_scaffold', { blueprint: 'memo' });
     expect(unknown.ok).toBe(false);
     expect(unknown.diagnostics[0]).toMatchObject({
@@ -202,7 +202,7 @@ describe('what a scaffold is', () => {
     });
     expect(pptx.diagnostics[0]).toMatchObject({
       code: 'E_BLUEPRINT_NOT_FOUND',
-      context: { format: 'pptx', blueprints: [] },
+      context: { format: 'pptx', blueprints: ['consulting-deck'] },
     });
   });
 });
@@ -566,6 +566,87 @@ describe('scaffolding a technical report', () => {
         .filter((entry) => entry.path.startsWith(`${results}/`))
         .map((entry) => entry.path)
     ).not.toContain(`${results}/3/props/text`);
+  });
+});
+
+describe('scaffolding a consulting deck', () => {
+  it('opens a deck whose metadata sits under props, fills the cover from the brief and the slide titles and bodies from the outline', async () => {
+    const out = await call('jto_scaffold', {
+      format: 'pptx',
+      blueprint: 'consulting-deck',
+      variant: 'narrative',
+      brief: {
+        title: 'Growth improved as delivery became more reliable',
+        client: 'Example client',
+        date: 'September 2026',
+        author: 'Consulting team',
+      },
+      outline: [
+        '## Reliability, not price, drove the gain',
+        'Retained clients expanded scope in every quarter after delivery stabilised.',
+        '## Churn fell to 6% once ownership was assigned',
+        'Named owners closed the gap between promise and delivery.',
+        '## Revenue grew 18%',
+        'Each quarter outgrew the last.',
+      ].join('\n'),
+    });
+    expect(out.ok).toBe(true);
+    expect(out.workspace).toMatchObject({ revision: 1, format: 'pptx' });
+    expect(out.blueprint).toMatchObject({
+      id: 'consulting-deck',
+      variant: 'narrative',
+      theme: 'consulting',
+      profile: 'consulting-deck',
+      definitions: 'consulting-deck-blocks.pptx.json',
+    });
+    expect(out.blueprint.blocks).toEqual(
+      expect.arrayContaining([
+        'cover',
+        'statement',
+        'two-column',
+        'action-chart',
+      ])
+    );
+    expect(codes(out)).not.toContain('W_BRIEF_UNUSED');
+    const { document } = (await call('jto_workspace_inspect', {
+      handle: out.workspace.handle,
+      includeDocument: true,
+    })) as { document: any };
+    expect(document.props).toMatchObject({
+      title: 'Growth improved as delivery became more reliable',
+      author: 'Consulting team',
+      company: 'Example client',
+      qualityProfile: 'consulting-deck',
+    });
+    expect(document.props.metadata).toBeUndefined();
+    const cover = document.children[0].children[0].props.slots;
+    expect(cover).toMatchObject({
+      title: 'Growth improved as delivery became more reliable',
+      client: 'Example client',
+      date: 'September 2026',
+    });
+    // `##` fills the content slides' titles in order — the statement's
+    // assertion, then the two-column titles — and the paragraphs their
+    // support and text; the cover is never an opener.
+    const slide = (i: number) => document.children[i].children[0].props.slots;
+    expect(slide(1).assertion).toBe('Reliability, not price, drove the gain');
+    expect(slide(1).support).toBe(
+      'Retained clients expanded scope in every quarter after delivery stabilised.'
+    );
+    expect(slide(2).title).toBe('Churn fell to 6% once ownership was assigned');
+    expect(slide(2).text).toBe(
+      'Named owners closed the gap between promise and delivery.'
+    );
+    expect(slide(3).title).toBe('Revenue grew 18%');
+    expect(slide(3).text).toBe('Each quarter outgrew the last.');
+    // The remaining markers are still owed, and validation says so.
+    expect(out.fillMap.length).toBeGreaterThan(10);
+    const validated = (await call('jto_validate', {
+      format: 'pptx',
+      handle: out.workspace.handle,
+    })) as any;
+    expect(validated.profileId).toBe('consulting-deck');
+    expect(validated.generationReady).toBe(false);
   });
 });
 

--- a/packages/mcp-server/src/lib/core.ts
+++ b/packages/mcp-server/src/lib/core.ts
@@ -9,7 +9,7 @@
  * resource and the scaffold — without each of them repeating the dance.
  *
  * Everything is optional on the way out: a core that cannot be loaded, or a
- * PPTX core that exports no blueprints yet, answers `undefined` and the caller
+ * core that exports no blueprints, answers `undefined` and the caller
  * degrades to "none", never to a dead server.
  */
 
@@ -58,6 +58,8 @@ const CORE_EXPORTS: Record<
     themes: 'pptxThemes',
     profiles: 'PPTX_QUALITY_PROFILES',
     defaultProfile: 'PPTX_DEFAULT_QUALITY_PROFILE',
+    blueprints: 'PPTX_BLUEPRINTS',
+    instantiate: 'instantiatePptxBlueprint',
     rules: 'PPTX_QUALITY_RULES',
     resolveProfile: 'resolvePptxQualityProfile',
     declaredProfile: 'declaredPptxQualityProfile',

--- a/packages/mcp-server/src/tools/scaffold.ts
+++ b/packages/mcp-server/src/tools/scaffold.ts
@@ -64,6 +64,23 @@ const CHROME_BLOCKS: ReadonlySet<string> = new Set([
   'memo-header',
 ]);
 
+/** Where a format keeps its metadata: a document under `props.metadata`, a deck under `props`. */
+const METADATA_POINTER: Record<FormatName, string> = {
+  docx: '/props/metadata',
+  pptx: '/props',
+};
+
+/**
+ * The slots an outline paragraph may fill on a slide, in the order a block
+ * declares them: prose, the support under a statement, the takeaway beside a
+ * chart. A document's paragraphs go to its `text` markers instead.
+ */
+const SLIDE_BODY_SLOTS: ReadonlySet<string> = new Set([
+  'text',
+  'support',
+  'takeaway',
+]);
+
 /** Brief keys that also fill a metadata field under another name. */
 const METADATA_ALIASES: Readonly<Record<string, string>> = {
   client: 'company',
@@ -208,7 +225,8 @@ export function applyFacts(
   document: Record<string, unknown>,
   fillMap: readonly BlueprintFillEntry[],
   brief: Readonly<Record<string, string>>,
-  outline: Outline | undefined
+  outline: Outline | undefined,
+  format: FormatName = 'docx'
 ): Fill {
   const done = new Set<string>();
   const diagnostics: Diagnostic[] = [];
@@ -226,7 +244,7 @@ export function applyFacts(
   for (const [key, value] of Object.entries(facts)) {
     const metadataPaths = [key, METADATA_ALIASES[key]]
       .filter((name): name is string => name !== undefined)
-      .map((name) => `/props/metadata/${name}`);
+      .map((name) => `${METADATA_POINTER[format]}/${name}`);
     const slotNames = [key, ...(SLOT_ALIASES[key] ?? [])];
     const targets = pending().filter(
       (entry) =>
@@ -260,8 +278,15 @@ export function applyFacts(
   }
 
   if (outline) {
-    const openers = pending().filter(
-      (entry) => entry.block === 'section-opener' && entry.slot === 'title'
+    // What a `##` fills: a section opener's title in a document; on a deck,
+    // the title of each content slide — the action title, or a statement's
+    // assertion — never the cover's.
+    const openers = pending().filter((entry) =>
+      format === 'docx'
+        ? entry.block === 'section-opener' && entry.slot === 'title'
+        : entry.kind === 'slot' &&
+          entry.block !== 'cover' &&
+          (entry.slot === 'title' || entry.slot === 'assertion')
     );
     // A section's markers are the ones between its opener and the next, in
     // fill-map (document) order — the same thing as "the same top-level
@@ -280,8 +305,12 @@ export function applyFacts(
       write(opener, section.heading);
       const own = under(index);
       const subheadings = own.filter((entry) => isHeadingText(document, entry));
-      const bodies = own.filter(
-        (entry) => entry.kind === 'text' && !subheadings.includes(entry)
+      const bodies = own.filter((entry) =>
+        format === 'docx'
+          ? entry.kind === 'text' && !subheadings.includes(entry)
+          : entry.kind === 'slot' &&
+            entry.slot !== undefined &&
+            SLIDE_BODY_SLOTS.has(entry.slot)
       );
       section.subheadings.forEach((text, i) => {
         if (subheadings[i]) write(subheadings[i], text);
@@ -374,7 +403,7 @@ export function register(server: McpServer, deps: ToolDeps): void {
     {
       title: 'Scaffold a document from a blueprint',
       description:
-        'The first move for a report: pick a blueprint from jto_discover (or jto://blueprints), name the theme and what you know of the brief, and get back a draft workspace — a handle at revision 1 — plus a fill map listing every `{{…}}` marker still owed: its JSON pointer, kind, budget and the guidance for filling it. The scaffold is schema- and semantic-valid, carries the block definitions it invokes, and names its quality profile, so jto_validate judges it against the archetype from the first call and reports the markers as advisory draft findings with `generationReady: false`; jto_generate refuses until every marker is replaced. Fill slots by pointer with jto_workspace_patch. A brief fact fills props.metadata.<key> and the <key> slot of the cover, running head and memo header (`title` is a memo’s subject); a markdown outline fills the body — `#` is the title, each `##` in order the next section opener, each `###` beneath it the next sub-heading, the paragraphs that section’s body text. Whatever matches nothing is reported.',
+        'The first move for a report: pick a blueprint from jto_discover (or jto://blueprints), name the theme and what you know of the brief, and get back a draft workspace — a handle at revision 1 — plus a fill map listing every `{{…}}` marker still owed: its JSON pointer, kind, budget and the guidance for filling it. The scaffold is schema- and semantic-valid, carries the block definitions it invokes, and names its quality profile, so jto_validate judges it against the archetype from the first call and reports the markers as advisory draft findings with `generationReady: false`; jto_generate refuses until every marker is replaced. Fill slots by pointer with jto_workspace_patch. A brief fact fills props.metadata.<key> and the <key> slot of the cover, running head and memo header (`title` is a memo’s subject); a markdown outline fills the body — `#` is the title, each `##` in order the next section opener (on a deck, the next content slide’s title), each `###` beneath it the next sub-heading, the paragraphs that section’s body text (on a deck, the slide’s text, support or takeaway). Whatever matches nothing is reported.',
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -385,13 +414,13 @@ export function register(server: McpServer, deps: ToolDeps): void {
         properties: {
           format: {
             ...formatSchema,
-            description: 'Defaults to docx, the only format with blueprints.',
+            description: 'Defaults to docx.',
           },
           blueprint: {
             type: 'string',
             minLength: 1,
             description:
-              'A blueprint id from jto_discover, e.g. "client-report" or "technical-report".',
+              'A blueprint id from jto_discover, e.g. "client-report", "technical-report" or "consulting-deck".',
           },
           variant: {
             type: 'string',
@@ -537,7 +566,8 @@ export function register(server: McpServer, deps: ToolDeps): void {
             instantiated.document,
             instantiated.fillMap,
             args.brief ?? {},
-            outline
+            outline,
+            format
           );
 
           const title = args.title ?? args.brief?.title ?? outline?.title;

--- a/packages/shared/src/blueprints/index.ts
+++ b/packages/shared/src/blueprints/index.ts
@@ -1,1 +1,2 @@
 export * from './schema';
+export * from './instantiate';

--- a/packages/shared/src/blueprints/instantiate.ts
+++ b/packages/shared/src/blueprints/instantiate.ts
@@ -1,0 +1,256 @@
+/**
+ * What instantiating a blueprint means in either format, so each core keeps
+ * only the shape of its own root.
+ *
+ * A registry is the bundled JSON files, each validated against the shared
+ * schema when the module loads (each core scans its own directory for more,
+ * since this module also serves the browser). Instantiation copies a variant's children, brings the definitions
+ * the children invoke — and the definitions those depend on — from the
+ * playground template the blueprint names, and lists every `{{…}}` scaffold
+ * marker as a fill-map entry: where it is, what kind of slot holds it, its
+ * budget and the guidance the marker text carries. The core decides where its
+ * metadata lives (`props.metadata` in a document, `props` in a deck) and hands
+ * over the marker occurrences its placeholder detector found.
+ */
+import { blockDependencies } from '../blocks';
+import type { BlockSlot, JsonBlockDefinition } from '../blocks';
+import {
+  validateBlueprint,
+  type Blueprint,
+  type BlueprintFillEntry,
+  type BlueprintFormat,
+  type BlueprintVariant,
+} from './schema';
+
+/** Validate and key candidate blueprints of one format by id. */
+export function registerBlueprints(
+  format: BlueprintFormat,
+  candidates: readonly unknown[]
+): Record<string, Blueprint> {
+  const registry: Record<string, Blueprint> = {};
+  for (const candidate of candidates) {
+    const issues = validateBlueprint(candidate);
+    if (issues.length > 0)
+      throw new Error(
+        `Invalid bundled blueprint: ${issues
+          .map((issue) => `${issue.path}: ${issue.message}`)
+          .join('; ')}`
+      );
+    const blueprint = candidate as Blueprint;
+    if (blueprint.format !== format)
+      throw new Error(
+        `Blueprint ${blueprint.id} is not a ${format.toUpperCase()} blueprint.`
+      );
+    if (registry[blueprint.id])
+      throw new Error(
+        `Two bundled blueprints share the id "${blueprint.id}"; the later one would silently replace the earlier.`
+      );
+    registry[blueprint.id] = blueprint;
+  }
+  return registry;
+}
+
+export interface InstantiateBlueprintOptions {
+  /** A variant id from `blueprint.variants`; the first when omitted. */
+  variant?: string;
+  /** Overrides the blueprint's recommended theme. */
+  theme?: string;
+  /**
+   * The block definitions the variant invokes — the `props.blocks` of the
+   * playground template the blueprint names. The scaffold carries the ones it
+   * uses, plus their dependencies; nothing is looked up at render time.
+   */
+  definitions: Readonly<Record<string, JsonBlockDefinition>>;
+  /** Metadata values that replace the variant's marked ones. */
+  metadata?: Readonly<Record<string, string>>;
+}
+
+export interface InstantiatedBlueprint {
+  document: Record<string, unknown>;
+  fillMap: BlueprintFillEntry[];
+  variant: string;
+}
+
+/** One `{{…}}` occurrence the core's placeholder detector found. */
+export interface MarkerOccurrence {
+  path: string;
+  text: string;
+}
+
+export interface InstantiateRoot {
+  /** The format, which is also the root component's name. */
+  format: BlueprintFormat;
+  /** Props the root carries besides theme, profile, blocks and metadata. */
+  props?: Readonly<Record<string, unknown>>;
+  /** JSON pointer prefix under which metadata lives: `/props/metadata` or `/props`. */
+  metadataPointer: string;
+  /** The scaffold markers in a document, in document order. */
+  markers: (document: unknown) => readonly MarkerOccurrence[];
+}
+
+const MARKER = /^\{\{\s*([\s\S]*?)\s*\}\}$/;
+
+/** The variant a request names, or the first; throws on a wrong format or a missing variant. */
+export function selectVariant(
+  blueprint: Blueprint,
+  format: BlueprintFormat,
+  variantId: string | undefined
+): { id: string; variant: BlueprintVariant } {
+  if (blueprint.format !== format)
+    throw new Error(
+      `Blueprint ${blueprint.id} is a ${blueprint.format} blueprint; this instantiates ${format.toUpperCase()} ones.`
+    );
+  const id = variantId ?? Object.keys(blueprint.variants)[0];
+  const variant = blueprint.variants[id];
+  if (!variant)
+    throw new Error(
+      `Blueprint ${blueprint.id} has no variant "${id}"; it has ${Object.keys(
+        blueprint.variants
+      ).join(', ')}.`
+    );
+  return { id, variant };
+}
+
+export function instantiateBlueprint(
+  blueprint: Blueprint,
+  options: InstantiateBlueprintOptions,
+  root: InstantiateRoot
+): InstantiatedBlueprint {
+  const { id: variantId, variant } = selectVariant(
+    blueprint,
+    root.format,
+    options.variant
+  );
+  const children = structuredClone(variant.children) as unknown[];
+  const blocks = definitionsFor(children, options.definitions, blueprint);
+  const metadata = { ...variant.metadata, ...options.metadata };
+  const props: Record<string, unknown> = {
+    theme: options.theme ?? blueprint.theme,
+    qualityProfile: blueprint.profile,
+    ...root.props,
+    ...(Object.keys(blocks).length > 0 && { blocks }),
+    ...(root.metadataPointer === '/props' ? metadata : { metadata }),
+  };
+  const document: Record<string, unknown> = {
+    name: root.format,
+    props,
+    children,
+  };
+  return {
+    document,
+    fillMap: fillMap(document, blocks, root),
+    variant: variantId,
+  };
+}
+
+/** The definitions the children invoke, dependencies first, from `available`. */
+export function definitionsFor(
+  children: unknown[],
+  available: Readonly<Record<string, JsonBlockDefinition>>,
+  blueprint: Blueprint
+): Record<string, JsonBlockDefinition> {
+  const refs = new Set<string>();
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) return node.forEach(visit);
+    if (!node || typeof node !== 'object') return;
+    const record = node as Record<string, unknown>;
+    const props = record.props as Record<string, unknown> | undefined;
+    if (record.name === 'block' && typeof props?.ref === 'string')
+      refs.add(props.ref);
+    Object.values(record).forEach(visit);
+  };
+  visit(children);
+  const result: Record<string, JsonBlockDefinition> = {};
+  for (const ref of refs) {
+    if (!available[ref])
+      throw new Error(
+        `Blueprint ${blueprint.id} invokes "${ref}", which ${blueprint.definitions} does not define.`
+      );
+    for (const name of [...blockDependencies(available, ref), ref])
+      result[name] ??= structuredClone(available[name]);
+  }
+  return result;
+}
+
+function fillMap(
+  document: unknown,
+  blocks: Readonly<Record<string, JsonBlockDefinition>>,
+  root: InstantiateRoot
+): BlueprintFillEntry[] {
+  const metadataPrefix = `${root.metadataPointer}/`;
+  return root.markers(document).map((occurrence) => {
+    const guidance = occurrence.text.match(MARKER)?.[1] ?? occurrence.text;
+    const base = { path: occurrence.path, marker: occurrence.text, guidance };
+    // Under `/props` only a direct child is metadata: `/props/blocks/...` and
+    // `/props/theme` are not, and a marker never lands in those anyway.
+    if (
+      occurrence.path.startsWith(metadataPrefix) &&
+      !occurrence.path.slice(metadataPrefix.length).includes('/')
+    )
+      return { ...base, kind: 'metadata' as const };
+    const slot = slotAt(document, occurrence.path, blocks);
+    return slot
+      ? { ...base, kind: 'slot' as const, ...slot }
+      : { ...base, kind: 'text' as const };
+  });
+}
+
+/** The declared slot a pointer inside an invocation's `slots` lands in. */
+export function slotAt(
+  document: unknown,
+  pointer: string,
+  blocks: Readonly<Record<string, JsonBlockDefinition>>
+):
+  | Omit<BlueprintFillEntry, 'path' | 'marker' | 'guidance' | 'kind'>
+  | undefined {
+  const at = pointer.lastIndexOf('/props/slots/');
+  if (at < 0) return undefined;
+  const invocation = valueAt(document, pointer.slice(0, at)) as
+    | { props?: { ref?: unknown } }
+    | undefined;
+  const ref = invocation?.props?.ref;
+  if (typeof ref !== 'string' || !blocks[ref]) return undefined;
+  const segments = pointer
+    .slice(at + '/props/slots/'.length)
+    .split('/')
+    .map(unescape);
+  let slot: BlockSlot | undefined = blocks[ref].slots[segments[0]];
+  const names = [segments[0]];
+  for (const segment of segments.slice(1)) {
+    if (!slot) break;
+    if (slot.type === 'array' && /^\d+$/.test(segment)) slot = slot.items;
+    else if (slot.type === 'object') {
+      slot = slot.properties?.[segment];
+      names.push(segment);
+    } else if (slot.type === 'component')
+      break; // content inside the slot
+    else slot = undefined;
+  }
+  if (!slot) return undefined;
+  return {
+    block: ref,
+    slot: names.join('.'),
+    type: slot.type,
+    ...(slot.maxWords !== undefined && { maxWords: slot.maxWords }),
+    ...(slot.maxLength !== undefined && { maxLength: slot.maxLength }),
+    ...(slot.oneLine !== undefined && { oneLine: slot.oneLine }),
+    ...(slot.required !== undefined && { required: slot.required }),
+  };
+}
+
+function unescape(segment: string): string {
+  return segment.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+/** The value a JSON pointer names, or undefined. */
+export function valueAt(root: unknown, pointer: string): unknown {
+  if (pointer === '') return root;
+  let current: unknown = root;
+  for (const segment of pointer.split('/').slice(1).map(unescape)) {
+    if (Array.isArray(current)) current = current[Number(segment)];
+    else if (current && typeof current === 'object')
+      current = (current as Record<string, unknown>)[segment];
+    else return undefined;
+  }
+  return current;
+}


### PR DESCRIPTION
Closes #342. Stacked on #413 (base is its branch; retargets when it merges). With this the epic's post-checkpoint sequence — technical report (#411), alternate themes (#412), pptx blocks (#413), deck blueprint (this) — is all on stacked PRs.

## What changes

**`consulting-deck` blueprint** (`core-pptx/src/templates/blueprints/`), two variants over the five deck blocks, judged by the `consulting-deck` profile:

| variant | slides |
|---|---|
| `data-heavy` | cover; KPI row; three action-charts with takeaway and source; two-column bullets beside a table; closing statement (6–9) |
| `narrative` | cover; the position as a statement; two two-column slides arguing it beside a chart; one action-chart; two-column table; closing statement (6–8) |

Chart slots are `chart` components with marker series, labels and axis title and `chartColors` from the theme; table content right-aligns numeric columns per cell (a slot that may hold a table cannot carry chart props, and a block cannot know which columns are numbers — both surfaced by the profile's rules on the filled scaffold).

**Instantiation shared between the cores.** `shared/src/blueprints/instantiate.ts` carries what instantiating means — registry validation, the invoked definitions and their dependencies, the fill map with each marker's slot budget — and each core keeps only the shape of its root: `core-docx` (metadata under `props.metadata`) is a thin wrapper now, byte-for-byte green on its 49 blueprint tests; `core-pptx` exports `PPTX_BLUEPRINTS`, `pptxBlueprint`, `instantiatePptxBlueprint` (metadata under `props`, the wide canvas as default). The directory scan stays in each core: `shared` also serves the browser.

**`jto_scaffold` in either format.** The MCP loader already resolved blueprints by export name; the tool's brief and outline mapping is now format-aware: brief facts fill a deck's `title`, `author`, `company` and the cover's slots; each `##` fills the next content slide's title (action title or statement assertion, never the cover's) and its paragraphs the slide's `text`, `support` or `takeaway` slots in order; `###` has no place on a slide and is reported.

## Verification

`consulting-deck.test.ts` (22): registered and schema-valid; both variants validate, carry their definitions, put metadata under `props`, report only markers (and the template's known info-level tight box) under their own profile, render warning-clean; filled scaffolds carry no non-info finding on any of the six themes; a blanked source or takeaway is `CHROME_MISSING` under `consulting-deck` and not under `technical-presentation`. `scaffold.test.ts` gains a deck journey over the tool: brief to props and cover, outline to slide titles and bodies, `jto_validate` on the handle judged by `consulting-deck` with `generationReady: false`. Serial `turbo test` (every package green; the `quality` worker died on teardown once with a native V8 crash after its five files passed, and passes alone), typecheck, lint, prettier.

## Not done

The issue's fuller outline mapping (long bullet lists split across slides, tables to two-column slots, numbers promoted to KPI rows) is not attempted; the mapping is documented as it is in `docs/reference/blueprints.md`. Documented in the MCP guide through the generated design guide, which reads the registry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the consulting-deck blueprint for PPTX presentations, including data-heavy and narrative variants.
  * Added reusable cover, KPI, chart, evidence, two-column, and statement slide layouts.
  * Added PPTX blueprint discovery and scaffolding, including outline-to-slide content mapping.
  * Added vermilion and devportal theme support across DOCX and PPTX, with improved font safety and rendering consistency.

* **Documentation**
  * Documented consulting-deck variants, charts, tables, metadata, canvas, profiles, and deck scaffolding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->