### PR TITLE
fix(pptx): complete every registered theme name

### DIFF
--- a/.changeset/pptx-theme-completion.md
+++ b/.changeset/pptx-theme-completion.md
@@ -1,0 +1,21 @@
+---
+'@json-to-office/shared-pptx': patch
+'@json-to-office/shared-docx': patch
+'@json-to-office/jto': patch
+---
+
+Fix `"theme"` autocomplete offering the wrong set of themes
+
+Two independent defects left the playground's `"theme": ""` completion
+showing four names on a pptx deck when eleven were available.
+
+The pptx schema hardcoded its own copy of the built-in names, so `vermilion`
+and `devportal` were completable on docx and invisible on pptx for as long as
+they shipped. Both formats now build the description and the `examples` from a
+single exported list, and guard tests pin the theme registry to it.
+
+Custom themes were dropped entirely on pptx: the injector checked `type ===
+'string'` before anything else, and pptx declares `theme` as `string | inline
+theme config` — a union node with `anyOf` and no `type` of its own. It now
+recurses into union branches first, so themes served from the playground's
+theme library complete alongside the built-ins.

--- a/packages/core-docx/src/themes/__tests__/bundled-themes.test.ts
+++ b/packages/core-docx/src/themes/__tests__/bundled-themes.test.ts
@@ -11,6 +11,10 @@ import { fileURLToPath } from 'url';
 import { validateThemeJson, formatValidationErrors } from '../json/validator';
 import { createMinimalTheme } from '../json';
 import { getTheme, getThemeNames } from '../../templates/themes';
