### PR TITLE
fix(schema): a text-box holds what a section holds; discovery skips test data

### DIFF
--- a/.changeset/discovery-skips-test-data.md
+++ b/.changeset/discovery-skips-test-data.md
@@ -1,0 +1,5 @@
+---
+'@json-to-office/jto-cli': patch
+---
+
+Document, theme and plugin discovery skip `__tests__/` and `__fixtures__/` directories, and core-docx's bundled example documents. The hosted playground scans the monorepo root and listed seven regression fixtures and the two library examples beside its templates.

--- a/.changeset/text-box-holds-flow-content.md
+++ b/.changeset/text-box-holds-flow-content.md
@@ -1,0 +1,14 @@
+---
+'@json-to-office/shared-docx': minor
+'@json-to-office/shared': patch
+'@json-to-office/mcp-server': patch
+'@json-to-office/jto': patch
+---
+
+A `text-box` holds what a section holds. The published DOCX schema narrowed it to headings, paragraphs, images and dividers — the renderer compiles the box as a one-cell table and takes any flow content, so the cover block's metadata band (a table inside a floating box) built and rendered while the editor and the published schema flagged `table` as not accepted.
+
+Flow content — what a section body holds — is now one shared recursive definition (`FlowContent_<renderer>`) that `section`, `group` and `text-box` reference, instead of a copy inlined per container. That is what lets the containers in flow nest each other (a text-box holding a columns holding a text-box), which the inlining pass could not express and the `group` special case only approximated: inside a group the editor used to report a bad component name twice, once against every component and once against the allowed ones. `columns` keeps its narrower list (everything but another `columns`).
+
+The block-authoring schema no longer loses a component branch that is inlined while it is still being built, which the now-cyclic definition graph exposed.
+
+Two guards: every bundled playground template validates without a marker through the editor's own JSON language service, and every gallery template satisfies the JSON Schema the MCP server publishes.

--- a/docs/guide/writing-docx.md
+++ b/docs/guide/writing-docx.md
@@ -339,7 +339,7 @@ Two layout containers exist below the section level. `columns` splits content in
 
 Each child fills the next column. Columns accept nearly everything a section does (headings, paragraphs, images, tables, lists, charts, text boxes) — but not another `columns`.
 
-`text-box` draws a bordered, padded, optionally floating box containing headings, paragraphs, and images — the classic callout or sidebar:
+`text-box` draws a bordered, padded, optionally floating box containing anything a section can — headings, paragraphs, images, a table, a `columns` — the classic callout, sidebar or cover band:
 
 ```json
 {

--- a/docs/reference/docx/components.md
+++ b/docs/reference/docx/components.md
@@ -9,7 +9,7 @@ The complete catalog of DOCX components: what each one does, every prop it accep
 | [`docx`](/reference/docx/document#docx-root)  | container               | `section` only                                                                                                              |
 | [`section`](/reference/docx/document#section) | container               | heading, paragraph, image, statistic, table, list, toc, divider, highcharts, chart, visual, columns, text-box, block, group |
 | [`columns`](#columns)                         | layout                  | same as section, minus `columns` (no nesting)                                                                               |
-| [`text-box`](#text-box)                       | layout                  | heading, paragraph, image, divider                                                                                          |
+| [`text-box`](#text-box)                       | layout                  | same as section — the box is a one-cell table, so it holds a table, a columns, another text-box                             |
 | [`heading`](#heading)                         | content                 | —                                                                                                                           |
 | [`paragraph`](#paragraph)                     | content                 | —                                                                                                                           |
 | [`image`](#image)                             | content                 | —                                                                                                                           |
@@ -515,7 +515,7 @@ Inside a `text-box`, a nested `columns` renders as a multi-column table.
 
 ## `text-box`
 
-A bordered, padded box — callouts, sidebars, cover-page blocks. Allowed children: `heading`, `paragraph`, `image`.
+A bordered, padded box — callouts, sidebars, cover-page blocks. It holds what a section holds: headings, paragraphs, images, and also a `table` (the cover block's metadata band), a `columns`, another `text-box` — the box is a one-cell table, and a cell takes any flow content.
 
 | Prop            | Type                                                                                | Required | Default   | Description                                                                            |
 | --------------- | ----------------------------------------------------------------------------------- | -------- | --------- | -------------------------------------------------------------------------------------- |

--- a/docs/reference/json-schemas.md
+++ b/docs/reference/json-schemas.md
@@ -44,8 +44,8 @@ pnpm generate:schemas   # runs tsx scripts/generate-schemas.ts
 `pnpm build` runs the same step through turbo, so the files in `schemas/` are regenerated on every full build. The conversion:
 
 - emits `$schema: "http://json-schema.org/draft-07/schema#"` — draft-07's own `$id`, so a stock validator resolves the dialect without being told,
-- hoists recursive subschemas into `definitions`,
-- rewrites TypeBox's internal self-references to `#/definitions/ComponentDefinition`, so the recursive component tree is expressed as a normal JSON Schema `$ref`.
+- hoists recursive subschemas into `definitions` — one component union per renderer (`ComponentDefinition_<renderer>`), and for DOCX the flow content a section, group or text-box holds (`FlowContent_<renderer>`), so the containers in flow can hold each other by `$ref` rather than by an inlined copy,
+- rewrites TypeBox's internal self-references to those definitions, so the recursive component tree is expressed as a normal JSON Schema `$ref`.
 
 The TypeBox component registry is the source of truth for the generated schemas, runtime validators, and TypeScript types. CI regenerates the schemas and uses them in the example conformance checks.
 