+import {
+  BUILT_IN_DOCX_THEME_NAMES,
+  ReportPropsSchema,
+} from '@json-to-office/shared-docx';
 
 const themesDir = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -49,13 +53,25 @@ describe('built-in theme registry', () => {
 
   it('registers the statically imported themes', () => {
     expect(registeredNames).toEqual(
-      expect.arrayContaining([
-        'minimal',
-        'devportal',
-        'vermilion',
-        'consulting',
-      ])
+      expect.arrayContaining([...BUILT_IN_DOCX_THEME_NAMES])
     );
+  });
+
+  /**
+   * The editor completes `"theme": ""` from these `examples`, so a theme that
+   * reaches the registry without reaching the list is one the renderer accepts
+   * and the editor never suggests. That is exactly what happened on the pptx
+   * side, where the two lists were maintained by hand and drifted.
+   */
+  it('offers every registered theme for completion', () => {
+    const theme = (ReportPropsSchema as any).properties.theme;
+    expect([...theme.examples].sort()).toEqual(
+      [...BUILT_IN_DOCX_THEME_NAMES].sort()
+    );
+    for (const name of BUILT_IN_DOCX_THEME_NAMES) {
+      expect(registeredNames).toContain(name);
+      expect(theme.description).toContain(name);
+    }
   });
 
   it.each(registeredNames)('getTheme(%s) returns a valid theme', (name) => {

--- a/packages/core-pptx/src/themes/__tests__/bundled-themes.test.ts
+++ b/packages/core-pptx/src/themes/__tests__/bundled-themes.test.ts
@@ -21,7 +21,11 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { isSafeFont } from '@json-to-office/shared';
-import { validatePptxTheme } from '@json-to-office/shared-pptx';
+import {
+  BUILT_IN_PPTX_THEME_NAMES,
+  PresentationPropsSchema,
+  validatePptxTheme,
+} from '@json-to-office/shared-pptx';
 import {
   DEFAULT_PPTX_THEME,
   getPptxTheme,
@@ -38,16 +42,39 @@ function errorsFor(theme: unknown): string[] {
 
 const names = Object.keys(pptxThemes).sort();
 
+/**
+ * The `examples` of the string branch of `props.theme` — what the editor
+ * offers when the caller types `"theme": ""`.
+ */
+function schemaThemeExamples(): string[] {
+  const theme = (PresentationPropsSchema as any).properties.theme;
+  const stringBranch = theme.anyOf.find((b: any) => b.type === 'string');
+  return [...stringBranch.examples].sort();
+}
+
 describe('built-in pptx themes', () => {
-  it('registers the themes the docs and the schema enum promise', () => {
-    expect(names).toEqual([
-      'consulting',
-      'dark',
-      'default',
-      'devportal',
-      'minimal',
-      'vermilion',
-    ]);
+  it('registers exactly the themes the schema names', () => {
+    expect(names).toEqual([...BUILT_IN_PPTX_THEME_NAMES].sort());
+  });
+
+  /**
+   * This assertion is the point of the list existing in one place. The
+   * predecessor of this test hardcoded its own second copy of the names and
+   * called itself a check on "the schema enum", which is how `vermilion` and
+   * `devportal` reached the registry, and the renderer, while the schema went
+   * on offering only the four names it was born with — the editor completed
+   * `"theme": ""` to a set that had been wrong since they landed.
+   */
+  it('offers every registered theme for completion', () => {
+    expect(schemaThemeExamples()).toEqual(names);
+  });
+
+  it('names the built-ins in its own description', () => {
+    const theme = (PresentationPropsSchema as any).properties.theme;
+    const stringBranch = theme.anyOf.find((b: any) => b.type === 'string');
+    for (const name of names) {
+      expect(stringBranch.description).toContain(name);
+    }
   });
 
   it.each(names)('%s validates against the theme schema', (name) => {

--- a/packages/jto/src/client/lib/__tests__/monaco-theme-injection.test.ts
+++ b/packages/jto/src/client/lib/__tests__/monaco-theme-injection.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Custom theme names are offered for `props.theme` by injecting them into the
+ * schema's `examples` before it is installed.
+ *
+ * The docx schema declares `theme` as a bare string, but the pptx one declares
+ * it as `string | inline theme config` — a TypeBox union, which compiles to a
+ * node carrying `anyOf` and no `type` of its own. The injector checked `type`
+ * before anything else, so on pptx it reached the property and returned
+ * immediately: the playground served six custom themes from
+ * `public/templates/themes/` and the editor offered none of them.
+ */
+
+const setDiagnosticsOptions = vi.fn();
+const fakeMonaco = {
+  languages: {
+    json: {
+      jsonDefaults: {
+        diagnosticsOptions: {} as Record<string, unknown>,
+        setDiagnosticsOptions: (options: Record<string, unknown>) => {
+          setDiagnosticsOptions(options);
+          fakeMonaco.languages.json.jsonDefaults.diagnosticsOptions = options;
+        },
+      },
+    },
+    registerDocumentFormattingEditProvider: vi.fn(),
+    registerCompletionItemProvider: vi.fn(() => ({ dispose: vi.fn() })),
+  },
+  editor: { getModels: () => [], setModelLanguage: vi.fn() },
+};
+
+const fetchDocumentSchema = vi.fn();
+
+vi.mock('@monaco-editor/react', () => ({
+  loader: { init: async () => fakeMonaco },
+}));
+vi.mock('../schema-service', () => ({
+  schemaService: {
+    fetchDocumentSchema: (...args: unknown[]) => fetchDocumentSchema(...args),
+    clearPluginSchemaCache: vi.fn(),
+  },
+}));
+vi.mock('../json-schema-generator', () => ({
+  createReportSchemaConfig: () => ({
+    uri: 'report',
+    fileMatch: [],
+    schema: {},
+  }),
+  createThemeSchemaConfig: () => ({ uri: 'theme', fileMatch: [], schema: {} }),
+}));
+vi.mock('../quality-policy-schema', () => ({
+  createQualityPolicySchemaConfig: () => ({
+    uri: 'quality',
+    fileMatch: [],
+    schema: {},
+  }),
+}));
+vi.mock('../monaco-fonts-codelens', () => ({ registerFontCodeLens: vi.fn() }));
+vi.mock('../block-references', () => ({ loadBlockReferences: async () => [] }));
+vi.mock('../monaco-theme', () => ({ registerMonacoThemes: vi.fn() }));
+
+import { updateMonacoWithPlugins } from '../monaco-config';
+import type { Monaco } from '@monaco-editor/react';
+
+const monaco = fakeMonaco as unknown as Monaco;
+
+/** A `theme` property shaped the way the pptx schema declares it. */
+function unionThemeProp() {
+  return {
+    description: 'Theme to apply: a name, or an inline theme config object',
+    anyOf: [
+      { type: 'string', examples: ['consulting', 'default'] },
+      { type: 'object', properties: { colors: { type: 'object' } } },
+    ],
+  };
+}
+
+/** A `theme` property shaped the way the docx schema declares it. */
+function stringThemeProp() {
+  return { type: 'string', examples: ['minimal'] };
+}
+
+function propsHolder(themeProp: unknown) {
+  return {
+    type: 'object',
+    properties: {
+      props: { type: 'object', properties: { theme: themeProp } },
+    },
+  };
+}
+
+/**
+ * The pptx root dispatches on `renderer` to one referenced definition per
+ * profile, each of which is itself a union carrying the root component — the
+ * two-level walk the injector has to make.
+ */
+function pptxShapedSchema() {
+  return {
+    type: 'object',
+    definitions: {
+      PptxComponentDefinition_pptxgenjs: {
+        allOf: [
+          {
+            if: { properties: { name: { const: 'pptx' } } },
+            then: propsHolder(unionThemeProp()),
+          },
+        ],
+      },
+    },
+    allOf: [
+      {
+        if: { properties: { renderer: { const: 'pptxgenjs' } } },
+        then: { $ref: '#/definitions/PptxComponentDefinition_pptxgenjs' },
+      },
+    ],
+  };
+}
+
+/** Theme `examples` from every string branch the installed schema carries. */
+function installedThemeExamples(): string[] {
+  const options = fakeMonaco.languages.json.jsonDefaults.diagnosticsOptions;
+  const schemas = (options.schemas ?? []) as Array<{
+    uri: string;
+    schema: unknown;
+  }>;
+  const report = schemas.find((s) => s.uri.includes('report'));
+  const found: string[] = [];
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    const obj = node as Record<string, unknown>;
+    const theme = (obj.properties as Record<string, unknown> | undefined)
+      ?.theme;
+    if (theme) {
+      const branches = (theme as Record<string, unknown>).anyOf ?? [theme];
+      for (const branch of branches as Array<Record<string, unknown>>) {
+        if (branch?.type === 'string' && Array.isArray(branch.examples)) {
+          found.push(...(branch.examples as string[]));
+        }
+      }
+    }
+    Object.values(obj).forEach(walk);
+  };
+  walk(report?.schema);
+  return [...new Set(found)];
+}
+
+describe('custom theme name injection', () => {
+  beforeEach(() => {
+    setDiagnosticsOptions.mockClear();
+    fetchDocumentSchema.mockReset();
+    fakeMonaco.languages.json.jsonDefaults.diagnosticsOptions = {};
+  });
+
+  it('reaches the string branch of a union-typed theme property (pptx)', async () => {
+    fetchDocumentSchema.mockResolvedValue(pptxShapedSchema());
+
+    await updateMonacoWithPlugins(monaco, [], ['lumina', 'wiseair']);
+
+    const examples = installedThemeExamples();
+    expect(examples).toContain('lumina');
+    expect(examples).toContain('wiseair');
+    // The built-ins the schema shipped with are kept, not replaced.
+    expect(examples).toContain('consulting');
+  });
+
+  it('leaves the inline theme config branch alone', async () => {
+    fetchDocumentSchema.mockResolvedValue(pptxShapedSchema());
+
+    await updateMonacoWithPlugins(monaco, [], ['lumina']);
+
+    const options = fakeMonaco.languages.json.jsonDefaults.diagnosticsOptions;
+    const schemas = (options.schemas ?? []) as Array<{
+      uri: string;
+      schema: Record<string, any>;
+    }>;
+    const report = schemas.find((s) => s.uri.includes('report'));
+    const theme =
+      report?.schema.definitions.PptxComponentDefinition_pptxgenjs.allOf[0].then
+        .properties.props.properties.theme;
+    expect(theme.anyOf[1]).not.toHaveProperty('examples');
+  });
+
+  it('still injects into a bare string theme property (docx)', async () => {
+    fetchDocumentSchema.mockResolvedValue(propsHolder(stringThemeProp()));
+
+    await updateMonacoWithPlugins(monaco, [], ['corporate']);
+
+    expect(installedThemeExamples()).toEqual(['minimal', 'corporate']);
+  });
+});

--- a/packages/jto/src/client/lib/monaco-config.ts
+++ b/packages/jto/src/client/lib/monaco-config.ts
@@ -267,7 +267,20 @@ function stripDiscriminator(obj: any): void {
  */
 function injectCustomThemeNames(schema: any, themeNames: string[]): void {
   function inject(themeProp: any): void {
-    if (!themeProp || themeProp.type !== 'string') return;
+    if (!themeProp) return;
+    // `theme` is a bare string on docx but `string | inline theme config` on
+    // pptx, and a TypeBox union compiles to a node carrying `anyOf` and no
+    // `type` of its own. Checking `type` first skipped every pptx document
+    // silently: the property was reached, the names were never added, and the
+    // editor offered only the built-ins the schema was born with. The string
+    // branch is the one that takes names; the object branch has no `type`
+    // 'string' and falls out below.
+    const branches = themeProp.anyOf ?? themeProp.oneOf;
+    if (Array.isArray(branches)) {
+      branches.forEach(inject);
+      return;
+    }
+    if (themeProp.type !== 'string') return;
     const existing = Array.isArray(themeProp.examples)
       ? themeProp.examples
       : [];

--- a/packages/shared-docx/src/index.ts
+++ b/packages/shared-docx/src/index.ts
@@ -93,6 +93,7 @@ export type {
 // ============================================================================
 
 export {
+  BUILT_IN_DOCX_THEME_NAMES,
   ThemeConfigSchema,
   ThemeOverridesSchema,
   isValidThemeConfig,

--- a/packages/shared-docx/src/schemas/components/report.ts
+++ b/packages/shared-docx/src/schemas/components/report.ts
@@ -9,7 +9,7 @@ import {
 } from '@json-to-office/shared';
 import { ComponentDefaultsSchema } from '../component-defaults';
 import { NoProofWordsSchema } from '../font';
-import { ThemeOverridesSchema } from '../theme';
+import { BUILT_IN_DOCX_THEME_NAMES, ThemeOverridesSchema } from '../theme';
 
 // Create a function to generate ReportPropsSchema with recursive component reference
 export const createReportPropsSchema = (_componentRef?: TSchema) =>
@@ -19,8 +19,10 @@ export const createReportPropsSchema = (_componentRef?: TSchema) =>
       theme: Type.Optional(
         Type.String({
           description:
-            'Theme name to apply (default: "minimal"). Built-ins: consulting (the house style), minimal, devportal, vermilion.',
-          examples: ['consulting', 'minimal', 'devportal', 'vermilion'],
+            'Theme name to apply (default: "minimal"). Built-ins: ' +
+            `${BUILT_IN_DOCX_THEME_NAMES.join(', ')} ` +
+            '(consulting is the house style).',
+          examples: [...BUILT_IN_DOCX_THEME_NAMES],
           default: 'minimal',
         })
       ),

--- a/packages/shared-docx/src/schemas/theme.ts
+++ b/packages/shared-docx/src/schemas/theme.ts
@@ -19,6 +19,22 @@ import { IndentSchema } from './components/common';
 // Document Margins Schema
 // ============================================================================
 
+/**
+ * Built-in theme names, in the order the schema description and the editor's
+ * completion list offer them.
+ *
+ * The only place the set is written down: the `theme` property's description
+ * and `examples` are both built from it, and a guard test in `core-docx` pins
+ * the bundled theme registry to it. Its pptx twin is
+ * `BUILT_IN_PPTX_THEME_NAMES`, where the two drifted apart.
+ */
+export const BUILT_IN_DOCX_THEME_NAMES = [
+  'consulting',
+  'devportal',
+  'minimal',
+  'vermilion',
+] as const;
+
 export const DocumentMarginsSchema = Type.Object(
   {
     top: Type.Number({ minimum: 0 }),

--- a/packages/shared-pptx/src/index.ts
+++ b/packages/shared-pptx/src/index.ts
@@ -113,6 +113,7 @@ export type {
 
 // Theme
 export {
+  BUILT_IN_PPTX_THEME_NAMES,
   ThemeConfigSchema,
   ColorValueSchema,
   SEMANTIC_COLOR_NAMES,

--- a/packages/shared-pptx/src/schemas/components/presentation.ts
+++ b/packages/shared-pptx/src/schemas/components/presentation.ts
@@ -7,7 +7,11 @@ import {
   BlockDefinitionsSchema,
   FontRegistrySchema,
 } from '@json-to-office/shared';
-import { GridConfigSchema, ThemeConfigSchema } from '../theme';
+import {
+  BUILT_IN_PPTX_THEME_NAMES,
+  GridConfigSchema,
+  ThemeConfigSchema,
+} from '../theme';
 import { PptxComponentDefaultsSchema } from '../component-defaults';
 
 export const PresentationPropsSchema = Type.Object(
@@ -29,8 +33,10 @@ export const PresentationPropsSchema = Type.Object(
         [
           Type.String({
             description:
-              'Theme name to apply (default: "default"). Built-ins: consulting (the house style), default, dark, minimal.',
-            examples: ['consulting', 'default', 'dark', 'minimal'],
+              'Theme name to apply (default: "default"). Built-ins: ' +
+              `${BUILT_IN_PPTX_THEME_NAMES.join(', ')} ` +
+              '(consulting is the house style).',
+            examples: [...BUILT_IN_PPTX_THEME_NAMES],
             default: 'default',
           }),
           ThemeConfigSchema,

--- a/packages/shared-pptx/src/schemas/theme.ts
+++ b/packages/shared-pptx/src/schemas/theme.ts
@@ -25,6 +25,26 @@ export {
 } from '@json-to-office/shared/schemas/slide-content';
 export type { StyleName } from '@json-to-office/shared/schemas/slide-content';
 
+/**
+ * Built-in theme names, in the order the schema description and the editor's
+ * completion list offer them.
+ *
+ * This is the only place the set is written down: the `theme` property's
+ * description and `examples` are both built from it, and a guard test in
+ * `core-pptx` pins the theme registry to it. Adding a theme to the registry
+ * without adding it here is what left `vermilion` and `devportal`
+ * uncompletable for as long as they shipped — the schema still offered the
+ * four names it was born with.
+ */
+export const BUILT_IN_PPTX_THEME_NAMES = [
+  'consulting',
+  'dark',
+  'default',
+  'devportal',
+  'minimal',
+  'vermilion',
+] as const;
+
 export const GridMarginSchema = Type.Union(
   [
     Type.Number({ description: 'Margin in inches (all sides)' }),


### PR DESCRIPTION
Typing `"theme": ""` in a pptx deck offered four names — `consulting`, `dark`, `default`, `minimal` — while the sidebar listed nine themes and the registry held eleven. Two unrelated causes, one symptom.

## The schema carried its own copy of the names

`presentation.ts` hardcoded `examples: ['consulting', 'default', 'dark', 'minimal']` and repeated them in prose. `PPTX_THEMES` meanwhile grew `vermilion` and `devportal`, which have been renderable and uncompletable ever since.

The existing guard is the interesting part: `bundled-themes.test.ts` had a case named *"registers the themes the docs and the schema enum promise"* whose body asserted a **third** hardcoded copy of the list and never touched the schema. It passed throughout.

Both formats now derive the description and `examples` from one exported constant — `BUILT_IN_PPTX_THEME_NAMES` / `BUILT_IN_DOCX_THEME_NAMES` — and the bundled-theme tests assert registry ≡ list ≡ `examples`, description included. docx matched by luck; nothing pinned it either.

## Custom themes never reached pptx at all

```ts
if (!themeProp || themeProp.type !== 'string') return;
```

docx declares `theme` as a bare `Type.String`. pptx declares it as `Type.Union([Type.String, ThemeConfigSchema])`, which compiles to a node carrying `anyOf` and **no `type` of its own** — so the injector walked to the right property and returned on its first line, every time. The six themes the playground serves from `client/public/templates/themes/` were never offered.

Verified against the real generated schema before and after: current implementation injects into **0** nodes, fixed into **2** (one per renderer profile). It now recurses into `anyOf`/`oneOf` first, then applies the string check, so the inline-theme-config branch is left untouched.

## Tests

- `monaco-theme-injection.test.ts` — new; drives `updateMonacoWithPlugins` with the pptx union shape, the docx bare-string shape, and asserts the config branch is not decorated. Confirmed red on the old injector, green on the new.
- `bundled-themes.test.ts` (both formats) — registry pinned to the schema list rather than to a private copy.

Full suites green: core-pptx + core-docx 987/987, shared-pptx + shared-docx 562/562, jto client 359/359. (Two collection errors seen mid-run were a stale `shared` dist in the working tree, present on `main` too, and clear after a rebuild.)

## Out of scope

The sidebar will still list nine where completion offers eleven: it enumerates theme *files*, and `default` and `dark` are object literals in `defaults.ts` with no JSON on disk. Left alone deliberately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PPTX theme autocomplete now supports custom inline themes, including themes defined within schema union branches.
  - Built-in PPTX and DOCX theme names are consistently shown in editor suggestions and schema documentation.

- **Bug Fixes**
  - Improved custom theme-name injection for PPTX while preserving existing DOCX theme completion behavior.

- **Tests**
  - Added coverage verifying built-in theme registrations, schema examples, descriptions, and custom theme completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->