--- a/packages/jto-cli/src/services/__tests__/file-scanner.test.ts
+++ b/packages/jto-cli/src/services/__tests__/file-scanner.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Discovery skips test data and core-docx's bundled examples. The hosted
+ * playground scans the monorepo root, and listed regression fixtures and the
+ * library examples beside the templates.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { FileSystemScanner } from '../file-scanner.js';
+
+const TEMPLATE = 'packages/jto/src/client/public/templates/annual.docx.json';
+
+const FILES = [
+  'report.docx.json',
+  TEMPLATE,
+  'packages/design-evals/src/__fixtures__/regressions/fixture.docx.json',
+  'packages/core-docx/src/__tests__/case.docx.json',
+  'packages/core-docx/src/templates/documents/example.docx.json',
+];
+
+describe('FileSystemScanner exclusions', () => {
+  let root: string;
+
+  beforeAll(async () => {
+    root = await fs.mkdtemp(path.join(process.cwd(), '.tmp-scanner-'));
+    await fs.writeFile(path.join(root, 'package.json'), '{}');
+    for (const file of FILES) {
+      await fs.mkdir(path.dirname(path.join(root, file)), { recursive: true });
+      await fs.writeFile(path.join(root, file), '{}');
+    }
+  });
+
+  afterAll(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const relative = (files: string[]) =>
+    [...new Set(files.map((file) => path.relative(root, file)))].sort();
+
+  it('the depth scan skips them', async () => {
+    const found = await new FileSystemScanner().scan(root, 'docx-document');
+    expect(relative(found)).toEqual([TEMPLATE, 'report.docx.json']);
+  });
+
+  it('the monorepo scan skips them', async () => {
+    const found = await new FileSystemScanner().scanMonorepoLocations(
+      root,
+      'docx-document'
+    );
+    expect(relative(found)).toEqual([TEMPLATE]);
+  });
+});

--- a/packages/jto-cli/src/services/__tests__/file-scanner.test.ts
+++ b/packages/jto-cli/src/services/__tests__/file-scanner.test.ts
@@ -34,8 +34,14 @@ describe('FileSystemScanner exclusions', () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
+  // Posix separators whatever the host: the fixtures above are written that
+  // way, and `path.relative` answers with backslashes on Windows.
   const relative = (files: string[]) =>
-    [...new Set(files.map((file) => path.relative(root, file)))].sort();
+    [
+      ...new Set(
+        files.map((file) => path.relative(root, file).split(path.sep).join('/'))
+      ),
+    ].sort();
 
   it('the depth scan skips them', async () => {
     const found = await new FileSystemScanner().scan(root, 'docx-document');

--- a/packages/jto-cli/src/services/file-scanner.ts
+++ b/packages/jto-cli/src/services/file-scanner.ts
@@ -116,6 +116,13 @@ export class FileSystemScanner {
     '**/tmp/**',
     '**/.cache/**',
     '**/out/**',
+    // Test data, not documents: the hosted playground scans this monorepo and
+    // listed every regression fixture beside the templates.
+    '**/__tests__/**',
+    '**/__fixtures__/**',
+    // core-docx's bundled examples: library data `loadJsonExample` reads from
+    // dist, only ever in source inside this monorepo.
+    '**/core-docx/src/templates/documents/**',
   ];
 
   async scan(

--- a/packages/jto/src/server/routes/__tests__/bundled-templates-editor.test.ts
+++ b/packages/jto/src/server/routes/__tests__/bundled-templates-editor.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Every bundled template opens clean in the editor.
+ *
+ * The playground validates a document with the JSON language service Monaco
+ * embeds, against the schema `/discovery/schemas/document` serves with the
+ * document's own block definitions applied. Nothing else checks that pairing:
+ * `jto validate` and generation accept looser nesting than the published
+ * schema narrows to, so a template can build, render and ship — and still
+ * open with a red marker. The cover block's metadata band, a table inside a
+ * floating text-box, did exactly that. This drives the editor's own validator
+ * over each shipped template, the first thing a visitor opens.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Hono } from 'hono';
+import { getLanguageService, TextDocument } from 'vscode-json-languageservice';
+import { applyDocumentBlocksToSchema } from '@json-to-office/shared';
+import { docxDocumentBlockTargets } from '@json-to-office/shared-docx';
+import { preparePptxDocumentBlockTargets } from '@json-to-office/shared-pptx';
+import {
+  DocxFormatAdapter,
+  PluginRegistry,
+  PptxFormatAdapter,
+} from '@json-to-office/jto-cli';
+import { discoveryRouter } from '../discovery';
+import { Container } from '../../container';
+import { readDocumentBlockDefinitions } from '../../../client/lib/document-blocks';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_DIR = path.resolve(
+  __dirname,
+  '../../../client/public/templates'
+);
+
+const FORMATS = [
+  { format: 'docx', adapter: () => new DocxFormatAdapter() },
+  { format: 'pptx', adapter: () => new PptxFormatAdapter() },
+] as const;
+
+describe.each(FORMATS)(
+  '$format templates in the editor',
+  ({ format, adapter }) => {
+    const templates = fs
+      .readdirSync(TEMPLATE_DIR)
+      .filter((file) => file.endsWith(`.${format}.json`))
+      .sort();
+    let baseSchema: unknown;
+
+    beforeAll(async () => {
+      // The hosted playground autoloads its example plugin; plugins only add
+      // branches, so the plugin-free schema is the stricter of the two.
+      Container.initialize(adapter());
+      PluginRegistry.cleanup();
+      const app = new Hono();
+      app.route('/discovery', discoveryRouter as any);
+      const res = await app.request('/discovery/schemas/document?plugins=');
+      expect(res.status).toBe(200);
+      baseSchema = ((await res.json()) as { data: unknown }).data;
+    });
+
+    afterAll(() => {
+      PluginRegistry.cleanup();
+    });
+
+    it('ships templates to check', () => {
+      expect(templates.length).toBeGreaterThan(0);
+    });
+
+    it.each(templates)(
+      '%s validates without a marker',
+      async (file) => {
+        const text = fs.readFileSync(path.join(TEMPLATE_DIR, file), 'utf8');
+        // What monaco-config installs: the served schema, on a copy, with the
+        // document's block definitions applied where invocations live.
+        const schema = JSON.parse(JSON.stringify(baseSchema));
+        applyDocumentBlocksToSchema(
+          schema,
+          readDocumentBlockDefinitions(text),
+          format === 'docx'
+            ? docxDocumentBlockTargets(schema)
+            : preparePptxDocumentBlockTargets(schema)
+        );
+        const service = getLanguageService({});
+        service.configure({
+          allowComments: false,
+          schemas: [
+            {
+              uri: `test://${format}`,
+              fileMatch: [`*.${format}.json`],
+              schema,
+            },
+          ],
+        });
+        const doc = TextDocument.create(`test://${file}`, 'json', 1, text);
+        const diagnostics = await service.doValidation(
+          doc,
+          service.parseJSONDocument(doc),
+          { schemaValidation: 'error', trailingCommas: 'error' }
+        );
+        expect(
+          diagnostics.map(
+            (d) =>
+              `${file}:${d.range.start.line + 1}:${d.range.start.character + 1} ${d.message}`
+          )
+        ).toEqual([]);
+      },
+      60_000
+    );
+  }
+);

--- a/packages/mcp-server/src/__tests__/discovery-drift.test.ts
+++ b/packages/mcp-server/src/__tests__/discovery-drift.test.ts
@@ -46,6 +46,7 @@ import {
 import { loadCore } from '../lib/core.js';
 import { RESOURCE_URIS } from '../resources/index.js';
 import { designNote, designNoteNames } from '../lib/design-notes.js';
+import { galleryDocument, galleryManifests } from '../templates/gallery.js';
 import { PUBLISHED_SURFACE } from './fixtures/published-surface.js';
 
 let client: Client;
@@ -648,6 +649,40 @@ describe('tools and resources describe the same surface', () => {
         }
       }
     }
+    expect(broken, broken.join('\n')).toEqual([]);
+  });
+
+  it('every gallery template also satisfies the JSON Schema this server publishes', () => {
+    // The gallery is what jto_discover hands an agent to start a designed
+    // document from — the same promise as the starters, and the one the
+    // cover block broke: a table inside a floating text-box that built and
+    // rendered while the published schema refused it. A fresh Ajv, because
+    // the document schema carries an `$id` the shared instance may hold.
+    const broken: string[] = [];
+    let checked = 0;
+    for (const format of FORMAT_NAMES) {
+      const validate = new Ajv({
+        strict: false,
+        allErrors: true,
+        validateFormats: false,
+      }).compile(formatSchemas(format).document);
+      for (const manifest of galleryManifests(format)) {
+        const document = galleryDocument(manifest.name);
+        if (document === undefined) {
+          broken.push(`${manifest.name}: gallery document unreadable`);
+          continue;
+        }
+        checked += 1;
+        if (!validate(document)) {
+          broken.push(
+            `${manifest.name}: ${(validate.errors ?? [])
+              .map((e) => `${e.instancePath} ${e.message}`)
+              .join('; ')}`
+          );
+        }
+      }
+    }
+    expect(checked).toBeGreaterThan(0);
     expect(broken, broken.join('\n')).toEqual([]);
   });
 

--- a/packages/mcp-server/src/__tests__/fixtures/published-surface.ts
+++ b/packages/mcp-server/src/__tests__/fixtures/published-surface.ts
@@ -132,7 +132,25 @@ export const PUBLISHED_SURFACE: Record<FormatName, PublishedComponentSurface> =
           'toc',
           'visual',
         ],
-        'text-box': ['divider', 'heading', 'image', 'paragraph'],
+        // A one-cell table, so it holds what a section holds — the cover's
+        // metadata band is a table inside a floating box.
+        'text-box': [
+          'chart',
+          'columns',
+          'divider',
+          'heading',
+          'highcharts',
+          'image',
+          'block',
+          'group',
+          'list',
+          'paragraph',
+          'statistic',
+          'table',
+          'text-box',
+          'toc',
+          'visual',
+        ],
       },
     },
 

--- a/packages/mcp-server/src/__tests__/validate-gate.test.ts
+++ b/packages/mcp-server/src/__tests__/validate-gate.test.ts
@@ -123,14 +123,15 @@ const NULL_PROPS_SECTION = {
 };
 
 /**
- * DOCX containers the writer nests and the published schema does not let it.
- * Both come from the corpus, both have pinned goldens: a `section` inside a
- * `section` flattens away, and a `columns` inside a `text-box` becomes a table
- * of cells inside the box's own cell. `section.allowedChildren` and
- * `text-box.allowedChildren` name neither, and widening them would make both
- * containers mutually recursive — which the narrowing pass, whose whole output
- * is inlined, cannot express. Pinned so the day it is expressible the gap is
- * visible rather than assumed closed.
+ * The one DOCX nesting the writer accepts and the published schema does not:
+ * a `section` inside a `section` flattens away (corpus-pinned), and
+ * `section.allowedChildren` deliberately names no section — bare sections do
+ * not nest. Pinned so the gap stays visible rather than assumed closed.
+ *
+ * A `columns` inside a `text-box` used to sit beside it: the schema narrowed
+ * text-box children by inlining them, which could not express two containers
+ * holding each other. Flow content is one shared recursive definition now, so
+ * the box holds what a section holds and the gap is closed — asserted below.
  */
 const NESTED_SECTION = {
   name: 'docx',
@@ -352,23 +353,25 @@ describe('jto_validate mirrors the generation gate', () => {
     }
   });
 
-  it('pins the DOCX containers the schema narrows tighter than the writer', async () => {
+  it('pins the DOCX container the schema narrows tighter than the writer', async () => {
     // Not a props question and not closed by the requiredness fix: the
     // published schema is stricter here than `jto_validate` and the writer,
     // which is the one direction still open. Asserted rather than described so
     // widening `allowedChildren` (or narrowing the walk) reddens this test.
-    const gaps: Array<[string, unknown]> = [
-      ['nested section', NESTED_SECTION],
-      ['columns in a text-box', NESTED_COLUMNS_IN_TEXT_BOX],
+    // The second case is the gap that closed: all three must agree on it now,
+    // so a narrowing pass that stops sharing flow content reddens this too.
+    const cases: Array<[string, unknown, boolean]> = [
+      ['nested section', NESTED_SECTION, false],
+      ['columns in a text-box', NESTED_COLUMNS_IN_TEXT_BOX, true],
     ];
     const unexpected: string[] = [];
-    for (const [label, document] of gaps) {
+    for (const [label, document, accepted] of cases) {
       const verdict = await validate('docx', document);
       const generated = await renders('docx', document);
       const published = publishedSchemaAccepts('docx', document);
-      if (verdict.ok !== true || generated !== true || published !== false) {
+      if (verdict.ok !== true || generated !== true || published !== accepted) {
         unexpected.push(
-          `${label}: jto_validate ok=${verdict.ok}, generation ok=${generated}, published schema ok=${published} (expected true/true/false)`
+          `${label}: jto_validate ok=${verdict.ok}, generation ok=${generated}, published schema ok=${published} (expected true/true/${accepted})`
         );
       }
     }

--- a/packages/shared-docx/src/__tests__/allowed-children.test.ts
+++ b/packages/shared-docx/src/__tests__/allowed-children.test.ts
@@ -89,11 +89,11 @@ describe('narrowed children validation', () => {
     expect(valid).toBe(false);
   });
 
-  it('rejects toc inside text-box (only heading/paragraph/image allowed)', () => {
+  it('rejects section inside text-box (flow content only)', () => {
     const textBox = {
       name: 'text-box',
       props: {},
-      children: [{ name: 'toc', props: {} }],
+      children: [{ name: 'section', props: {}, children: [] }],
     };
     const valid = Value.Check(ComponentDefinitionSchema, textBox);
     expect(valid).toBe(false);
@@ -107,5 +107,42 @@ describe('narrowed children validation', () => {
     };
     const valid = Value.Check(ComponentDefinitionSchema, textBox);
     expect(valid).toBe(true);
+  });
+
+  it('accepts what a section holds inside text-box, containers included', () => {
+    // A text-box is a one-cell table, so the cover's metadata band (a table
+    // inside a floating box) and a columns inside a box are legal — and the
+    // containers in flow nest each other without bound.
+    const textBox = {
+      name: 'text-box',
+      children: [
+        {
+          name: 'table',
+          props: {
+            columns: [{ header: { content: 'A' }, cells: [{ content: '1' }] }],
+          },
+        },
+        {
+          name: 'columns',
+          props: { columns: 2 },
+          children: [
+            {
+              name: 'text-box',
+              children: [{ name: 'toc' }, { name: 'group', children: [] }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(Value.Check(ComponentDefinitionSchema, textBox)).toBe(true);
+  });
+
+  it('keeps columns from nesting columns', () => {
+    const columns = {
+      name: 'columns',
+      props: { columns: 2 },
+      children: [{ name: 'columns', props: { columns: 2 }, children: [] }],
+    };
+    expect(Value.Check(ComponentDefinitionSchema, columns)).toBe(false);
   });
 });

--- a/packages/shared-docx/src/__tests__/name-completion-hints.test.ts
+++ b/packages/shared-docx/src/__tests__/name-completion-hints.test.ts
@@ -57,6 +57,40 @@ describe('component name autocomplete', () => {
     expect(labels).not.toContain('docx');
   });
 
+  it.each(['group', 'text-box'])(
+    'offers everything a section holds inside a %s',
+    async (container) => {
+      // A text-box is a one-cell table and a group is transparent, so both
+      // hold flow content — the cover's metadata band is a table inside a
+      // floating box. Same list as a section, from the same definition.
+      const labels = await completionsAt(
+        standardSchema,
+        `{"name":"docx","children":[{"name":"section","children":[{"name":"${container}","children":[{"name":""}]}]}]}`
+      );
+      for (const name of getStandardComponent('section')!.allowedChildren!)
+        expect(labels).toContain(name);
+      expect(labels).not.toContain('section');
+      expect(labels).not.toContain('docx');
+    }
+  );
+
+  it.each(['group', 'text-box'])(
+    'reports one discriminator error inside a %s, naming flow content only',
+    async (container) => {
+      // The group used to be typed as the full component union narrowed by an
+      // intersected name list, which the language service reported twice —
+      // once with every component, once with the allowed ones.
+      const diagnostics = await diagnosticsFor(
+        `{"name":"docx","children":[{"name":"section","children":[{"name":"${container}","children":[{"name":"bogus"}]}]}]}`
+      );
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]).toMatch(/Value is not accepted. Valid values:/);
+      expect(diagnostics[0]).toContain('"table"');
+      expect(diagnostics[0]).toContain('"columns"');
+      expect(diagnostics[0]).not.toContain('"section"');
+    }
+  );
+
   it('offers section plus content components at the document root', async () => {
     const labels = await completionsAt(
       standardSchema,

--- a/packages/shared-docx/src/index.ts
+++ b/packages/shared-docx/src/index.ts
@@ -300,6 +300,7 @@ export {
 // which can hold children, and what those children may be.
 export {
   STANDARD_COMPONENTS_REGISTRY,
+  FLOW_CHILDREN,
   getStandardComponent,
   getAllStandardComponentNames,
 } from './schemas/component-registry';
@@ -396,6 +397,7 @@ export {
   DEFAULT_DOCX_RENDERER_ID,
   collectDocxRendererErrors,
   docxComponentDefinitionName,
+  docxFlowDefinitionName,
 } from './schemas/renderer';
 export type { DocxRendererId } from './schemas/renderer';
 

--- a/packages/shared-docx/src/schemas/component-registry.ts
+++ b/packages/shared-docx/src/schemas/component-registry.ts
@@ -38,6 +38,7 @@ import { ChartPropsSchema } from './components/chart';
 import { VisualPropsSchema } from './components/visual';
 import {
   DOCX_RENDERER_IDS,
+  docxFlowDefinitionName,
   docxPropsSchemaForRenderer,
   type DocxRendererId,
 } from './renderer';
@@ -124,6 +125,34 @@ export interface StandardComponentDefinition {
 }
 
 /**
+ * Flow content: everything a section body holds.
+ *
+ * The containers that sit in flow — `group`, `columns`, `text-box` — are each
+ * compiled to a table cell or a transparent run of blocks, and a cell holds
+ * whatever a section holds. So they name this same list (`columns` minus
+ * itself), and the schema builder below gives every container that names the
+ * whole list one shared recursive definition instead of an inlined copy:
+ * that is what lets a text-box hold a columns that holds a text-box.
+ */
+export const FLOW_CHILDREN = [
+  'block',
+  'group',
+  'heading',
+  'paragraph',
+  'image',
+  'statistic',
+  'table',
+  'list',
+  'toc',
+  'divider',
+  'highcharts',
+  'chart',
+  'visual',
+  'columns',
+  'text-box',
+] as const;
+
+/**
  * SINGLE SOURCE OF TRUTH for all standard components
  *
  * This is the ONLY place where standard components are defined.
@@ -163,23 +192,7 @@ export const STANDARD_COMPONENTS_REGISTRY: readonly StandardComponentDefinition[
         { path: ['footer'], arity: 'component-array', reportStructure: true },
       ],
       hasChildren: true,
-      allowedChildren: [
-        'block',
-        'group',
-        'heading',
-        'paragraph',
-        'image',
-        'statistic',
-        'table',
-        'list',
-        'toc',
-        'divider',
-        'highcharts',
-        'chart',
-        'visual',
-        'columns',
-        'text-box',
-      ],
+      allowedChildren: FLOW_CHILDREN,
       category: 'container',
       description:
         'Section container - groups related content with optional title. Use for organizing document structure.',
@@ -188,22 +201,9 @@ export const STANDARD_COMPONENTS_REGISTRY: readonly StandardComponentDefinition[
       name: 'columns',
       propsSchema: ColumnsPropsSchema,
       hasChildren: true,
-      allowedChildren: [
-        'block',
-        'group',
-        'heading',
-        'paragraph',
-        'image',
-        'statistic',
-        'table',
-        'list',
-        'toc',
-        'divider',
-        'highcharts',
-        'chart',
-        'visual',
-        'text-box',
-      ],
+      // Everything in flow but another `columns`: at the top level a columns
+      // becomes a section column layout, which has no second level.
+      allowedChildren: FLOW_CHILDREN.filter((name) => name !== 'columns'),
       category: 'layout',
       description:
         'Multi-column layout - arranges content in 2-4 columns. Great for side-by-side content.',
@@ -212,10 +212,12 @@ export const STANDARD_COMPONENTS_REGISTRY: readonly StandardComponentDefinition[
       name: 'text-box',
       propsSchema: TextBoxPropsSchema,
       hasChildren: true,
-      allowedChildren: ['heading', 'paragraph', 'image', 'divider'],
+      // A one-cell table, so it holds what a section holds — a table for a
+      // metadata band, a columns for a two-up sidebar, another text-box.
+      allowedChildren: FLOW_CHILDREN,
       category: 'layout',
       description:
-        'Floating text container - allows positioning text anywhere on the page with absolute or relative positioning.',
+        'Floating text container - allows positioning text anywhere on the page with absolute or relative positioning. Holds any flow content, tables and columns included.',
     },
 
     // ========================================================================
@@ -265,23 +267,7 @@ export const STANDARD_COMPONENTS_REGISTRY: readonly StandardComponentDefinition[
       name: 'group',
       propsSchema: GroupPropsSchema,
       hasChildren: true,
-      allowedChildren: [
-        'group',
-        'block',
-        'heading',
-        'paragraph',
-        'image',
-        'statistic',
-        'table',
-        'list',
-        'toc',
-        'divider',
-        'highcharts',
-        'chart',
-        'visual',
-        'columns',
-        'text-box',
-      ],
+      allowedChildren: FLOW_CHILDREN,
       category: 'container',
       description:
         'Transparent group of flow components; also the inspectable result of block expansion.',
@@ -539,114 +525,159 @@ export function createAllComponentSchemas(
   );
 }
 
+/** Same names, in any order. */
+function sameNames(a: readonly string[], b: readonly string[]): boolean {
+  const set = new Set(a);
+  return (
+    a.length === set.size && b.length === set.size && b.every((n) => set.has(n))
+  );
+}
+
 /**
  * Build all standard component schemas with per-container narrowed children.
  *
- * Resolves containers in dependency order so each container's children union
- * only references its allowedChildren. Plugin schemas are always included in
- * every container's children.
+ * Flow content is one shared recursive definition (`flow`): every container
+ * whose `allowedChildren` is exactly `FLOW_CHILDREN` — `section`, `group`,
+ * `text-box` — takes it as its children type, which is what lets the containers
+ * in flow nest each other without a cycle in the schema. A container that
+ * narrows the list (`docx` to sections, `columns` to flow minus itself) gets an
+ * inlined union of the branches it names, resolved in dependency order; only
+ * those can still form a cycle, and one is a registry mistake.
  *
- * @param selfRef - The Type.Recursive self-reference (used as fallback and for plugin children)
+ * Plugin schemas join the flow definition and every inlined union, so a plugin
+ * is allowed wherever a standard component is.
+ *
+ * @param selfRef - The Type.Recursive self-reference: table cell content,
+ *   section header and footer, plugin children — the positions that take any
+ *   component at all.
  * @param pluginSchemas - Plugin component schemas (always allowed in all containers)
- * @returns schemas array and a byName map for direct lookups
+ * @returns every standard branch (`schemas`, by name in `byName`), the flow
+ *   definition, and `roots` — the branches outside flow (`docx`, `section`).
+ *   A union a TypeBox check can walk on its own is `[...roots, flow]`: the flow
+ *   branches reference the definition by `$id`, which only resolves through it.
  */
 export function createAllComponentSchemasNarrowed(
   selfRef: TSchema,
   pluginSchemas: TSchema[] = [],
   profile?: { renderer: DocxRendererId; requireDiscriminator: boolean }
-): { schemas: TSchema[]; byName: Map<string, TSchema> } {
+): {
+  schemas: TSchema[];
+  byName: Map<string, TSchema>;
+  flow: TSchema;
+  roots: TSchema[];
+} {
   // A component whose `renderers` excludes this profile is not built at all,
   // so it is absent from the union *and* from every container's narrowed
   // children — `allowedChildren` maps through these maps and drops what it
   // cannot find, which keeps the two lists from disagreeing.
   const drawnHere = (comp: StandardComponentDefinition): boolean =>
     !profile || !comp.renderers || comp.renderers.includes(profile.renderer);
+  const components = STANDARD_COMPONENTS_REGISTRY.filter(drawnHere);
+  const inFlow = new Set<string>(FLOW_CHILDREN);
+  const byName = new Map<string, TSchema>();
 
-  // Phase 1: Build leaf (non-container) component schemas — no children
-  // selfRef is passed so factories (e.g. table) can wire up recursive refs.
-  const leafSchemas = new Map<string, TSchema>();
-  for (const comp of STANDARD_COMPONENTS_REGISTRY) {
-    if (!drawnHere(comp)) continue;
+  // Leaves first: selfRef is passed so factories (e.g. table) can wire up
+  // recursive refs.
+  for (const comp of components) {
     if (!comp.hasChildren) {
-      leafSchemas.set(
+      byName.set(
         comp.name,
         createComponentSchemaObject(comp, undefined, selfRef, profile)
       );
     }
   }
 
-  // Phase 2: Resolve containers in dependency order
-  const containers = STANDARD_COMPONENTS_REGISTRY.filter(
-    (c) => c.hasChildren && drawnHere(c)
+  /**
+   * Resolve a set of containers against `flowRef`. Inside the recursive
+   * callback that is the placeholder reference; afterwards it is the built
+   * definition itself, which `section` embeds so a check that starts at a
+   * root reaches the `$id` before any branch refers to it.
+   */
+  const resolveContainers = (
+    containers: readonly StandardComponentDefinition[],
+    flowRef: TSchema
+  ): void => {
+    const pending = [...containers];
+    while (pending.length > 0) {
+      const before = pending.length;
+      for (let i = pending.length - 1; i >= 0; i--) {
+        const comp = pending[i];
+        if (!comp.allowedChildren) {
+          // No allowedChildren declared — fallback to full recursive ref
+          byName.set(
+            comp.name,
+            createComponentSchemaObject(comp, selfRef, selfRef, profile)
+          );
+          pending.splice(i, 1);
+          continue;
+        }
+        if (sameNames(comp.allowedChildren, FLOW_CHILDREN)) {
+          byName.set(
+            comp.name,
+            createComponentSchemaObject(comp, flowRef, selfRef, profile)
+          );
+          pending.splice(i, 1);
+          continue;
+        }
+
+        // A narrowed union inlines its branches, so those have to exist first.
+        const deps = comp.allowedChildren.filter((name) =>
+          components.some((c) => c.name === name && c.hasChildren)
+        );
+        if (!deps.every((name) => byName.has(name))) continue;
+
+        const childSchemas = comp.allowedChildren
+          .map((name) => byName.get(name))
+          .filter((s): s is TSchema => s !== undefined);
+        const allChildSchemas = [...childSchemas, ...pluginSchemas];
+        const childrenType =
+          allChildSchemas.length === 1
+            ? allChildSchemas[0]
+            : Type.Union(allChildSchemas);
+        byName.set(
+          comp.name,
+          createComponentSchemaObject(comp, childrenType, selfRef, profile)
+        );
+        pending.splice(i, 1);
+      }
+
+      if (pending.length === before) {
+        throw new Error(
+          `Circular allowedChildren among: ${pending.map((c) => c.name).join(', ')}`
+        );
+      }
+    }
+  };
+
+  const flow = Type.Recursive(
+    (Flow) => {
+      resolveContainers(
+        components.filter((c) => c.hasChildren && inFlow.has(c.name)),
+        Flow
+      );
+      const members = FLOW_CHILDREN.map((name) => byName.get(name)).filter(
+        (s): s is TSchema => s !== undefined
+      );
+      return Type.Union([...members, ...pluginSchemas], {
+        discriminator: { propertyName: 'name' },
+        description:
+          'Flow content: what a section body holds, and so what a group, columns or text-box holds.',
+      });
+    },
+    { $id: docxFlowDefinitionName(profile?.renderer) }
   );
-  const resolved = new Map<string, TSchema>();
-  const pending = [...containers];
 
-  while (pending.length > 0) {
-    const before = pending.length;
-    for (let i = pending.length - 1; i >= 0; i--) {
-      const comp = pending[i];
+  resolveContainers(
+    components.filter((c) => c.hasChildren && !inFlow.has(c.name)),
+    flow
+  );
 
-      if (comp.name === 'group') {
-        // Transparent flow groups recurse without admitting document/section roots.
-        const flow = Type.Intersect([
-          selfRef,
-          Type.Object({
-            name: Type.Union([
-              ...comp.allowedChildren!.map((name) => Type.Literal(name)),
-              ...pluginSchemas.map((schema) => schema.properties.name),
-            ]),
-          }),
-        ]);
-        resolved.set(
-          comp.name,
-          createComponentSchemaObject(comp, flow, selfRef, profile)
-        );
-        pending.splice(i, 1);
-        continue;
-      }
-      if (!comp.allowedChildren) {
-        // No allowedChildren declared — fallback to full recursive ref
-        resolved.set(
-          comp.name,
-          createComponentSchemaObject(comp, selfRef, selfRef, profile)
-        );
-        pending.splice(i, 1);
-        continue;
-      }
-
-      // Check if all container dependencies are resolved
-      const containerDeps = comp.allowedChildren.filter((name) =>
-        containers.some((c) => c.name === name)
-      );
-      if (!containerDeps.every((d) => resolved.has(d))) continue;
-
-      // Build narrowed children union
-      const childSchemas = comp.allowedChildren
-        .map((name) => resolved.get(name) ?? leafSchemas.get(name))
-        .filter((s): s is TSchema => s !== undefined);
-
-      const allChildSchemas = [...childSchemas, ...pluginSchemas];
-      const childrenType =
-        allChildSchemas.length === 1
-          ? allChildSchemas[0]
-          : Type.Union(allChildSchemas);
-
-      resolved.set(
-        comp.name,
-        createComponentSchemaObject(comp, childrenType, selfRef, profile)
-      );
-      pending.splice(i, 1);
-    }
-
-    if (pending.length === before) {
-      throw new Error(
-        `Circular allowedChildren among: ${pending.map((c) => c.name).join(', ')}`
-      );
-    }
-  }
-
-  // Combine: containers (resolved) + leaves
-  const byName = new Map([...resolved, ...leafSchemas]);
-  return { schemas: [...byName.values()], byName };
+  // Registry order, so the exported unions read the way the registry does.
+  const schemas = components
+    .map((comp) => byName.get(comp.name))
+    .filter((s): s is TSchema => s !== undefined);
+  const roots = components
+    .filter((comp) => !inFlow.has(comp.name))
+    .map((comp) => byName.get(comp.name)!);
+  return { schemas, byName, flow, roots };
 }

--- a/packages/shared-docx/src/schemas/components.ts
+++ b/packages/shared-docx/src/schemas/components.ts
@@ -51,18 +51,18 @@ export const StandardComponentDefinitionSchema = Type.Union(
   }
 );
 
-export const ComponentDefinitionSchema = Type.Recursive((This) =>
-  Type.Union(
-    [
-      // Standard components from registry with per-container narrowed children
-      ...createAllComponentSchemasNarrowed(This).schemas,
-    ],
-    {
-      discriminator: { propertyName: 'name' },
-      description: 'Component definition with discriminated union',
-    }
-  )
-);
+export const ComponentDefinitionSchema = Type.Recursive((This) => {
+  // Standard components from registry with per-container narrowed children.
+  // The roots outside flow plus the flow definition itself: a check that
+  // enters the flow union through the definition can resolve the `$id` the
+  // flow branches point their children at, which a flat list of branches
+  // could not.
+  const { roots, flow } = createAllComponentSchemasNarrowed(This);
+  return Type.Union([...roots, flow], {
+    discriminator: { propertyName: 'name' },
+    description: 'Component definition with discriminated union',
+  });
+});
 
 // ============================================================================
 // TypeScript Types

--- a/packages/shared-docx/src/schemas/renderer.ts
+++ b/packages/shared-docx/src/schemas/renderer.ts
@@ -28,6 +28,15 @@ export function docxComponentDefinitionName(renderer: DocxRendererId): string {
 }
 
 /**
+ * The flow-content definition: what a section body holds, and so what every
+ * container in flow — `group`, `columns`, `text-box` — holds too. Per renderer
+ * for the same reason as above; unsuffixed for the unprofiled runtime schema.
+ */
+export function docxFlowDefinitionName(renderer?: DocxRendererId): string {
+  return renderer ? `FlowContent_${renderer}` : 'FlowContent';
+}
+
+/**
  * Derive one renderer view from the canonical props schema.
  *
  * The canonical schema is the union of everything any backend can express, so

--- a/packages/shared/src/blocks/authoring-schema.ts
+++ b/packages/shared/src/blocks/authoring-schema.ts
@@ -178,8 +178,14 @@ export function createBlockAuthoringSchema(
     if (cached) return { ...ref(cached), ...metadata(schema) };
     const name = `${prefix}_Literal${nextId++}`;
     literals.set(key, name);
-    definitions[name] = {};
-    const result: Schema = { ...schema };
+    // Filled in place, never replaced: a name-const branch of a union below is
+    // inlined by object, and the component graph is cyclic through its named
+    // definitions (a group's children are flow content, which holds groups),
+    // so a branch can be inlined while it is still being built. Swapping the
+    // placeholder for a new object would leave that inline copy empty — a
+    // branch with no `name` that then blocks the union's dispatch rewrite.
+    const result: Schema = (definitions[name] = {});
+    Object.assign(result, schema);
     if (typeof schema.$ref === 'string') {
       const target = resolve(schema.$ref);
       if (target !== undefined) {
@@ -235,7 +241,6 @@ export function createBlockAuthoringSchema(
     // Conditions/negations inspect literal values, not binding syntax.
     for (const key of ['then', 'else'])
       if (schema[key] !== undefined) result[key] = literal(schema[key]);
-    definitions[name] = result;
     return { ...ref(name), ...metadata(schema) };
   }
 


### PR DESCRIPTION
## Summary

Two things the hosted DOCX playground showed after the masthead cover landed (f9b6c20):

**Every stock template opened with a red marker: `"table"` "not accepted" inside the cover's floating `text-box`.** `text-box.allowedChildren` was `heading/paragraph/image/divider` while the renderer compiles the box as a one-cell table and takes any flow content — so the band built and rendered, `jto validate` said fine (the runtime gate treats containment as guidance), and only the editor and the published JSON Schema refused it. Adding `table` to the list would have left the real limit in place: the narrowing pass inlined every container's children, which cannot express `text-box ↔ columns ↔ group` (a cycle), and that gap was pinned as known in `validate-gate.test.ts`.

Flow content — `FLOW_CHILDREN`, what a section body holds — is now one shared recursive definition (`FlowContent_<renderer>`) that `section`, `group` and `text-box` reference; containers that narrow it (`docx` → section, `columns` → flow minus itself) still inline. The `group` special case (`Intersect`) goes away with it: inside a group the language service used to report a bad name twice, once against every component and once against the allowed ones. The runtime TypeBox union is `[...roots, flow]` so `Value.Check` reaches the `$id` before any branch refers to it.

Collateral: `createBlockAuthoringSchema` now fills a literal's placeholder in place — the cyclic graph inlined a branch while it was still being built and left it `{}`, which silently blocked the union's if/then rewrite (block-body completions lost every component that requires props).

**Seventeen "documents" in the sidebar instead of eight.** Discovery walks the working directory, and the Docker image copies `packages/`, so the regression fixtures added in 27e76b1 and core-docx's two bundled examples were listed beside the templates. `__tests__/`, `__fixtures__/` and `core-docx/src/templates/documents/` are excluded now.

Guards, so neither drifts back:
- `packages/jto/src/server/routes/__tests__/bundled-templates-editor.test.ts` — every bundled template, both formats, validates without a marker through the editor's own JSON language service with the document's block definitions applied (would have caught f9b6c20)
- `discovery-drift.test.ts` — every gallery template satisfies the schema the MCP server publishes
- `file-scanner.test.ts` — the exclusions
- `published-surface.ts` records the widened `text-box`; the pinned-gap test now asserts the columns-in-text-box case is closed and keeps nested `section` as the one remaining gap

Reviewer notes:
- pptx keeps its own `group` `Intersect` special case (same double-diagnostic wart); porting the same mechanism is a follow-up.
- Verified in the local playground: `client-report-blocks` 0 markers (was 1), `table` proposed inside the text-box; sidebar lists 8 stock templates (+ `examples/`, which the image does not ship).
- Every package suite run individually (shared, shared-docx, shared-pptx, core-docx, core-pptx, jto-cli, jto, jto-ops, mcp-server, quality, design-evals); mcp-server's `stdio-*` suites time out when typecheck/lint run alongside — they pass alone.

## Checklist

- [x] Added a changeset (`pnpm changeset`)
- [x] Tests pass (`pnpm check`)
- [x] Docs updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - DOCX text boxes now support tables, columns, nested text boxes, groups, and other section-compatible flow content.
  - Component suggestions and validation now reflect expanded content in text boxes and groups.
  - Schema generation provides more accurate renderer-specific and recursive definitions.

- **Bug Fixes**
  - Discovery skips test, fixture, and bundled example directories by default.
  - Improved handling of recursive schemas and block-authoring configurations.

- **Documentation**
  - Updated DOCX guides and schema references for expanded text-box content and recursive definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->